### PR TITLE
More lint fixups from mozilla-central.

### DIFF
--- a/components/nimbus/examples/config/config.json
+++ b/components/nimbus/examples/config/config.json
@@ -1,10 +1,10 @@
 {
-    "context": {
-        "app_id": "org.mozilla.fenix",
-        "app_name": "fenix",
-        "channel": "nightly",
-        "locale": "en-US"
-    },
-    "collection_name": "nimbus-mobile-experiments",
-    "client_id": "{2204ac0e-1428-11eb-adc1-0242ac120002}"
+  "context": {
+    "app_id": "org.mozilla.fenix",
+    "app_name": "fenix",
+    "channel": "nightly",
+    "locale": "en-US"
+  },
+  "collection_name": "nimbus-mobile-experiments",
+  "client_id": "{2204ac0e-1428-11eb-adc1-0242ac120002}"
 }

--- a/components/support/nimbus-cli/assets/index.html
+++ b/components/support/nimbus-cli/assets/index.html
@@ -3,19 +3,17 @@
    - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <html>
-    <head>
-        <title>nimbus-cli test server</title>
-        <link href="/style.css" rel="stylesheet" />
-        <script src="/script.js" ></script>
-    </head>
-    <body>
-        <ul id="platform-list">
-            {android}
-            {ios}
-            {web}
-        </ul>
-        <div class="wrapper">
-            <button id="the-only-button" onclick="onClick()"></button>
-        </div>
-    </body>
+  <head>
+    <title>nimbus-cli test server</title>
+    <link href="/style.css" rel="stylesheet" />
+    <script src="/script.js"></script>
+  </head>
+  <body>
+    <ul id="platform-list">
+      {android} {ios} {web}
+    </ul>
+    <div class="wrapper">
+      <button id="the-only-button" onclick="onClick()"></button>
+    </div>
+  </body>
 </html>

--- a/components/support/nimbus-cli/assets/script.js
+++ b/components/support/nimbus-cli/assets/script.js
@@ -3,30 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 function onReload() {
-    const uaString = window.navigator.userAgent.toLowerCase();
-    let el;
-    if (uaString.indexOf("iphone") >= 0) {
-        el = document.getElementById("ios-latest");
-    } else if (uaString.indexOf("android") >= 0) {
-        el = document.getElementById("android-latest");
-    } else {
-        el = document.getElementById("web-latest");
-    }
+  const uaString = window.navigator.userAgent.toLowerCase();
+  let el;
+  if (uaString.includes("iphone")) {
+    el = document.getElementById("ios-latest");
+  } else if (uaString.includes("android")) {
+    el = document.getElementById("android-latest");
+  } else {
+    el = document.getElementById("web-latest");
+  }
 
-    const button = document.getElementById("the-only-button");
-    if (el) {
-        button.textContent = String.fromCodePoint(0x25B6);
-        el.click()
-    } else {
-        button.textContent = String.fromCodePoint(0x1F504);
-    }
+  const button = document.getElementById("the-only-button");
+  if (el) {
+    button.textContent = String.fromCodePoint(0x25b6);
+    el.click();
+  } else {
+    button.textContent = String.fromCodePoint(0x1f504);
+  }
 }
 
 function onClick() {
-    window.location.reload();
+  window.location.reload();
 }
 
-window.addEventListener("DOMContentLoaded", (event) => {
-    console.log("DOM fully loaded and parsed");
-    onReload()
+window.addEventListener("DOMContentLoaded", () => {
+  // eslint-disable-next-line no-console
+  console.log("DOM fully loaded and parsed");
+  onReload();
 });

--- a/components/support/nimbus-cli/test/fixtures/fenix-nimbus-validation-v3.json
+++ b/components/support/nimbus-cli/test/fixtures/fenix-nimbus-validation-v3.json
@@ -33,9 +33,7 @@
   "channel": "nightly",
   "endDate": "2021-02-11",
   "enrollmentEndDate": "2021-02-11",
-  "featureIds": [
-    "no-feature-fenix"
-  ],
+  "featureIds": ["no-feature-fenix"],
   "featureValidationOptOut": false,
   "id": "fenix-nimbus-validation-v3",
   "isEnrollmentPaused": false,

--- a/components/support/nimbus-fml/ExperimentFeatureManifest.schema.json
+++ b/components/support/nimbus-fml/ExperimentFeatureManifest.schema.json
@@ -32,12 +32,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "json",
-                        "boolean",
-                        "int",
-                        "string"
-                      ]
+                      "enum": ["json", "boolean", "int", "string"]
                     },
                     "fallbackPref": {
                       "type": "string"
@@ -50,19 +45,13 @@
                       "description": "Explain how this value is being used"
                     }
                   },
-                  "required": [
-                    "type",
-                    "description"
-                  ],
+                  "required": ["type", "description"],
                   "additionalProperties": false
                 }
               }
             }
           },
-          "required": [
-            "description",
-            "hasExposure"
-          ],
+          "required": ["description", "hasExposure"],
           "if": {
             "properties": {
               "hasExposure": {
@@ -71,9 +60,7 @@
             }
           },
           "then": {
-            "required": [
-              "exposureDescription"
-            ]
+            "required": ["exposureDescription"]
           }
         }
       }

--- a/components/support/nimbus-fml/fixtures/fe/config-examples/external-partial-example.json
+++ b/components/support/nimbus-fml/fixtures/fe/config-examples/external-partial-example.json
@@ -1,3 +1,3 @@
 {
-    "component-string": "Partial example for imported feature from JSON file"
+  "component-string": "Partial example for imported feature from JSON file"
 }

--- a/components/support/nimbus-fml/fixtures/ir/app_menu.json
+++ b/components/support/nimbus-fml/fixtures/ir/app_menu.json
@@ -99,12 +99,7 @@
               "Enum": "MenuItemId"
             }
           },
-          "default": [
-            "resume-game",
-            "start-game",
-            "community",
-            "settings"
-          ]
+          "default": ["resume-game", "start-game", "community", "settings"]
         },
         {
           "name": "all-menu-items",
@@ -120,7 +115,7 @@
               "deeplink": "deeplink://start"
             },
             {
-              "label":"Resume Game",
+              "label": "Resume Game",
               "deeplink": "deeplink://start?continue=true"
             }
           ]
@@ -161,7 +156,9 @@
           "name": "profile-ordering",
           "doc": "",
           "type": {
-            "List": {"EnumMap": [{"Enum": "PlayerProfile"}, {"Enum": "MenuItemId"}]}
+            "List": {
+              "EnumMap": [{ "Enum": "PlayerProfile" }, { "Enum": "MenuItemId" }]
+            }
           },
           "default": [
             {

--- a/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
@@ -67,11 +67,7 @@
               "Enum": "HomeScreenSection"
             }
           },
-          "default": [
-            "top-sites",
-            "jump-back-in",
-            "recently-saved"
-          ]
+          "default": ["top-sites", "jump-back-in", "recently-saved"]
         }
       ],
       "default": null,

--- a/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
@@ -93,11 +93,7 @@
           "type": {
             "List": "Int"
           },
-          "default": [
-            1,
-            2,
-            3
-          ]
+          "default": [1, 2, 3]
         },
         {
           "name": "enum-list",
@@ -107,10 +103,7 @@
               "Enum": "Position"
             }
           },
-          "default": [
-            "top",
-            "bottom"
-          ]
+          "default": ["top", "bottom"]
         }
       ],
       "default": null,

--- a/components/support/nimbus-fml/fixtures/loaders/config_files/remote.json
+++ b/components/support/nimbus-fml/fixtures/loaders/config_files/remote.json
@@ -1,4 +1,4 @@
 {
-    "my/remote": "https://example.com/repo/branch",
-    "test/nested2": "v100.0"
+  "my/remote": "https://example.com/repo/branch",
+  "test/nested2": "v100.0"
 }

--- a/testing/separated/places-bench/fixtures/dummy_urls.json
+++ b/testing/separated/places-bench/fixtures/dummy_urls.json
@@ -1,2193 +1,8699 @@
 [
-    {"url":"https://i.imgur.com/AMitlCd.jpg","title":"It's been a while."},
-    {"url":"https://fossbytes.com/firefox-quantum-57-is-here-to-kill-google-chrome-download-for-windows-mac-linux/","title":"Firefox Quantum 57 Is Here To Kill Google Chrome: Download For Windows, Mac, Linux"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7dfgnr/youve_earned_it_firefox/","title":"You've earned it Firefox"},
-    {"url":"https://old.reddit.com/r/firefox/comments/776710/is_it_just_me_or_google_is_really_getting_worse/","title":"Is it just me, or Google is really getting worse even than Microsoft? Not allowed to use Firefox anymore?"},
-    {"url":"https://drewdevault.com/2017/12/16/Firefox-is-on-a-slippery-slope.html","title":"Firefox is on a slippery slope"},
-    {"url":"https://old.reddit.com/r/firefox/comments/74uc5c/evolution_of_the_fox/","title":"Evolution of the Fox"},
-    {"url":"https://i.imgur.com/EDYvlK4.png","title":"Shit like this should be illegal"},
-    {"url":"https://gfycat.com/DishonestDiscreteAfricanfisheagle","title":"ok"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6e9bk4/when_you_accidentally_open_a_new_window_instead/","title":"When you accidentally open a new window instead of new tab on firefox"},
-    {"url":"https://blog.mozilla.org/internetcitizen/2018/05/23/gdpr-mozilla/?utm_source=newsletter&utm_medium=email&utm_campaign=mih-05-24-18&utm_content=button","title":"Mozilla will not update its privacy policy : it doesn't need to"},
-    {"url":"https://i.redd.it/b9voq7d53jr01.jpg","title":"When my friends complain about Chrome"},
-    {"url":"https://archive.mozilla.org/pub/firefox/releases/57.0/","title":"Mozilla Firefox 57.0 Final"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7b70uz/internet_is_dark_and_full_of_terrors/","title":"Internet is dark and full of terrors"},
-    {"url":"https://robertheaton.com/2018/07/02/stylish-browser-extension-steals-your-internet-history/","title":"\"Stylish\" browser extension steals all your internet history"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6uhkuo/ahahaha_such_new_many_logo_wow_icon/","title":"Ahahaha such new many logo wow icon"},
-    {"url":"https://www.wired.com/story/firefox-quantum-the-browser-built-for-2017/","title":"Ciao, Chrome: Firefox Quantum Is The Browser Built for 2017"},
-    {"url":"https://mybroadband.co.za/news/software/269659-google-has-slowed-down-youtube-on-firefox-and-edge-mozilla-exec.html","title":"Google has slowed down YouTube on Firefox and Edge – Mozilla exec"},
-    {"url":"https://twitter.com/cpeterso/status/1021626510296285185","title":"YouTube page load is 5x slower in Firefox and Edge than in Chrome because YouTube's Polymer redesign relies on the deprecated Shadow DOM v0 API only implemented in Chrome"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/noscript/versions/","title":"NoScript 10.1.1 WebExtension is finally released!"},
-    {"url":"https://i.imgur.com/imlFOlO.png","title":"Current mood at /r/chrome"},
-    {"url":"https://twitter.com/GrouponHelpUS/status/934896721842225152","title":"Its 1995 again."},
-    {"url":"https://blog.mozilla.org/firefox/update-looking-glass-add/","title":"Update from Mozilla: Looking Glass Add-on"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6tuxbd/stay_classy_google/","title":"Stay classy, Google."},
-    {"url":"http://www.wired.co.uk/article/mozilla-firefox-quantum-browser-vs-google-chrome","title":"Firefox thinks Quantum can beat Chrome with ethics… and speed"},
-    {"url":"https://twitter.com/zcorpan/status/1090719253379104779","title":"Mozilla developer fixes Chromium bug because Google decided to break Chromium instead of fixing a Google site"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8aaduz/firefox_is_now_for_flatearthers/","title":"Firefox is now for flat-earthers"},
-    {"url":"https://imgur.com/a/EdTnI","title":"[OC] I redid the Thunderbird icon to look more quantum-y"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/","title":"Official AMO link for uBlock Origin"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8ogary/soon_githubcom_has_been_optimized_for_edge/","title":"Soon: Github.com has been optimized for Edge!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/aj6167/is_this_thebreal_reason/","title":"Is this thebreal reason?"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7lv0r2/what_a_lovely_scam/","title":"What a lovely scam."},
-    {"url":"https://old.reddit.com/r/firefox/comments/5our4n/windows_10_now_has_builtin_adds_targeting_firefox/","title":"Windows 10 Now Has Built-In Adds Targeting FireFox... Seriously Microsoft???"},
-    {"url":"https://twitter.com/SeanKHoffman/status/1039573136168169475","title":"Microsoft engaging in anti-competitive practices again"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8bi6ld/firefox_looks_damn_great_on_linux_now_d/","title":"firefox looks damn great on linux now :D"},
-    {"url":"https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html","title":"Firefox Is Back. It’s Time to Give It a Try."},
-    {"url":"https://i.redd.it/jqkr3512ft501.jpg","title":"The most important gift"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9h6ogn/apple_blocking_firefox_from_accessing_their_new/","title":"Apple blocking Firefox from accessing their new portal for business users."},
-    {"url":"https://old.reddit.com/r/firefox/comments/7bn59r/firefox_ublock_origin_is_like_a_premium_version/","title":"Firefox + uBlock Origin is like a premium version of the internet"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6yxy3h/monopolization_at_its_best/","title":"Monopolization at its best"},
-    {"url":"https://bugs.chromium.org/p/chromium/issues/detail?id=896897&desc=2#c23","title":"Raymond Hill creator of uBlock Origin (\"uBO\") and uMatrix said that they will not exist on Chrome in the next months if Chrome maintains this orientation, they would only be available on Firefox."},
-    {"url":"https://www.theverge.com/2018/4/15/17239548/firefox-chrome-safari-competition","title":"The Verge: 'It’s time to give Firefox a fresh chance'"},
-    {"url":"https://twitter.com/steveklabnik/status/941709048529014784","title":"\"I am pretty upset with my employer, @mozilla, today\""},
-    {"url":"https://blog.mozilla.org/firefox/facebook-container-extension/","title":"Facebook Container Extension: Take control of how you’re being tracked – The Firefox Frontier"},
-    {"url":"https://www.fastcodesign.com/90174010/bye-chrome-why-im-switching-to-firefox-and-you-should-too","title":"Bye, Chrome: Why I’m switching to Firefox and you should too"},
-    {"url":"https://www.tomshardware.com/news/google-killing-chrome-ad-blockers,38498.html","title":"People Are Mad That Google Chrome May Kill Ad Blockers"},
-    {"url":"https://i.imgur.com/bbaDjEA.png","title":"I'm not sure what I just did, but I'm glad Firefox has this feature"},
-    {"url":"https://github.com/mozilla-mobile/fenix/","title":"Mozilla is working on a new Android browser"},
-    {"url":"https://v.redd.it/rayxp1yvcj421","title":"Would you like to set firefox as your default browser?"},
-    {"url":"https://about.gitlab.com/images/blogimages/gitlab-blog-cover.png","title":"My wallpaper with the new FireFox logo. 👍"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8vg3r3/thank_you_firefox/","title":"Thank you Firefox!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6rnkn3/new_logo_on_the_last_firefox_nightly_release/","title":"New logo on the last Firefox Nightly release"},
-    {"url":"https://old.reddit.com/r/firefox/comments/85sdet/just_noticed_there_is_a_doorknob_in_the_home/","title":"Just noticed there is a doorknob in the home button"},
-    {"url":"https://imgur.com/a/oqzoM","title":"Firefox users of all countries, unite!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/afpxf4/firefox_with_webrender_vs_chrome_scrolling/","title":"Firefox with WebRender vs Chrome scrolling"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8nhkww/this_is_apples_gdpr_page_it_supports_chrome_ie11/","title":"This is Apple's GDPR page. It supports Chrome, IE11, and some releases of Safari. No mobile. No Firefox."},
-    {"url":"http://www.zdnet.com/article/firefox-59-will-stop-websites-snooping-on-where-youve-just-been/","title":"Firefox 59 will reduce how much information websites pass on about visitors in an attempt to improve privacy for users of its private browsing mode"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6l0zho/some_marketing_skills_firefox_repost_from_rfunny/","title":"Some marketing skills - Firefox [repost from r/funny]"},
-    {"url":"https://www.netmarketshare.com/browser-market-share.aspx?qprid=1&qpcustomb=0&qpsp=202&qpnp=25&qptimeframe=M","title":"Firefox hits 2year peak market share in October at 13.14%"},
-    {"url":"https://i.imgur.com/aLLsqGm.png","title":"Nice try Chrome!"},
-    {"url":"https://blog.mozilla.org/blog/2018/01/16/mozilla-files-suit-fcc-protect-net-neutrality/","title":"Mozilla Files Suit Against FCC to Protect Net Neutrality"},
-    {"url":"https://techcrunch.com/2017/11/14/mozilla-terminates-its-deal-with-yahoo-and-makes-google-the-default-in-firefox-again/","title":"Mozilla Terminates its Deal With Yahoo and Makes Google the Default in Firefox Again"},
-    {"url":"https://www.cnet.com/news/mozilla-revenue-jump-fuels-its-firefox-overhaul-plan/","title":"Mozilla revenue jump fuels its Firefox overhaul plan. The nonprofit pulled in an all-time high of $520 million"},
-    {"url":"https://medium.com/mozilla-tech/mozilla-celebrates-release-of-free-high-quality-video-compression-technology-av1-in-firefox-65-7c95f2b7e56","title":"Mozilla Celebrates Release of Free, High-Quality Video Compression Technology AV1 in Firefox 65"},
-    {"url":"https://www.mozilla.org/en-US/firefox/quantum/","title":"2x faster and 30% less memory | Firefox Quantum Browser"},
-    {"url":"https://old.reddit.com/r/firefox/comments/a7bbyb/i_hate_the_internet/","title":"I hate the internet."},
-    {"url":"https://www.reddit.com/r/webdev/comments/a8e5qo/i_may_not_be_a_web_developer_but_you_really_cant/","title":"I may not be a web developer, but you really can't call Google a supporter of open standards when they're basically defining the standards and forcing other browsers to use them for fear of losing Google compatibility."},
-    {"url":"https://old.reddit.com/r/firefox/comments/6vqk30/rip_firedoge_we_hardly_knew_you/","title":"R.I.P. Firedoge: We hardly knew you."},
-    {"url":"https://www.techspot.com/news/77765-mozilla-ceo-edge-chromium-switch-hands-over-control.html","title":"Mozilla CEO: Edge's Chromium switch hands over control of 'even more' online life to Google"},
-    {"url":"https://i.imgur.com/aPDtv64.png","title":"Cliqz-owned Ghostery just leaked user email addresses in the process of notifying them about GDPR changes."},
-    {"url":"http://i.imgur.com/4i64UJa.png","title":"Anyone else get this as their new Firefox Nightly icon?"},
-    {"url":"https://blog.mozilla.org/firefox/facebook-container-extension-now-includes-instagram-and-facebook-messenger/","title":"Facebook Container extension now includes Instagram and Facebook Messenger – The Firefox Frontier"},
-    {"url":"https://www.reddit.com/r/europe/comments/8q9bw3/polish_inventor_says_google_is_patenting_work_he/","title":"Polish inventor says Google is patenting work he put in the public domain, Creator of a breakthrough compression algorithm fights to keep it patent-free"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7rlj8e/really_appreciate_this_feature/","title":"Really appreciate this feature!"},
-    {"url":"https://itsfoss.com/barcelona-open-source/","title":"City of Barcelona will migrate to Linux, and Firefox/LibreOffice will be the default Browser and Office Suite..."},
-    {"url":"https://i.imgur.com/ONnvspj.png","title":"A day in the life of an add-on author"},
-    {"url":"https://www.ghacks.net/2019/01/22/chrome-extension-manifest-v3-could-end-ublock-origin-for-chrome/","title":"Chrome Extension Manifest V3 could end uBlock Origin for Chromium (Potentially moving more users to Firefox)"},
-    {"url":"https://old.reddit.com/r/firefox/comments/akfzbv/fun_fact_about_firefox_users/","title":"Fun fact about Firefox users"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7bshls/why_does_the_page_called_get_addons_in_firefox/","title":"Why does the page called \"Get Add-ons\" (in Firefox settings) not have a search option for addons? Would be so frustrated as a new user."},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/https-everywhere/","title":"HTTPS Everywhere WebExtension released to AMO stable!"},
-    {"url":"https://www.theverge.com/2017/12/16/16784628/mozilla-mr-robot-arg-plugin-firefox-looking-glass","title":"Mozilla faces blowback after slipping Mr Robot plugin into Firefox"},
-    {"url":"https://twitter.com/search?q=Firefox&src=tren","title":"Firefox is trending globally on Twitter right now"},
-    {"url":"https://blogs.adobe.com/conversations/2017/07/adobe-flash-update.html","title":"Adobe is announcing EOL plans for its Flash plugin - huge win for the web :-D"},
-    {"url":"https://i.imgur.com/enS60o9.png","title":"Firefox 12 running inside modern Firefox via a JS-powered Windows 2000 Virtual Machine"},
-    {"url":"https://medium.com/firefox-test-pilot/introducing-firefox-color-and-side-view-20fa66c01ff4","title":"Test Pilot: Introducing Firefox Color and Side View"},
-    {"url":"https://i.imgur.com/1ySs9NQ.png","title":"Finally, the dark theme feels like a real dark theme in 61.0"},
-    {"url":"https://i.imgur.com/fici1qY.png","title":"Interesting Firefox is appearing on Chrome's top stories. It made me laugh, in a good way."},
-    {"url":"https://trac.torproject.org/projects/tor/wiki/org/meetings/2018Rome/Notes/FusionProject","title":"Mozilla Project Fusion: Tor Integration into Firefox"},
-    {"url":"http://img06.deviantart.net/ec29/i/2011/163/3/f/114_firefox_vs_chrome_by_foice-d3ipqiu.jpg","title":"Soon, we will be ready"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-63-to-get-improved-tracking-protection-that-blocks-in-browser-miners/","title":"Firefox 63 to Get Improved Tracking Protection That Blocks In-Browser Miners"},
-    {"url":"https://www.techradar.com/news/the-best-web-browser","title":"TechRadar: Firefox is #1 browser of 2018: faster and more secure"},
-    {"url":"https://old.reddit.com/r/firefox/comments/93ij56/when_firefox_is_going_to_have_a_new_logo/","title":"When firefox is going to have a new logo."},
-    {"url":"https://asadotzler.com/2018/03/31/mozilla-org-is-20-years-old/","title":"mozilla.org is 20 years old"},
-    {"url":"https://i.redd.it/d6t3g75dvf721.png","title":"Firefox is now placing ads on your home page."},
-    {"url":"https://www.mozilla.org/en-US/firefox/all/","title":"Firefox 58.0 Final is out now"},
-    {"url":"https://www.bleepingcomputer.com/news/security/firefox-will-warn-users-when-visiting-sites-that-suffered-a-data-breach/","title":"Firefox Will Warn Users When Visiting Sites That Suffered a Data Breach"},
-    {"url":"https://www.reddit.com/r/privacy/comments/92ndkf/be_careful_adblock_bought_ublock_not_confuse_with/","title":"Be careful: Adblock bought uBlock (not confuse with uBlock Origin) • r/privacy"},
-    {"url":"https://twitter.com/auchenberg/status/1088587621721231361?s=19","title":"Microsoft engineer: \"Thought: It's time for @mozilla to get down from their philosophical ivory tower. The web is dominated by Chromium, if they really *cared* about the web they would be contributing instead of building a parallel universe that's used by less than 5%?\""},
-    {"url":"https://i.imgur.com/MmmFEHf.png","title":"\"You've been hacked?\" is not really a great email subject to receive. How about \"Find out if you've been hacked.\" instead"},
-    {"url":"https://sonniesedge.co.uk/posts/amp-urls/","title":"The mysterious case of missing URLs and Google's AMP - Google has a monopoly on search rankings. We can't let them obtain a monopoly on websites."},
-    {"url":"https://boingboing.net/2018/09/12/vichy-nerds-2.html","title":"Europe just voted to wreck the internet, spying on everything and censoring vast swathes of our communications - Cory Doctorow"},
-    {"url":"https://imgur.com/a/4KsFFBK","title":"Hey guys im a long time Google Chrome user and just started using Firefox the other day. Ive made a lot of little changes to make the transition easier and thought it would be cool to share what I've done with others who might be going through something similar, so I made a very in-depth imgur album"},
-    {"url":"https://andregarzia.com/2018/12/while-we-blink-we-loose-the-web.html","title":"While we Blink, we lose the Web"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7xnmkd/this_is_blatant_discrimination_against_firefox/","title":"This is blatant discrimination against Firefox and also bullcrap"},
-    {"url":"https://old.reddit.com/r/firefox/comments/896oqv/built_in_dark_theme_now_works_with_new_tab/","title":"Built in dark theme now works with new tab"},
-    {"url":"https://www.ghacks.net/2017/10/28/firefox-58-warns-you-if-sites-use-canvas-image-data/","title":"Firefox 58 warns you if sites use Canvas image data - which could be used to uniquely identify your computer"},
-    {"url":"https://arstechnica.com/gadgets/2018/12/the-web-now-belongs-to-google-and-that-should-worry-us-all/","title":"Google isn’t the company that we should have handed the Web over to"},
-    {"url":"https://techcrunch.com/2017/12/15/mozillas-mr-robot-promo-backfires-after-it-installs-firefox-extension-without-permission/amp/","title":"Mozilla’s Mr. Robot promo backfires after it installs a Firefox extension without permission"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7ek2au/not_even_a_month_of_web_browsing_and_over_1000/","title":"Not even a month of web browsing and over 1000 sites have tried tracking me..."},
-    {"url":"https://old.reddit.com/r/firefox/comments/9z0dju/didnt_know_firefox_can_warn_user_for_breached/","title":"Didn't know Firefox can warn user for breached account, is this new?"},
-    {"url":"https://blog.mozilla.org/blog/2017/12/12/mozilla-joins-net-neutrality-blackout-for-break-the-internet-day/","title":"Mozilla Joins Net Neutrality Blackout for ‘Break the Internet’ Day"},
-    {"url":"https://danielmiessler.com/blog/google-amp-not-good-thing/","title":"Google AMP is Not a Good Thing - \"If this were to become widely adopted, you’d search for something, get results, consume the content, and you’d never leave Google.\""},
-    {"url":"https://www.mozilla.org/en-US/firefox/61.0/releasenotes/","title":"Firefox 61.0 got released — Release Notes"},
-    {"url":"https://i.imgur.com/aMHz2px.png","title":"Firefox 57 has reached Developer Edition!"},
-    {"url":"https://www.reddit.com/personalization?done=true","title":"Reddit now tracks and sells individual user behavior by default (including outbound clicks). Here's the setting to disallow it."},
-    {"url":"https://old.reddit.com/r/firefox/comments/817juo/gif_vs_jif_how_about_yif/","title":"“GIF” vs “JIF”? How about “YIF”?"},
-    {"url":"https://boingboing.net/2015/11/20/assad-government-secretly-sent.html","title":"Syria secretly sentenced developer and Firefox contributor Bassel Khartabil to death"},
-    {"url":"https://www.cnn.com/2018/03/29/opinions/tech-backlash-facebook-google-opinion-baker/index.html","title":"Backlash against tech companies is a wake-up call - By Mozilla Founder Mitchell Baker"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8ra5oi/there_is_now_an_option_in_nightly_to_reopen_tab/","title":"There is now an option in nightly to reopen tab in a container."},
-    {"url":"https://blog.mozilla.org/blog/2017/09/26/firefox-quantum-beta-developer-edition/","title":"Firefox Quantum Lands in Beta, Developer Edition – The Mozilla Blog"},
-    {"url":"https://blog.mozilla.org/blog/2017/02/27/mozilla-acquires-pocket/","title":"Mozilla Acquires Pocket"},
-    {"url":"http://imgur.com/SJF8e0i","title":"Loving this new Firefox advertising"},
-    {"url":"https://i.imgur.com/ERQbQrW.png","title":"Almost updated Firefox, then noticed something is A BIT suspicious. Where can I send/report this?"},
-    {"url":"https://blog.mozilla.org/blog/2018/12/06/goodbye-edge/","title":"Goodbye, EdgeHTML – The Mozilla Blog"},
-    {"url":"https://www.cnet.com/news/microsoft-windows-removes-warning-about-installing-chrome-firefox/","title":"Good news : Microsoft Windows U-turn removes warning about installing other browsers"},
-    {"url":"https://techcrunch.com/2017/09/29/its-time-to-give-firefox-another-chance/","title":"It’s time to give Firefox another chance"},
-    {"url":"https://www.zdnet.com/article/firefox-and-the-4-year-battle-to-have-google-to-treat-it-as-a-first-class-citizen/","title":"Firefox and the 4-year battle to have Google to treat it as a first-class citizen"},
-    {"url":"https://old.reddit.com/r/firefox/comments/88a2sf/so_i_was_looking_for_an_extension_to_edit/","title":"So I was looking for an extension to edit keyboard shortcuts"},
-    {"url":"https://www.polemicdigital.com/google-amp-go-to-hell/ants_websites_to_adopt_amp_as_the_default/","title":"Google wants websites to adopt AMP as the default approach to building webpages. Tell them no."},
-    {"url":"https://youtu.be/6fcrKa0mk0k","title":"Color: a brand new extension by Firefox"},
-    {"url":"https://arstechnica.co.uk/information-technology/2017/06/firefox-multiple-content-processes/","title":"Firefox 54 finally goes multi-process, eight years after work began"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-implements-another-privacy-preserving-feature-taken-from-the-tor-browser/","title":"Firefox Implements Another Privacy-Preserving Feature Taken From the Tor Browser"},
-    {"url":"https://www.nytimes.com/2018/06/11/technology/net-neutrality-repeal.html","title":"Net Neutrality Repeal is now official"},
-    {"url":"https://www.fxsitecompat.com/en-CA/docs/2018/third-party-tracking-cookies-are-now-blocked-by-default/","title":"Third-party tracking cookies are now blocked by default"},
-    {"url":"https://old.reddit.com/r/firefox/comments/75y9ii/menus_are_blindingly_white_in_the_dark_theme/","title":"Menus are blindingly white in the dark theme"},
-    {"url":"https://old.reddit.com/r/firefox/comments/a5sqsi/wow_impressive/","title":"Wow impressive."},
-    {"url":"https://old.reddit.com/r/firefox/comments/7hq44o/as_if_i_didnt_dislike_spotify_enough_already/","title":"As if I didn't dislike Spotify enough already..."},
-    {"url":"https://groups.google.com/forum/#!topic/mozilla.governance/81gMQeMEL0w","title":"Firefox planning to anonymously collect browsing data"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-prepares-to-mark-all-http-sites-not-secure-after-https-adoption-rises/","title":"Firefox Prepares to Mark All HTTP Sites \"Not Secure\" After HTTPS Adoption Rises"},
-    {"url":"https://www.reddit.com/r/talesfromtechsupport/comments/7k7wum/when_all_online_tests_are_invalidated_blame_mr/","title":"Real world effects of the Looking Glass experiment."},
-    {"url":"https://liliputing.com/2017/11/mozilla-releases-open-source-speech-recognition-tools.html","title":"Mozilla releases open source speech recognition tools"},
-    {"url":"https://lifehacker.com/why-you-should-switch-from-google-chrome-to-firefox-1821879163","title":"Why You Should Switch From Google Chrome to Firefox"},
-    {"url":"https://i.imgur.com/5IBXo0u.png","title":"TIP: You can add keywords to any search bar and then use them in the main URL bar for faster access"},
-    {"url":"https://i.imgur.com/Rx42mAn.jpg","title":"Happy Halloween!"},
-    {"url":"https://psyq123.wordpress.com/2015/11/26/to-defend-the-free-web-you-must-save-mozilla/","title":"To defend the free web, you must save Mozilla"},
-    {"url":"https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/","title":"Introducing the New Firefox: Firefox Quantum – The Mozilla Blog"},
-    {"url":"https://i.imgur.com/2kW3vGD.png","title":"New Developer Edition (aurora) icon for 57"},
-    {"url":"https://www.youtube.com/watch?v=Am4pKF5T_jU","title":"It's time to root for underdog browser Firefox again"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/amp2html/","title":"Seeing more and more AMP links being shared around on social media lately. Don't let this become normal, install this extension to redirect to non-AMP sites and help save the web."},
-    {"url":"https://www.eff.org/deeplinks/2018/10/privacy-badger-now-fights-more-sneaky-google-tracking","title":"Privacy Badger Now Fights More Sneaky Google Tracking"},
-    {"url":"https://old.reddit.com/r/firefox/comments/91yebi/firefox_needs_to_clear_cookies/","title":"Firefox needs to clear cookies"},
-    {"url":"https://www.extremetech.com/computing/282685-google-denies-crippling-edge-to-chromes-advantage","title":"Google Denies Crippling Edge to Chrome's Advantage"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9g4h0c/in_finnish_mythology_its_believed_that_the_aurora/","title":"In Finnish mythology , it's believed that the Aurora Borealis is caused by a firefox who ran so quickly across the snow that it's tail caused sparks to fly into the night sky creating the Aurora. The Finnish word “Revontulet” literally translates as \"Fox flames\""},
-    {"url":"https://twitter.com/mike_conley/status/978991881337081856","title":"Dark themes in Firefox Nightly now affect the URL and search dropdowns"},
-    {"url":"http://i.imgur.com/StabbzB.jpg","title":"Today at Mozilla (x-post from /r/geek)"},
-    {"url":"https://old.reddit.com/r/firefox/comments/96r74c/ive_never_seen_a_major_website_recommend_firefox/","title":"I've never seen a major website recommend Firefox over Chrome in such an open way."},
-    {"url":"https://blog.mozilla.org/services/2018/05/22/two-step-authentication-in-firefox-accounts/","title":"Firefox Accounts getting two-step authentication"},
-    {"url":"https://i.imgur.com/bSwEDvo.png","title":"Just hit my millionth element blocked. Could never do this on IE"},
-    {"url":"https://blog.mozilla.org/firefox/firefox-64-default-64-bit-windows/","title":"64-bit Firefox is the new default on 64-bit Windows"},
-    {"url":"https://old.reddit.com/r/firefox/comments/ag8uyv/you_can_now_manage_keyboard_shortcuts_of/","title":"You can now manage keyboard shortcuts of extensions at about:addons"},
-    {"url":"https://twitter.com/ctavan/status/1044282084020441088","title":"Chrome 69 will keep Google Cookies when you tell it to delete all cookies"},
-    {"url":"https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#html-filters","title":"HTML filtering is coming to uBO 1.14.25, capable of preventing the execution of specific inline scripts, only supported on Firefox 57+"},
-    {"url":"https://cbsi.secure.force.com/CBSi/ViewArticle_allaccess?popup=true&aId=kA00L000000Hfaq&categories=CBS_Entertainment%3AAll_Access&template=template_cbsvod&referer=cbs.com/vod&data=&cfs=SFS_FT","title":"CBS site requires Firefox users turn off anti-tracking to see content"},
-    {"url":"https://www.theverge.com/2017/12/30/16829804/browser-password-manager-adthink-princeton-research","title":"Ad targeters are pulling data from your browser’s password manager"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6mue3v/thanks_mozilla_for_spreading_awareness_about_net/","title":"Thanks Mozilla for spreading awareness about Net Neutrality!"},
-    {"url":"http://venturebeat.com/2015/07/24/firefox-is-getting-audio-indicators-to-show-noisy-tabs-and-will-let-you-mute-them/","title":"Firefox Will Soon Show You Which Tabs Are Making Noise, and Let You Mute Them"},
-    {"url":"https://twitter.com/mozilla/status/994216229593284608","title":"Mozilla is joining 🚨 RED ALERT for NetNeutrality because you deserve to know what YOU stand to lose if the FCC repeal of net neutrality becomes the law of the land."},
-    {"url":"https://advocacy.mozilla.org/en-US/net-neutrality-comments?sample_rate=0.01&snippet_name=6819#utm_source=desktop-snippet&utm_medium=snippet&utm_campaign=net-neutrality","title":"The beginning of the end of the open internet? Not if we do something about it."},
-    {"url":"https://old.reddit.com/r/firefox/comments/7dc0fc/how_long_have_you_been_using_firefox/","title":"How long have you been using Firefox?"},
-    {"url":"https://9to5google.com/2018/04/22/google-chrome-canary-reveals-new-refreshed-material-design-look-gallery/","title":"Chrome’s new design looks strangely familiar. 🤔"},
-    {"url":"https://www.troyhunt.com/were-baking-have-i-been-pwned-into-firefox-and-1password/","title":"We're Baking Have I Been Pwned into Firefox and 1Password"},
-    {"url":"https://i.imgur.com/r3pbGfJ.png","title":"Came into work and my laptop went straight to this when logging in....good try Microsoft."},
-    {"url":"https://discourse.mozilla.org/t/support-ublock-origin/6746/451","title":"uBlock Origin developer on Chrome vs Firefox WebExtensions"},
-    {"url":"https://twitter.com/asadotzler/status/1088617089974251522","title":"Firefox Product Manager on Twitter: Firefox isn't going to do anything with ad blockers"},
-    {"url":"https://www.zdnet.com/article/google-and-mozilla-are-right-av-firms-do-need-to-stop-breaking-https-security/","title":"Google and Mozilla are right: AV firms do need to stop breaking HTTPS security"},
-    {"url":"https://i.imgur.com/jXyCaaQ.png","title":"Firefox 58!"},
-    {"url":"https://www.howtogeek.com/333230/why-firefox-had-to-kill-your-favorite-extension/","title":"Why Firefox Had to Kill Your Favorite Extension"},
-    {"url":"https://www.eff.org/deeplinks/2016/04/save-firefox","title":"Save Firefox!"},
-    {"url":"https://i.imgur.com/GYPwJKd.jpg","title":"Why does Progressive Insurance hate Firefox?"},
-    {"url":"https://i.imgur.com/c01C86Q.png","title":"You can't download anymore from MEGA without additional software."},
-    {"url":"https://www.zdnet.com/article/malicious-sites-abuse-11-year-old-firefox-bug-that-mozilla-failed-to-fix/","title":"Malicious sites abuse 11-year-old Firefox bug that Mozilla failed to fix"},
-    {"url":"https://www.howtogeek.com/335712/update-why-you-shouldnt-use-waterfox-pale-moon-or-basilisk/","title":"How-To Geek recommends against using Waterfox, Pale Moon, and Basilisk"},
-    {"url":"https://gizmodo.com/after-blowback-firefox-will-move-mr-robot-extension-t-1821354314","title":"After Blowback, Firefox Will Move Mr. Robot Extension to Store"},
-    {"url":"https://www.mozilla.org/en-US/firefox/55.0/releasenotes/","title":"Firefox — Notes (55.0)"},
-    {"url":"https://www.bleepingcomputer.com/news/security/mozilla-removes-23-firefox-add-ons-that-snooped-on-users/","title":"Mozilla Removes 23 Firefox Add-Ons That Snooped on Users"},
-    {"url":"https://twitter.com/letsencrypt/status/1020058447922978816","title":"Let's Encrypt: \"The percentage of Web pages loaded by Firefox using HTTPS has reached over 80% among U.S. users! We are thrilled to help secure the Web. (Stats via @firefox telemetry)\""},
-    {"url":"https://www.reddit.com/r/privacy/comments/8poozr/facebook_reportedly_sold_user_data_to_businesses/","title":"Facebook reportedly sold user data to businesses in secret deals - Developing • r/privacy"},
-    {"url":"https://i.imgur.com/UA82pHS.png","title":"Google Blog blocks Firefox mobile but recommends Firefox..."},
-    {"url":"https://old.reddit.com/r/firefox/comments/8grw52/one_youtube_video_running_6gb_memory_41_cpu/","title":"One Youtube video running. 6GB memory 41% CPU"},
-    {"url":"https://www.quora.com/Does-Chrome-have-a-feature-similar-to-Firefox-container-tabs","title":"Does Google literally pay \"shills\" to bash Firefox and promote Chrome?"},
-    {"url":"https://www.wordfence.com/blog/2016/11/emergency-bulletin-firefox-0-day-wild/?utm_source=list&utm_campaign=113016&utm_medium=email","title":"Bulletin: Firefox 0 day in the wild."},
-    {"url":"https://hg.mozilla.org/mozilla-central/raw-file/7c50f0c999c5/browser/branding/nightly/VisualElements_150.png","title":"Next Nighty Logo. Let's see if it stays like this."},
-    {"url":"https://np.reddit.com/r/wow/comments/5exq2d/wowheadcom_sucking_bandwidth/dagbmie/","title":"uBlock Origin developer Raymond Hill on wowhead.com: \"It's like the site is designed to fire a lot of obfuscated garbage network requests along with a few legitimate ones, as a punishment for using a blocker\""},
-    {"url":"http://www.ghacks.net/2017/01/28/firefox-add-on-quicksaver-quits/","title":"Firefox loses yet another high profile add-on author: Quicksaver quits"},
-    {"url":"https://www.mozilla.org/en-US/firefox/59.0/releasenotes/","title":"Firefox 59 Release Notes"},
-    {"url":"https://www.zdnet.com/article/mozilla-will-match-all-donations-to-the-tor-project/","title":"Mozilla will match all donations to the Tor Project | ZDNet"},
-    {"url":"https://venturebeat.com/2018/12/31/mozilla-ad-on-firefoxs-new-tab-page-was-just-another-experiment/","title":"Mozilla on Firefox's Booking.com Snippet: “It was not a paid placement or advertisement. We are continually looking for more ways to say thanks for using Firefox.\""},
-    {"url":"https://old.reddit.com/r/firefox/comments/7h24ra/firefox_lost_its_1_position_on_the_desktop_in/","title":"Firefox lost its #1 position on the desktop in Germany in the last two months -- what happened?"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7whdv4/googlecom_in_firefox_for_android_normal_vs_w/","title":"Google.com in Firefox for Android, normal vs w/ UserAgent spoofing"},
-    {"url":"https://blog.mozilla.org/advancingcontent/2015/12/04/advancing-content/","title":"Mozilla to stop advertising through new tab tiles"},
-    {"url":"https://tamebay.com/2018/08/firefox-to-distrust-all-tls-certificates-issued-by-symantec.html","title":"Firefox to distrust all SSL/TLS certificates issued by Symantec"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8kq47d/acrylic_photon_firefox_mockup/","title":"Acrylic photon Firefox mock-up"},
-    {"url":"https://i.imgur.com/dgTgfqO.png","title":"Spell \"Antitrust\""},
-    {"url":"https://www.firefox.net.cn/read-54613","title":"Mining codes been discovered in two reviewed add-ons from \"Add-ons for Firefox\" site."},
-    {"url":"https://blog.torproject.org/new-release-tor-browser-80","title":"New Release: Tor Browser 8.0 based on Firefox Quantum"},
-    {"url":"https://www.cnet.com/news/firefox-to-support-googles-webp-image-format-for-a-faster-web/","title":"Firefox to support Google's WebP image format for a faster web"},
-    {"url":"https://old.reddit.com/r/firefox/comments/788fmc/few_more_customizations_for_default_dark_theme/","title":"Few More Customizations for Default Dark Theme"},
-    {"url":"https://ferdychristant.com/the-state-of-web-browsers-f5a83a41c1cb","title":"\"The State of Web Browsers\" - Firefox's the long road to irrelevance"},
-    {"url":"https://blog.mozilla.org/blog/2017/06/20/10615/","title":"Firefox Focus New to Android, blocks annoying ads and protects your privacy"},
-    {"url":"https://imgur.com/a/uJXUT","title":"Firefox Wallpapers All Versions 27 high res. Images"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6teno8/another_new_firefox_nightly_icon/","title":"Another new Firefox Nightly icon"},
-    {"url":"http://i.imgur.com/L0xBM0B.png","title":"Really disappointed in Directv Now..."},
-    {"url":"https://www.mozilla.org/en-US/firefox/50.0/releasenotes/","title":"Firefox 50.0 out today, with better startup improvements."},
-    {"url":"https://www.theguardian.com/technology/2019/jan/28/eu-data-watchdog-raises-concerns-facebook-integration","title":"EU data watchdog raises concerns over Facebook’s plan to merge WhatsApp, Instagram and Facebook Messenger"},
-    {"url":"https://blog.cryptographyengineering.com/2018/09/23/why-im-leaving-chrome/","title":"Why I’m done with Chrome – A Few Thoughts on Cryptographic Engineering"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/decentraleyes/#detail-relnotes","title":"Decentraleyes 2.0 (Webextension) released to AMO stable"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6z4kv6/seems_legit/","title":"Seems legit."},
-    {"url":"https://send.firefox.com/","title":"Firefox Send - You can now share up to 1 GB files with Firefox via any browser"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7kzj0z/i_didnt_expect_firefox_to_support_this_kind_of/","title":"I didn't expect Firefox to support this kind of device 😳"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7cn208/firefox_quantum_57_final_out_now/","title":"Firefox Quantum 57 final out now"},
-    {"url":"https://i.imgur.com/fIrkllM.gif","title":"I like this"},
-    {"url":"https://github.com/mozilla/multi-account-containers/issues/339#issuecomment-434534754","title":"Mozilla plans to spend some full-time on Containers add-on; synchronization feature discussed"},
-    {"url":"https://www.ghacks.net/2018/10/21/mozilla-tests-premium-vpn-service/","title":"Mozilla tests Premium VPN Service"},
-    {"url":"https://www.pcmag.com/news/357788/mozilla-yahoo-sue-each-other-over-firefoxs-default-search","title":"Mozilla, Yahoo Sue Each Other Over Firefox's Default Search"},
-    {"url":"http://www.ghacks.net/2016/08/30/firefox-51-flac-audio-codec-support/","title":"Firefox 51 will have FLAC audio codec support out of the box"},
-    {"url":"https://venturebeat.com/2018/07/30/mozilla-is-rebranding-firefox-and-wants-your-opinion/","title":"Mozilla is rebranding Firefox and wants your opinion"},
-    {"url":"https://i.imgur.com/Vip6WBC.jpg","title":"Opera Touch (android app) icon colours seem familiar... Where have I seen those gradients before... 🤔"},
-    {"url":"https://forum.f-droid.org/t/making-it-easier-for-f-droid-to-package-mozilla-firefox/1649/8","title":"Firefox Android may get a F-Droid build, without GCM"},
-    {"url":"https://i.imgur.com/SM0GNye.png","title":"Firefox Screenshots finally has a \"copy to clipboard\" option!"},
-    {"url":"https://www.bleepingcomputer.com/news/microsoft/microsoft-has-effectively-banned-third-party-browsers-from-the-windows-store/","title":"Microsoft Has Effectively Banned Third-Party Browsers From the Windows Store"},
-    {"url":"https://github.com/vladikoff/netflix-1080p-firefox/pull/14","title":"The Netflix 1080p add-on for Firefox has been updated and should be working again"},
-    {"url":"https://newfirefox.mozilla.community/","title":"Firefox Quantum Release Campaign - Support Mozilla in Announcing Firefox!"},
-    {"url":"https://www.ghacks.net/2018/12/03/ublock-origin-performance-improvements-thanks-to-wasm-firefox-only-for-now/","title":"uBlock Origin performance improvements thanks to WASM (Firefox only, for now) - gHacks Tech News"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9lpe9l/nightly_is_sending_notificions_to_action_center/","title":"Nightly is sending notificions to Action Center in Windows"},
-    {"url":"https://soylentnews.org/article.pl?sid=18/05/17/028245","title":"Privacy Tool uBlock (NOT uBlock Origin) Adds User Tracking Feature"},
-    {"url":"https://old.reddit.com/r/firefox/comments/aa1age/didnt_age_well/","title":"Didn't age well"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9wukkn/how_does_firefox_decide_that_extension_with_0/","title":"How does Firefox decide that extension with 0 users is \"Trending\"?"},
-    {"url":"https://www.mozilla.org/en-US/firefox/60.0.2/releasenotes/","title":"Firefox 60.0.2 released, security and bug fixes."},
-    {"url":"https://github.com/devunt/make-gis-great-again#make-google-image-search-great-again","title":"\"So this web extension simply adds \"View Image\" button to Google Image Search results again.\" Yay!"},
-    {"url":"https://www.popularmechanics.com/technology/a22887479/firefox-block-third-party-trackers/","title":"Firefox To Block Third-Party Trackers That Harvest Your Data and Slow Down Your Internet"},
-    {"url":"https://old.reddit.com/r/firefox/comments/a2zirb/cristal_fox_part_of_my_art_everyday_art_project/","title":"Cristal fox. Part of my art everyday art project. CC1"},
-    {"url":"https://www.mozilla.org/en-US/firefox/dedicated-profiles/","title":"Starting with Firefox 67, Firefox Nightly will run a dedicated profile"},
-    {"url":"https://twitter.com/letsencrypt/status/1043291536400805891","title":"Let's Encrypt: 75% of Web pages loaded by @firefox use HTTPS!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8mwhnm/bank_of_america_finds_firefox_quantum_600_as_an/","title":"Bank of America finds Firefox Quantum 60.0 as an Old & Outdated Browser!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8msjvg/so_is_this_the_ultimate_privacy_firefox_am_i/","title":"So is this the ultimate Privacy Firefox? Am I missing something?"},
-    {"url":"https://arstechnica.com/gadgets/2018/05/firefox-will-show-sponsored-content-thats-personalized-but-private/","title":"Firefox will show sponsored content that’s personalized but private"},
-    {"url":"https://imgur.com/gallery/agD1McH","title":"I love these fun facts"},
-    {"url":"https://savecodeshare.eu/","title":"EU Parliament is planning new copyright rules which threatens Open-Source code platforms like Github, Gitlab and others. Sign the FSFE open letter now!"},
-    {"url":"https://venturebeat.com/2018/01/26/probeat-google-chrome-and-mozilla-firefox-are-bringing-back-the-browser-wars/","title":"ProBeat: Google Chrome and Mozilla Firefox are bringing back the browser wars"},
-    {"url":"https://twitter.com/slac/status/943474837766524928","title":"Google Hangouts finally supports Firefox"},
-    {"url":"https://blog.torproject.org/powering-digital-resistance-help-mozilla","title":"Mozilla is matching donations to the Tor Project up to a total of $500,000"},
-    {"url":"http://sourceforge.net/projects/firefox.mirror/","title":"Ownership of Firefox on sourceforge Was transfered to sf-editor1 (SourceForge Staff)"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1450784","title":"Firefox 65 to show ‘Mozilla_PKIX_ERROR_ MITM_Detected’ when antivirus interferes with SSL connections"},
-    {"url":"https://blog.mozilla.org/futurereleases/2018/08/30/changing-our-approach-to-anti-tracking/","title":"Changing Our Approach to Anti-tracking – Future Releases"},
-    {"url":"https://www.ghacks.net/2018/07/13/firefox-will-support-windows-10s-dark-mode/","title":"Firefox will support Windows 10's dark mode"},
-    {"url":"https://imgur.com/gallery/6b6NOHL","title":"Firefox has encountered a bug"},
-    {"url":"https://user-images.githubusercontent.com/4400286/51053095-b233bb80-15a6-11e9-95f4-decdc82d1b7a.png","title":"New Firefox Logo?"},
-    {"url":"https://twitter.com/gorhill/status/1018484996212969472","title":"How can we be expected to trust extensions when this is allowed?"},
-    {"url":"https://blog.mozilla.org/blog/2017/07/20/firefox-focus-android-hits-one-million-downloads-today-launching-three-new-user-requested-features/","title":"Firefox Focus for Android Hits One Million Downloads! Today We’re Launching Three New User-Requested Features"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1358372#c45","title":"Firefox Nightly finally only creates one process in Windows volume mixer (coming with Firefox 60)"},
-    {"url":"http://i.imgur.com/buzWpgg.png","title":"The new Nightly icon has landed on Android"},
-    {"url":"http://i.imgur.com/HAPwCQG.png","title":"I'll take my business else where, then."},
-    {"url":"https://www.ghacks.net/2018/10/11/this-is-firefoxs-upcoming-aboutperformance-page-huge-improvements/","title":"This is Firefox's upcoming about:performance page (huge improvements) - gHacks Tech News"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/view-image/","title":"Have you noticed disappearance of \"view image\" button on Google? Firefox add-on brings it back"},
-    {"url":"https://twitter.com/NicolasPetton/status/884694176515936256","title":"Security Fuckup: about:addons uses Google Analytics"},
-    {"url":"https://imgur.com/a/D4LCn","title":"For Night Owls! The Dark Mode ;)"},
-    {"url":"http://www.dailydot.com/technology/hola-vpn-security/?tw=dd","title":"Stop using the Hola VPN right now. The company behind Hola is turning your computer into a node on a botnet, and selling your network to anyone who is willing to pay. [X-post from /r/Chrome]"},
-    {"url":"https://www.mozilla.org/en-US/firefox/62.0/releasenotes/","title":"Firefox 62.0 got released — Release Notes"},
-    {"url":"https://blog.mozilla.org/blog/2018/10/23/latest-firefox-rolls-out-enhanced-tracking-protection/","title":"Latest Firefox Rolls Out Enhanced Tracking Protection – The Mozilla Blog"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8hrb78/firefox_62_reaches_the_nightly_channel/","title":"Firefox 62 reaches the Nightly channel"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7yvrkw/popular_chrome_extension_dark_reader_now_supports/","title":"Popular Chrome extension Dark Reader now supports for Firefox"},
-    {"url":"https://blog.mozilla.org/blog/2017/05/08/next-10-days-critical-internets-future/","title":"Why the Next 10 Days Are Critical to the Internet’s Future"},
-    {"url":"https://screenshots.firefox.com/YnyWizx6ulrPZ23e/null","title":"New Firefox logo lands in Nightly"},
-    {"url":"https://news.fastcompany.com/mozilla-is-crowdsourcing-a-massive-speech-recognition-system-4043612","title":"Mozilla is crowdsourcing a massive speech-recognition system"},
-    {"url":"https://www.google.com/earth/","title":"New version of Google Earth runs on Chrome only"},
-    {"url":"https://theintercept.com/2017/06/05/be-careful-celebrating-googles-new-ad-blocker-heres-whats-really-going-on/","title":"Be Careful Celebrating Google’s New Ad Blocker. Here’s What’s Really Going On."},
-    {"url":"https://www.mozilla.org/en-US/firefox/36.0/releasenotes/","title":"Firefox 36.0 released!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/90jgd2/nightly_now_lets_you_allow_or_block_autoplay_per/","title":"Nightly now lets you allow or block autoplay per website"},
-    {"url":"https://old.reddit.com/r/firefox/comments/80lzun/nightly_now_supports_theming_arrow_panels/","title":"Nightly now supports theming arrow panels"},
-    {"url":"https://hacks.mozilla.org/2017/10/the-whole-web-at-maximum-fps-how-webrender-gets-rid-of-jank/","title":"The whole web at maximum FPS: How WebRender gets rid of jank"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7rgro4/firefox_nightly_590a1_finally_properly_hides/","title":"Firefox Nightly (59.0a1) finally properly hides title bar on Ubuntu Mate"},
-    {"url":"https://i.imgur.com/LNz4VBY.jpg","title":"Our beloved browser's logo in real life (x-post from /r/redpandas)"},
-    {"url":"https://www.thurrott.com/cloud/197417/chromes-new-ad-blocker-goes-worldwide-in-july","title":"Chrome’s Ad Blocker Goes Worldwide in July"},
-    {"url":"https://www.trustedreviews.com/news/google-kaios-firefox-os-3497173","title":"Google just spent $22m on what used to be Firefox OS"},
-    {"url":"https://www.theverge.com/2018/6/13/17446660/mozilla-firefox-pocket-recommendations-ceo-nate-weiner-interview-converge-podcast","title":"How Firefox is using Pocket to try to build a better news feed than Facebook"},
-    {"url":"https://old.reddit.com/r/firefox/comments/aifypn/is_there_a_plugin_to_block_this_style_of_email/","title":"Is there a plugin to block this style of email sign-up overlay messages? I get them constantly on sites these days and it drives me nuts."},
-    {"url":"https://arstechnica.com/tech-policy/2018/07/net-neutrality-rules-are-illegal-according-to-trumps-supreme-court-pick/","title":"Trump’s Supreme Court pick: ISPs have 1st Amendment right to block websites"},
-    {"url":"https://streamable.com/gy45e","title":"Firefox's new reload/stop animation for Photon just hit Nightly"},
-    {"url":"http://i.imgur.com/u8TvSJo.png","title":"Mozilla should do something about these malware ads that appear as the first two results in a Google search for \"firefox\""},
-    {"url":"https://boingboing.net/2018/11/29/but-not-chrome.html","title":"Mozilla pulls a popular paywall circumvention tool from Firefox add-ons store"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9w3azf/thunderbird_is_seperate_from_mozilla/","title":"Thunderbird is seperate from mozilla?"},
-    {"url":"http://www.theverge.com/2016/9/13/12890050/adblock-plus-now-sells-ads","title":"Adblock Plus now sells ads"},
-    {"url":"https://i.imgur.com/OeI0IBy.png","title":"Photon Rectangular tabs have landed in Nightly!"},
-    {"url":"http://www.wired.com/wiredenterprise/2014/01/mozilla/","title":"Mozilla Calls On World To Protect Firefox Browser From the NSA"},
-    {"url":"https://blog.mozilla.org/blog/2018/09/25/introducing-firefox-monitor-helping-people-take-control-after-a-data-breach/","title":"Introducing Firefox Monitor, Helping People Take Control After a Data Breach – The Mozilla Blog"},
-    {"url":"http://www.motherjones.com/mojo/2014/04/okcupid-ceo-donate-anti-gay-firefox","title":"And now irony: OkCupid's CEO Donated to an Anti-Gay Campaign Once, Too"},
-    {"url":"http://www.ghacks.net/2016/11/05/mozilla-and-google-remove-wot-extension/","title":"Mozilla and Google remove WOT (Web of Trust) extension from browser's addon stores"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1405971","title":"Webextensions in Firefox suffer from a privacy leak. Calls done by the extension attach a `Origin: moz-extension://<internal-uuid>` header, thereby allowing servers, CDNs to track the user based on this persistent user identifier."},
-    {"url":"https://www.reddit.com/r/Windows10/comments/8uhw99/its_official_microsoft_acknowledged_firefox_as/","title":"It's official! Microsoft acknowledged Firefox as being faster than Chrome"},
-    {"url":"https://techcrunch.com/2016/09/02/multi-process-firefox-brings-400-700-improvement-in-responsiveness/?ncid=rss&utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+Techcrunch+%28TechCrunch%29","title":"Multi-process Firefox brings 400-700% improvement in responsiveness"},
-    {"url":"http://www.engadget.com/2015/07/22/twitch-starts-dumping-flash-for-html5/","title":"Twitch starts dumping Flash for HTML5"},
-    {"url":"http://i.imgur.com/jeMduiZ.gif","title":"Firefox is still king of customization"},
-    {"url":"https://www.ghacks.net/2018/11/28/mozilla-revenue-rose-by-over-40-million-in-2017/","title":"Mozilla revenue rose by over $40 million in 2017"},
-    {"url":"https://www.nbcnews.com/tech/tech-news/apple-firefox-browsers-aim-thwart-facebook-google-tracking-n909671","title":"Apple, Firefox browsers aim to thwart Facebook, Google tracking"},
-    {"url":"https://wccftech.com/firefox-damaged-user-trust-promote-mr-robot/","title":"Firefox May Have Damaged Its Own Name to Promote Mr. Robot"},
-    {"url":"https://www.mozilla.org/en-US/firefox/57.0.1/releasenotes/","title":"Firefox — Notes (57.0.1)"},
-    {"url":"http://www.ghacks.net/2017/03/07/firefox-52-0-released-find-out-what-is-new/","title":"Firefox 52.0 released: find out what is new"},
-    {"url":"https://www.reddit.com/r/Windows10/comments/a74z95/edgehtml_engineer_says_part_of_the_reason_why/","title":"EdgeHTML engineer says part of the reason why Microsoft gave up on Edge is because of Google intentionally making changes to their sites that broke other browsers"},
-    {"url":"https://www.mozilla.org/en-US/firefox/38.0/releasenotes/","title":"Firefox v38.0 Released"},
-    {"url":"http://i.imgur.com/UxzUYqp.png","title":"Not sure why this is needed"},
-    {"url":"https://www.mozilla.org/en-US/firefox/60.0/releasenotes/","title":"Firefox — Notes (60.0)"},
-    {"url":"https://nakedsecurity.sophos.com/2017/11/12/firefox-to-offer-tracking-protection-for-all-in-its-next-update/","title":"Firefox to offer tracking protection for all in its next update"},
-    {"url":"https://hg.mozilla.org/mozilla-central/raw-file/54ad22b649e5/browser/branding/nightly/VisualElements_150.png","title":"Today's (August 18) Nighty icon"},
-    {"url":"https://www.eff.org/deeplinks/2015/08/privacy-badger-10-here-stop-online-tracking","title":"EFF is excited to announce that today we are releasing version 1.0 of Privacy Badger for Chrome and Firefox. Privacy Badger is a browser extension that automatically blocks hidden trackers that would otherwise spy on your browsing habits as you surf the Web."},
-    {"url":"http://i.imgur.com/MMtWaIK.png","title":"Firefox forcing children into a block (from r/proprammerhumor)"},
-    {"url":"https://news.ycombinator.com/item?id=14421237","title":"Mozilla won"},
-    {"url":"http://imgur.com/a/3D2cP","title":"Firefox + uBlock Origin is 2x faster than Chrome on Android"},
-    {"url":"http://i.imgur.com/8hE2nfg.jpg","title":"Microsoft tells me I'll get better battery life if I use Microsoft Edge. How can they get away with this?"},
-    {"url":"http://robert.ocallahan.org/2014/08/choose-firefox-now-or-later-you-wont.html","title":"Choose Firefox Now, Or Later You Won't Get A Choice"},
-    {"url":"https://www.reddit.com/r/linux/comments/9hh3gc/to_unsuspecting_admins_firefox_continues_to_send/","title":"To unsuspecting admins: Firefox continues to send telemetry to Mozilla even when explicitly disabled."},
-    {"url":"https://www.mozilla.org/en-US/firefox/64.0.2/releasenotes/?utm_source=firefox-browser&utm_medium=firefox-browser&utm_campaign=whatsnew","title":"Firefox v64.0.2 Released."},
-    {"url":"http://imgur.com/a/7I0MP","title":"All I really want from Firefox."},
-    {"url":"http://i.imgur.com/Wi6rM.jpg","title":"Found this costume on r/cosplay, but it belongs here."},
-    {"url":"https://twitter.com/MkllSUMO/status/1085281415095308289","title":"The ability to upload your Firefox Screenshots to a Mozilla hosted site is being removed, along with the blue upload button"},
-    {"url":"https://www.eff.org/deeplinks/2018/04/https-everywhere-introduces-new-feature-continual-ruleset-updates","title":"HTTPS Everywhere Introduces New Feature: Continual Ruleset Updates"},
-    {"url":"https://github.com/Synzvato/decentraleyes/releases","title":"Decentraleyes now officially supports upcoming versions of Firefox."},
-    {"url":"https://www.ghacks.net/2018/09/09/mozilla-working-on-google-translate-integration-in-firefox/","title":"Mozilla working on Google Translate integration in Firefox - gHacks"},
-    {"url":"https://blog.mozilla.org/opendesign/evolving-the-firefox-brand/","title":"Evolving the Firefox Brand – Mozilla Open Design"},
-    {"url":"https://www.mozilla.org/firefox/60.0.1/releasenotes/","title":"Firefox 60.0.1 got released - fixes lags/performance issues caused by some addons"},
-    {"url":"https://www.reddit.com/r/BrowserWar/comments/7ob0zo/chrome_is_turning_into_the_new_internet_explorer_6/?utm_source=reddit-android","title":"Chrome is turning into the new Internet Explorer 6"},
-    {"url":"https://imgur.com/a/EIurE","title":"Just wanted to warn Firefox devs and community about this page using Firefox name to spread potential malware"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6pp2gi/new_test_pilot_experiments_coming/","title":"New test pilot experiments coming"},
-    {"url":"http://monica-at-mozilla.blogspot.ca/2015/05/tracking-protection-for-firefox-at-web.html","title":"Firefox Tracking Protection decreases page load time by 44%"},
-    {"url":"https://www.eff.org/deeplinks/2018/12/how-https-everywhere-keeps-protecting-users-increasingly-encrypted-web","title":"How HTTPS Everywhere Keeps Protecting Users On An Increasingly Encrypted Web"},
-    {"url":"https://www.theverge.com/2019/1/7/18172170/htc-vive-mozilla-firefox-reality-virtual-reality-browser-vr-ces-2019","title":"HTC partners with Mozilla to bring Firefox’s virtual reality web browser to the Vive headset"},
-    {"url":"https://old.reddit.com/r/firefox/comments/72xzl9/firefoxs_thanks_message/","title":"Firefox's thanks message"},
-    {"url":"http://www.omgubuntu.co.uk/2017/08/firefox-to-get-new-logo","title":"Firefox 57 is shaping up to be one of the browser’s biggest and most important releases in its history"},
-    {"url":"http://www.businessinsider.de/former-mozilla-ceo-brendan-eich-launches-ad-blocking-web-browser-brave-2016-1?utm_source=twitterfeed&utm_medium=twitter&utm_campaign=Feed%3A+typepad%2Falleyinsider%2Fsilicon_alley_insider+%28Silicon+Alley+Insider%29?r=US&IR=T","title":"The former CEO of Mozilla is launching a web browser that blocks all ads by default"},
-    {"url":"https://twitter.com/gorhill/status/1033706103782170625","title":"Seriously: Do NOT use similar-purposed blocker(s) along with uBlock Origin: this will cripple uBO's ability to defuse anti-blocker mechanisms and its ability to minimize likelihood of site breakage. (\"similar-purposed\" = any other blocker making use of EasyList)"},
-    {"url":"https://www.ghacks.net/2018/07/25/mozilla-plans-to-remove-rss-feed-reader-and-live-bookmarks-support-from-firefox/","title":"Mozilla plans to remove RSS feed reader and Live Bookmarks support from Firefox"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-working-on-protection-against-in-browser-cryptojacking-scripts/","title":"Firefox Working on Protection Against In-Browser Cryptojacking Scripts"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7q8bjl/some_pages_are_icons_some_thumbnails_but_why/","title":"some pages are icons, some thumbnails but why???"},
-    {"url":"http://imgur.com/a/it35o","title":"Firefox.com background image as wallpaper. Versions with and without the fox. [1920x1200]"},
-    {"url":"http://i.imgur.com/y7XGLdB.png","title":"This is the kind of customization I enjoy in Firefox"},
-    {"url":"http://techcrunch.com/2014/12/12/yahoo-starts-prompting-chrome-users-to-upgrade-to-firefox/","title":"Yahoo Starts Prompting Chrome Users To “Upgrade” To Firefox"},
-    {"url":"http://imgur.com/SnmLl","title":"In Firefox 11, you can see 3D View of Web Page Structure. Holy shit."},
-    {"url":"https://old.reddit.com/r/firefox/comments/8x4s6k/ebay_says_latest_version_of_firefox_on_ios_is_an/","title":"eBay says latest version of Firefox on iOS is an out of date browser"},
-    {"url":"https://ma.ttias.be/firefox-nightly-starts-marking-login-forms-in-http-as-insecure/","title":"Firefox Nightly starts marking login-forms in HTTP as insecure"},
-    {"url":"https://www.engadget.com/2017/11/23/firefox-notification-breached-sites/","title":"Firefox will soon flag sites that have been hacked"},
-    {"url":"https://www.ghacks.net/2019/01/12/firefox-69-flash-disabled-by-default/","title":"Firefox 69: Flash disabled by default - gHacks Tech News"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1294490","title":"Firefox now supports WebP image format"},
-    {"url":"https://github.com/containers-everywhere/contain-google","title":"Google Container for Firefox | Put Google Services in a sandbox"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=366559#c147","title":"Firefox developers discuss why they can't use '.bro' file extension for 'brotli' files because of feminism - they'll use '.br' instead"},
-    {"url":"https://en.wikipedia.org/wiki/Usage_share_of_web_browsers#Summary_tables","title":"Firefox's market share continues to decline since it fell below 10% in May of this year. Chrome is leading with 60%."},
-    {"url":"https://blog.mozilla.org/webrtc/firefox-is-now-supported-by-google-hangouts-and-meet/","title":"Firefox is now supported by Google Hangouts and Meet"},
-    {"url":"https://www.ctrl.blog/entry/firefox-reintroduces-opensearch","title":"Firefox to reintroduce OpenSearch discovery and installs in Firefox 61"},
-    {"url":"https://i.imgur.com/Fk0xB1v.jpg","title":"Soon 30K subscribers"},
-    {"url":"https://www.phoronix.com/scan.php?page=news_item&px=Google-Servo-Perf-Comparison","title":"Mozilla's Servo Is Whooping The Other Browsers In Performance"},
-    {"url":"https://www.youtube.com/watch?v=tBhfU0Cr6X0","title":"Remember when Mozilla livestreamed Red Pandas cubs to promote Firefox 4?"},
-    {"url":"https://i.imgur.com/urzqEJg.png","title":"I chose \"happy\", but this did make me feel a bit sad"},
-    {"url":"https://mozilla.invisionapp.com/share/7XG2P3JSY46#/screens/281059637","title":"\"New bookmark\" panel is getting a redesign"},
-    {"url":"https://www.mozilla.org/en-US/firefox/57.0/releasenotes/","title":"Firefox — Notes (57.0)"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/tree-style-tab/","title":"Tree Style Tab - It's finally here!!!"},
-    {"url":"https://twitter.com/EmilyKager/status/1010197494242791424","title":"Firefox Focus with GeckoView can now be tested"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8jm25h/firefox_wallpaper/","title":"Firefox Wallpaper"},
-    {"url":"https://imgur.com/a/IPmtGqL","title":"Google now looks nice and modern on Firefox Nightly"},
-    {"url":"https://www.theverge.com/2017/7/27/16019222/open-source-data-ai-mozilla-common-voice-project","title":"Mozilla is crowdsourcing voice recognition to make AI work for the people"},
-    {"url":"https://testpilot.firefox.com/experiments/firefox-lockbox","title":"Firefox Lockbox for iOS and Notes for Android are out today from your friends at Test Pilot!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/5d5i2x/when_i_start_firefox_i_sometimes_get_this_message/","title":"When I start Firefox, I sometimes get this message. Aww, Microsoft, you so cute<3"},
-    {"url":"http://www.reddit.com/r/youtube/comments/34cyca/firefox_is_now_using_the_html5_player_by_default/","title":"YouTube is now using HTML5 by default for Firefox"},
-    {"url":"https://wiki.mozilla.org/Firefox/Roadmap?duplicate","title":"Firefox 2018 Roadmap"},
-    {"url":"https://i.imgur.com/UZ32KzA.png","title":"My Chrome breakup didn't go so well."},
-    {"url":"https://i.imgur.com/ezlIYIl.png","title":"Guess it's time to upgrade then..."},
-    {"url":"http://www.downthemall.net/the-likely-end-of-downthemall/","title":"DownThemAll! » The likely end of DownThemAll? - August 21, 2015"},
-    {"url":"https://chrome.google.com/webstore/search/stylish?_category=extensions","title":"Stylish appears to have been removed from the Google Chrome store"},
-    {"url":"https://blog.mozilla.org/firefox/retrospective-looking-glass/","title":"Retrospective: Looking Glass"},
-    {"url":"http://arstechnica.com/business/2016/05/firefox-overtakes-microsoft-internet-explorer-edge-browsers-first-time-statcounter/","title":"Firefox tops Microsoft browser market share for first time"},
-    {"url":"http://www.theverge.com/2016/1/27/10840480/flash-dead-in-two-years-webm","title":"Flash is expected to be dead in two years"},
-    {"url":"https://www.zdnet.com/article/mozilla-wipes-23-firefox-add-ons-off-the-map-for-tracking-user-activity/","title":"Mozilla wipes 23 Firefox add-ons off the map for tracking user activity"},
-    {"url":"https://blog.mozilla.org/blog/2018/07/18/mozilla-responds-to-european-commissions-google-android-decision/","title":"Mozilla Responds to European Commission’s Google Android Decision – The Mozilla Blog"},
-    {"url":"https://twitter.com/firefox/status/451797073936269312","title":"Brendan Eich has stepped down as Mozilla's CEO"},
-    {"url":"https://selfie.votefornetneutrality.com/","title":"Big Cable’s lobbyists are telling Congress that no one cares about net neutrality."},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1427928#c45","title":"Several new WebExtensions APIs confirmed, including support for session management, userScripts, topSites, declarativeContent, bookmarks, clipboard, visual overlays"},
-    {"url":"http://gs.statcounter.com/browser-market-share/desktop/worldwide/#monthly-201612-201712","title":"Firefox continues to lose market share after Quantum release (Dec 2018)"},
-    {"url":"https://www.eff.org/files/https-everywhere-test/index.html","title":"HTTPS Everywhere WebExtension Updated"},
-    {"url":"https://www.bleepingcomputer.com/news/security/firefox-65-to-show-certificates-used-in-man-in-the-middle-ssl-attacks/","title":"Firefox 65 to Show Certificates Used in Man-in-the-Middle SSL Attacks"},
-    {"url":"https://techcrunch.com/2018/10/12/fcc-resorts-to-the-usual-malarkey-defending-itself-against-mozilla-lawsuit/","title":"FCC resorts to the usual malarkey defending itself against Mozilla lawsuit"},
-    {"url":"https://blog.mozilla.org/addons/2017/11/20/extensions-in-firefox-58/","title":"Extensions in Firefox 58"},
-    {"url":"https://youtu.be/YIywpvHewc0","title":"Firefox Quantum (Beta) vs Chrome"},
-    {"url":"http://imgur.com/D3feLeK","title":"Fuck this"},
-    {"url":"https://old.reddit.com/r/firefox/comments/adbzp9/why_is_my_duckduckgo_icon_on_the_new_tab_page_low/","title":"Why is my DuckDuckGo icon on the New Tab page low res?"},
-    {"url":"https://www.bleepingcomputer.com/news/security/firefox-master-password-system-has-been-poorly-secured-for-the-past-9-years/","title":"Firefox Master Password System Has Been Poorly Secured for the Past 9 Years"},
-    {"url":"http://tonsky.me/blog/chrome-intervention/","title":"Chrome breaks the Web"},
-    {"url":"https://twitter.com/Sesivany/status/908628645299748865","title":"Firefox with client side decorations on Linux coming soon"},
-    {"url":"https://www.bleepingcomputer.com/news/google/google-chrome-adding-support-for-signed-http-exchanges/","title":"Google Chrome Adding Support for Signed HTTP Exchanges (but Mozilla Firefox considers it harmful)"},
-    {"url":"https://old.reddit.com/r/firefox/comments/717h0j/i_love_firefox_easter_eggs_aboutrobots/","title":"I love Firefox Easter Eggs! (about:robots)"},
-    {"url":"http://www.pcworld.com/article/3138031/browsers/another-40-million-people-bolt-from-microsofts-browsers-as-mass-exodus-continues.html","title":"Good to see Firefox gaining back lost market share."},
-    {"url":"https://old.reddit.com/r/firefox/comments/7f8hbw/webrender_is_amazing/","title":"Webrender is amazing"},
-    {"url":"https://news.ycombinator.com/item?id=15696184","title":"Why the move to WebExtensions was so important for Firefox development"},
-    {"url":"https://searchsecurity.techtarget.com/news/252454489/Mozilla-distrusts-all-Symantec-certificates-with-Firefox-64-release","title":"Mozilla distrusts all Symantec certificates with Firefox 64 release"},
-    {"url":"https://hacks.mozilla.org/2018/01/making-webassembly-even-faster-firefoxs-new-streaming-and-tiering-compiler/","title":"Making WebAssembly even faster: Firefox’s new streaming and tiering compiler"},
-    {"url":"https://i.imgur.com/PogWRzD.gif","title":"So they introduced this new drop down menu so that you have to click one more time to see who verified the SSL connection"},
-    {"url":"https://www.zdnet.com/article/half-of-the-tor-projects-funding-now-comes-from-the-private-sector/","title":"Half of the Tor Project's funding now comes from the private sector | ZDNet"},
-    {"url":"https://www.ctrl.blog/entry/lastpass-deprecates-firefox-android","title":"LastPass quietly deprecates their Firefox for Android extension"},
-    {"url":"https://arstechnica.com/security/2017/03/firefox-gets-complaint-for-labeling-unencrypted-login-page-insecure/","title":"Firefox gets complaint for labeling unencrypted login page insecure"},
-    {"url":"http://arewetenyet.com/","title":"Happy Birthday, Firefox"},
-    {"url":"https://old.reddit.com/r/firefox/comments/akitmg/brave_gone_too_far/","title":"Brave gone too far?"},
-    {"url":"https://blog.mozilla.org/blog/2018/08/20/mozilla-files-arguments-against-the-fcc-latest-step-in-fight-to-save-net-neutrality/","title":"Mozilla files arguments against the FCC – latest step in fight to save net neutrality – The Mozilla Blog"},
-    {"url":"https://imgur.com/QEfxExh","title":"Left phone in pocket at work (locked and screen off) and Firefox pretty much destroyed my battery. Anyway to disable Firefox processes when phone locked?"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7stcul/nightly_has_a_veryinteresting_bug_this_time_around/","title":"Nightly has a very...interesting bug this time around."},
-    {"url":"https://redditenhancementsuite.com/releases/5.8.0/","title":"Reddit Enhancement Suite for Firefox is now a WebExtension."},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-will-add-a-settings-section-that-lets-you-control-performance-/","title":"Firefox Will Add a \"Performance\" Settings Section And Will Let You Control Number Of Processes and Memory"},
-    {"url":"https://www.mozilla.org/en-US/firefox/40.0/releasenotes/","title":"Firefox 40 now available"},
-    {"url":"https://www.mozilla.org/en-US/firefox/android/64.0.1/releasenotes/","title":"Firefox for Android 64.0.1, See All New Features, Updates and Fixes"},
-    {"url":"https://www.ghacks.net/2018/12/12/buster-promises-to-solve-captchas-automatically/","title":"Buster promises to solve captchas automatically"},
-    {"url":"http://thenextweb.com/apps/2012/12/01/ie10-grabs-0-51-market-share-firefox-passes-20-again-chrome-loses-users-third-month-in-a-row/","title":"Firefox Above 20% Again, Chrome Loses More Users"},
-    {"url":"https://medium.com/drill/the-internet-changes-http-3-will-not-use-tcp-anymore-427e82eeadc0","title":"The Internet changes: HTTP/3 will not use TCP anymore"},
-    {"url":"https://www.mozilla.org/en-US/firefox/62.0.2/releasenotes/","title":"Firefox 62.0.2 Release Notes"},
-    {"url":"https://i.imgur.com/dud9aNf.jpg","title":"Firefox in the wild."},
-    {"url":"https://superuser.com/questions/1250944/how-can-this-website-reidentify-me-even-after-deleting-all-of-my-browsers-histo","title":"Firefox not deleting IndexedDB storage, allowing websites to set persistent cookies"},
-    {"url":"https://blog.mozilla.org/blog/2013/06/11/stopwatching-us-mozilla-launches-massive-campaign-on-digital-surveillance/","title":"StopWatching.Us: Mozilla launches massive campaign on digital surveillance"},
-    {"url":"https://i.imgur.com/2fXtbvF.jpg","title":"We did boys, Firefox Android finally shows Google's \"new\" card view"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9d3tde/what_a_nice_design_good_job_guys/","title":"What a nice design! Good job guys!"},
-    {"url":"https://groups.google.com/forum/#!topic/mozilla.dev.platform/hlCGG_Hib1w","title":"Mozilla plans to migrate users to 64 bit builds on Win64 in Firefox 56"},
-    {"url":"http://www.ghacks.net/2015/09/15/mozilla-plans-to-reduce-power-consumption-of-firefox/","title":"Mozilla plans to reduce power consumption of Firefox"},
-    {"url":"https://github.com/gorhill/uBlock/releases/tag/0.9.1.0","title":"uBlock 0.9.1.0 was just released and it now officially includes Firefox Mobile support."},
-    {"url":"https://github.com/hackademix/noscript","title":"NoScript is on GitHub now."},
-    {"url":"https://old.reddit.com/r/firefox/comments/5v3g8b/why_does_my_about_firefox_mention_facebook/","title":"Why does my \"About Firefox\" mention Facebook?"},
-    {"url":"http://gizmodo.com/fuck-it-im-going-back-to-firefox-1685425815","title":"Fuck It, I'm Going Back to Firefox"},
-    {"url":"http://i.imgur.com/kfdys.png","title":"Nice Try Fake Firefox Update"},
-    {"url":"https://www.ghacks.net/2018/01/07/firefox-59-ui-options-to-block-notifications-microphone-camera-and-location/","title":"Firefox 59: UI options to block notifications, microphone, camera and location - gHacks Tech News"},
-    {"url":"https://www.flickr.com/photos/42178139@N06/24825255690/in/photostream/lightbox/","title":"Saw this last night in Chinatown (Photo)"},
-    {"url":"https://hacks.mozilla.org/2018/12/firefox-64-released/","title":"New interface, CSS, add-ons, and privacy features in Firefox 64 – Mozilla Hacks - the Web developer blog"},
-    {"url":"https://hacks.mozilla.org/2018/05/new-in-firefox-61-developer-edition/","title":"New in Firefox 61: Developer Edition"},
-    {"url":"https://www.wired.com/story/ghostery-open-source-new-business-model/","title":"Ad-Blocker Ghostery Just Went Open Source—And Has a New Business Model"},
-    {"url":"https://hackernoon.com/firefox-ffe71d0e16c3","title":"Is Firefox Quantum Worth it?"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7j3xyp/ok_now_this_is_just_straight_ads/","title":"OK now this is just straight ads"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6r5l3z/firefox_doesnt_support_send_please_try_firefox/","title":"Firefox doesn't support Send, please try Firefox"},
-    {"url":"http://i.imgur.com/CJ7Ugl6.png","title":"Firefox is now even with Chrome on Google's own benchmark"},
-    {"url":"https://www.eff.org/deeplinks/2018/10/eu-internet-censorship-will-censor-whole-worlds-internet","title":"EU Internet Censorship Will Censor the Whole World's Internet"},
-    {"url":"https://pspdfkit.com/blog/2018/a-real-world-webassembly-benchmark/","title":"Firefox won a \"Real-World WebAssembly Benchmark\""},
-    {"url":"https://old.reddit.com/r/firefox/comments/6uuvh7/whats_up_with_doge_meme_in_nightly_logo/","title":"What's up with doge meme in nightly logo"},
-    {"url":"https://metafluff.com/2017/07/21/i-am-a-tab-hoarder/","title":"The New Firefox and Ridiculous Numbers of Tabs"},
-    {"url":"https://i.imgur.com/dX1MNSR.png","title":"Mozilla should merge the Preferences and Add-ons pages (concept) [OC]"},
-    {"url":"https://blog.mozilla.org/blog/2018/10/02/new-firefox-focus-comes-with-search-suggestions-revamped-visual-design-and-an-under-the-hood-surprise-for-android-users/","title":"New Firefox Focus comes with search suggestions, revamped visual design and an under-the-hood surprise for Android users – The Mozilla Blog"},
-    {"url":"https://imgur.com/a/5LoAcTh","title":"New autoplay icon in Firefox is misaligned"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8j9uo6/is_this_the_new_design_for_firefox_nightly_on/","title":"is this the new design for FireFox Nightly on Android? looks cool!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7n9z7x/anyone_experienced_something_like_this_ad_is/","title":"Anyone experienced something like this? Ad is unclosable and CPU use jumped to 100% until I force-closed Firefox"},
-    {"url":"https://old.reddit.com/r/firefox/comments/70alt3/new_option_in_firefox_search_settings/","title":"New Option in Firefox Search Settings"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-52-borrows-one-more-privacy-feature-from-the-tor-browser/","title":"Firefox 52 Borrows One More Privacy Feature from the Tor Browser"},
-    {"url":"http://i.imgur.com/MuXDlat.png","title":"Firefox knows you. ( ͡° ͜ʖ ͡°)"},
-    {"url":"https://github.com/spikespaz/Firefox-NativeDark","title":"I made a really nice adaptive theme for Windows 10, that doubles as a dark theme for other systems."},
-    {"url":"https://old.reddit.com/r/firefox/comments/7fvpve/medieval_firefox_hours_of_joanna_the_mad_bruges/","title":"Medieval Firefox ('Hours of Joanna the Mad', Bruges, 1486-1506, via @Zweder_Masters)"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7aygyv/just_noticed_that_it_doesnt_say_firefox_beta/","title":"Just noticed that it doesn't say Firefox Beta anymore in the about dialog, but says Firefox Quantum"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8wu2h8/is_there_any_convenient_way_to_know_what_the_6/","title":"Is there any convenient way to know what the \"6 other domains\" are for this addon's permission request?"},
-    {"url":"https://www.mozilla.org/en-US/firefox/57.0.4/releasenotes/","title":"Firefox — Notes (57.0.4)"},
-    {"url":"http://www.ghacks.net/2015/11/08/mozilla-plans-to-remove-support-for-heavyweight-themes-in-firefox/","title":"Mozilla plans to remove support for heavyweight themes in Firefox"},
-    {"url":"http://i.imgur.com/XO0qTKY.png","title":"Thank you, Firefox. From Haiyan victims."},
-    {"url":"http://i.imgur.com/vh8Q7AI.png","title":"You can now see which tabs are playing audio and mute each one in the most recent Nightly"},
-    {"url":"http://i.imgur.com/2ptEuXf.png","title":"Is Dell allowed to sell Firefox?"},
-    {"url":"https://i.imgur.com/w5vwYp7.png","title":"German free mailer GMX says Firefox 62.0 is outdated and asks the user to install GMX Browser"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7iiycr/looks_like_this_dinosaur_should_have_taken_that/","title":"Looks like this dinosaur should have taken that left turn!"},
-    {"url":"https://blog.mozilla.org/blog/2017/11/20/firefox-private-browsing-vs-chrome-incognito/","title":"Firefox Private Browsing vs. Chrome Incognito: Which is Faster? – The Mozilla Blog"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7dcr92/an_adorable_family_picture_is_hiding_in_quantums/","title":"An adorable family picture is hiding in Quantums preferences :)"},
-    {"url":"https://blog.mozilla.org/blog/2017/10/03/mozilla-awards-half-million-open-source-projects/","title":"Mozilla Awards Over Half a Million to Open Source Projects"},
-    {"url":"http://www.ghacks.net/2016/03/03/beware-firefox-add-on-youtube-unblocker-put-on-blocklist/","title":"Popular add-on YouTube Unblocker blocked by Mozilla as it tampers with Firefox security preferences (using user.js manipulations) and downloads and installs an unrelated add-on from an unofficial website"},
-    {"url":"http://opensource.com/life/15/11/happy-birthday-eleven-mozilla-firefox","title":"Happy birthday Firefox!"},
-    {"url":"http://i.imgur.com/jU13JiX.png","title":"Firefox Developer Edition (Aurora) now supports Youtube videos at 60 fps"},
-    {"url":"https://www.mozilla.org/en-US/firefox/59.0.2/releasenotes/","title":"Firefox v59.0.2 - Release Notes"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1446404","title":"Cave: Mozilla is about to launch a shield study that will send your visited sites to a Cloudflare server"},
-    {"url":"https://imgur.com/ft53FvS","title":"[Idea] Instead of \"Recommended by Pocket\", there could be \"From your Pocket\". This would show links that you have saved to Pocket. I think it would be a nice reminder to not forget about certain things that you have saved."},
-    {"url":"https://www.ghacks.net/2017/04/19/firefox-53-0-release-find-out-what-is-new/","title":"Firefox 53.0 Release: Find out what is new."},
-    {"url":"http://arstechnica.com/security/2015/11/dell-does-superfish-ships-pcs-with-self-signed-root-certificates/","title":"Dell does a Superfish, ships PCs with easily cloneable root certificates. Chrome/IE vulnerable, Firefox unaffected."},
-    {"url":"http://imgur.com/CvTfoVc","title":"Firefox fixes HP 0 day initiative's pwn2own contest's security bug."},
-    {"url":"http://www.ghacks.net/2013/04/02/firefox-20-0-find-out-what-is-new/","title":"Firefox 20.0 comes today, find out what's new right away (very comprehensive)."},
-    {"url":"https://hacks.mozilla.org/2017/11/entering-the-quantum-era-how-firefox-got-fast-again-and-where-its-going-to-get-faster/","title":"Entering the Quantum Era—How Firefox got fast again and where it’s going to get faster"},
-    {"url":"https://imgur.com/a/njUdP","title":"wait I just literally turn on my computer"},
-    {"url":"https://letsencrypt.org/","title":"Let's Encrypt: Fast, Simple, Free SSL/TLS sponsored by Mozilla (and others)"},
-    {"url":"https://hg.mozilla.org/releases/mozilla-release/rev/0746f89a5aee","title":"Mozilla adds DuckDuckGo as a search engine option in Firefox"},
-    {"url":"https://www.reddit.com/r/phishing/comments/9b315f/youtube_video_downloader_firefox_addon_injecting/","title":"[X-Post] \"Youtube Video Downloader\" Firefox add-on injecting malicious JavaScript everywhere"},
-    {"url":"https://winaero.com/blog/firefox-65-memory-column-in-built-in-task-manager/","title":"Firefox 65: Memory column in Built-in Task Manager, and Performance/Memory section in Site Information flyout"},
-    {"url":"https://ha.x0r.be/posts/chrome-is-a-google-service/","title":"Wow, I think a lot of people are going to switch to Firefox because of this"},
-    {"url":"https://arstechnica.com/information-technology/2018/07/stylish-extension-with-2m-downloads-banished-for-tracking-every-site-visit/","title":"“Stylish” extension with 2M downloads banned for tracking every site visit"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7yfydd/i_like_this_feature_reader_mode_firefox_nightly/","title":"I like this feature. Reader mode (Firefox Nightly) shows the amount of time to read the document. Haven't noticed this anywhere else."},
-    {"url":"https://xkcd.com/1770/","title":"relevant XKCD"},
-    {"url":"https://github.com/gorhill/uBlock/commit/6d44605c0c1e04de15bbf7a57fd546b42e8a9daf","title":"uBlock Origin 1.13.9b0 Has been released as a webextension to AMO dev channel!"},
-    {"url":"https://www.mozilla.org/en-US/firefox/46.0/releasenotes/","title":"Firefox 46.0 has been released!"},
-    {"url":"https://lh6.googleusercontent.com/-3INB5vq6XWQ/VdXVK6brWFI/AAAAAAAAHAk/AQDX9t5JeBc/w754-h565-no/firefoxos.PNG","title":"Mozilla just sent me an email about Firefox OS, and this was at the bottom. I think they forgot something..."},
-    {"url":"https://www.bleepingcomputer.com/news/software/mozilla-to-provide-msi-installers-starting-with-firefox-65/","title":"Mozilla to Provide MSI Installers Starting with Firefox 65"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1368744","title":"Latest Nightly (finally) has a way to deny \"Allow notifications\" prompts!"},
-    {"url":"http://www.tomshardware.com/reviews/chrome-27-firefox-21-opera-next,3534-12.html","title":"Firefox beats Chrome in Performance for the first time in a few years."},
-    {"url":"https://betanews.com/2017/09/29/mozilla-firefox-privcy-notice/","title":"Mozilla updates Firefox Privacy Notice with greater detail, transparency and prominence"},
-    {"url":"https://blog.mozilla.org/firefox/introducing-firefox-multi-account-containers/","title":"Announcing The Firefox Multi-Account Containers Extension"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6uiwwn/this_is_why_ill_always_use_firefox/","title":"This is why I'll always use Firefox"},
-    {"url":"https://www.mozilla.org/en-US/firefox/54.0/releasenotes/","title":"Firefox — Notes (54.0)"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8en3og/testing_dead_switch_and_found_this_does_this_cute/","title":"Testing dead switch and found this. Does this cute little guy have a name?"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1356334","title":"Message about a slow script will now tell you which addon is causing it. (Nightly)"},
-    {"url":"https://www.bleepingcomputer.com/news/google/google-bans-adnauseam-from-chrome-the-ad-blocker-that-clicks-on-all-ads/","title":"Google Bans AdNauseam from Chrome Store, the Ad Blocker That Clicks on All Ads"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9v9813/how_to_keep_the_old_icon_on_android_81/","title":"How to keep the old icon on Android 8.1"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9eq0v6/why_is_firefoxs_contextmenu_autocorrect_so/","title":"Why is Firefox’s context-menu autocorrect so inaccurate? Do I need to change something in the settings?"},
-    {"url":"https://www.eff.org/deeplinks/2018/08/giving-privacy-badger-jump-start","title":"Giving Privacy Badger a Jump Start ."},
-    {"url":"https://www.mozilla.org/en-US/firefox/60.0beta/releasenotes/","title":"Firefox 60.0 beta has been released"},
-    {"url":"https://www.ghacks.net/2018/03/12/firefox-59-firefox-screenshots-gets-image-editing-functionality/","title":"Firefox 59: Firefox Screenshots gets image editing functionality"},
-    {"url":"https://www.mozilla.org/en-US/firefox/56.0/releasenotes","title":"Firefox — Notes (56.0)"},
-    {"url":"https://fosspost.org/news/bassel-khartabil-oss-contributor-confirmed-dead-syria","title":"Bassel Khartabil, Firefox Contributor, Confirmed Dead in Syria"},
-    {"url":"http://imgur.com/BQjfd","title":"DAE Hate playing \"Which one of these is going to let me do what I want?\""},
-    {"url":"http://i.imgur.com/ilui2.png","title":"A Parafox."},
-    {"url":"https://old.reddit.com/r/firefox/comments/73eenz/your_addon_tab_groups_has_been_discontinued/","title":"Your add-on Tab Groups has been discontinued! 🙀😾😿"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/imagus/?src=search","title":"Firefox 57+ compatible version of Imagus is out"},
-    {"url":"https://i.imgur.com/YhJ8fE8.png","title":"Nightly is now tagging non-WebExtensions as \"LEGACY\""},
-    {"url":"https://blog.mozilla.org/blog/2015/04/09/firefox-for-android-crosses-100-million-downloads/","title":"Firefox for Android Crosses 100 Million Downloads"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/","title":"Greasemonkey webextension released"},
-    {"url":"https://www.netmarketshare.com/browser-market-share.aspx?qprid=1&qpcustomb=0&qpsp=198&qpnp=25&qptimeframe=M","title":"NetMarketShare shows Firefox at the highest percentage in the last two years - 12.32%"},
-    {"url":"https://www.nytimes.com/2017/01/31/technology/ad-blocking-internet.html?mabReward=A3&recp=0&action=click&pgtype=Homepage&region=CColumn&module=Recommendation&src=rechp&WT.nav=RecEngine&_r=0","title":"Use of Ad-Blocking Software Rises by 30% Worldwide"},
-    {"url":"http://techblog.netflix.com/2015/12/html5-video-is-now-supported-in-firefox.html","title":"The Netflix Tech Blog: HTML5 Video is now supported in Firefox"},
-    {"url":"https://www.ghacks.net/2018/12/11/firefox-64-0-release-information/","title":"Firefox 64.0 Release Information - gHacks Tech News"},
-    {"url":"https://www.mozilla.org/firefox/57.0.2/releasenotes/","title":"Firefox — Notes (57.0.2)"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/blocked/i1523","title":"The Web of Trust (WOT) Add-on has been blocked due to security and privacy issues"},
-    {"url":"https://blog.mozilla.org/addons/2015/08/21/the-future-of-developing-firefox-add-ons/","title":"The Future of Developing Firefox Add-ons"},
-    {"url":"http://arstechnica.com/information-technology/2015/07/windows-10-upgrade-resets-your-default-browser-to-edge-mozilla-is-very-unhappy/","title":"Windows 10 upgrade resets your default browser to Edge; Mozilla is very unhappy | Ars Technica"},
-    {"url":"https://www.ghacks.net/2019/01/30/skypes-for-web-does-not-support-firefox/","title":"Skype's for Web does not support Firefox - gHacks Tech News"},
-    {"url":"https://hacks.mozilla.org/2018/10/calls-between-javascript-and-webassembly-are-finally-fast-%F0%9F%8E%89/","title":"Calls between JavaScript and WebAssembly are finally fast 🎉 – Mozilla Hacks - the Web developer blog"},
-    {"url":"https://www.zdnet.com/article/firefox-62-appears-as-mozilla-ends-support-for-windows-xp/","title":"Firefox 62 appears as Mozilla ends support for Windows XP | ZDNet"},
-    {"url":"https://www.phoronix.com/scan.php?page=news_item&px=Firefox-59-Wayland-Possibility","title":"Firefox 59 Might Ship With Working Wayland Support"},
-    {"url":"http://imgur.com/a/PFGSa","title":"Google Taking Steps to Counter Firefox's Change of Default Search Engines"},
-    {"url":"https://hacks.mozilla.org/2018/10/introducing-opus-1-3/","title":"Introducing Opus 1.3 – Mozilla Hacks - the Web developer blog"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9ewvb7/firefox_logo_concept_by_mark_forge/","title":"Firefox logo concept by Mark Forge"},
-    {"url":"https://www.reddit.com/r/privacy/comments/8t2x93/the_internet_is_angry_protest_for_net_neutrality/","title":"The Internet is Angry: Protest for Net Neutrality on June 26th • r/privacy"},
-    {"url":"https://old.reddit.com/r/firefox/comments/63lgn5/thank_you_firefox_for_proper_tabs_on_the_ipad/","title":"Thank You Firefox for Proper Tabs on the iPad!"},
-    {"url":"https://boingboing.net/2017/01/30/google-quietly-makes-optiona.html","title":"Google quietly makes \"optional\" web DRM mandatory in Chrome (x-post /r/Chrome)"},
-    {"url":"https://vimeo.com/167239422","title":"Firefox is finally getting dimmed find!"},
-    {"url":"https://blog.mozilla.org/blog/2016/05/10/you-can-help-build-the-future-of-firefox-with-the-new-test-pilot-program/","title":"You Can Help Build the Future of Firefox with the New Test Pilot Program"},
-    {"url":"http://imgur.com/HIEdj","title":"So... this has been possible for four years and nobody told me?"},
-    {"url":"https://www.mozilla.org/firefox/61.0.1/releasenotes/","title":"Firefox 61.0.1 got released (desktop only) - fixes some page loading issues, blank new tab page & more..."},
-    {"url":"https://vote.webbyawards.com/PublicVoting#/2018/podcasts-digital-audio/features/best-branded-podcast-or-segment","title":"Mozilla's podcast is nominated for a Webby Award!"},
-    {"url":"https://www.yubico.com/2017/09/firefox-nightly-enables-support-fido-u2f-security-keys/","title":"Firefox Nightly enables support for FIDO U2F Security Keys"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6bojw2/bet_you_didnt_know_there_was_a_third_option_on/","title":"Bet you didn't know there was a third option on the feedback page all along :p"},
-    {"url":"http://www.ghacks.net/2015/06/07/mozilla-needs-to-make-up-its-mind/","title":"Mozilla needs to make up its mind"},
-    {"url":"https://www.downthemall.net/delays/","title":"DownThemAll WebExtension is delayed"},
-    {"url":"https://blog.mozilla.org/addons/2016/08/02/multi-process-firefox-and-add-ons-a-call-to-action/","title":"Multi-process Firefox and Add-ons: A Call to Action"},
-    {"url":"https://blog.mozilla.org/data/2018/01/26/improving-privacy-without-breaking-the-web/","title":"Improving privacy without breaking the web"},
-    {"url":"https://old.reddit.com/r/firefox/comments/75docu/wow_just_found_abouthealthreport_interesting_stuff/","title":"Wow, just found about:healthreport. Interesting stuff!"},
-    {"url":"http://www.ghacks.net/2016/10/29/firefox-50-delayed/","title":"Firefox 50 delayed by a week; will ship with noticeable start-up improvements, especially for users with several add-ons"},
-    {"url":"http://i.imgur.com/sNxqkca.png","title":"Another release another icon I can remove from the toolbar"},
-    {"url":"https://www.mozilla.org/en-US/firefox/beta/all/","title":"64-bit now available for Firefox Beta"},
-    {"url":"http://i.imgur.com/q4XoC9Y.jpg","title":"Thank you Firefox for being pretty much the only browser that can render fonts properly on Windows"},
-    {"url":"http://imgur.com/MrypD36","title":"The new MEGA says Firefox isn't good enough?"},
-    {"url":"https://www.ghacks.net/2018/09/12/microsoft-intercepting-firefox-chrome-installation-on-windows-10/","title":"Microsoft intercepting Firefox and Chrome installation on Windows 10 - gHacks"},
-    {"url":"https://github.com/mozilla/infernyx","title":"The Tiles on Mozilla Firefox's \"New Tab\" page record the time, IP Address, and useragent of anyone that clicks on them to the Infernyx server. LPT: Just because something is opensource does not mean it is privacy friendly."},
-    {"url":"https://arstechnica.com/gadgets/2018/04/google-chromes-major-redesign-shows-a-lighter-rounder-ui/","title":"Chrome is becoming a Firefox clone (/s)"},
-    {"url":"https://youtu.be/cEzrFYG0114","title":"Switch from Chrome to Firefox in less than 30 seconds"},
-    {"url":"http://www.ghacks.net/2016/01/16/firefox-to-convert-old-youtube-flash-code-to-html5-video/","title":"Firefox to convert old YouTube Flash code to HTML5 Video"},
-    {"url":"http://www.ghacks.net/2015/06/28/mozilla-removes-option-to-change-new-tab-page-from-firefox/","title":"Mozilla removes option to change New Tab Page from Firefox"},
-    {"url":"https://www.omgubuntu.co.uk/2018/08/out-of-process-extensions-firefox-linux","title":"Firefox is (Finally) Bringing Out-of-Process Extensions to Linux"},
-    {"url":"https://hacks.mozilla.org/2018/02/how-to-build-your-own-private-smart-home-with-a-raspberry-pi-and-mozillas-things-gateway/","title":"How to build your own private smart home with a Raspberry Pi and Mozilla’s Things Gateway"},
-    {"url":"https://hackademix.net/2017/11/14/double-noscript/","title":"Double NoScript"},
-    {"url":"http://www.ghacks.net/2016/12/02/mozilla-is-doing-well-financially/","title":"Mozilla is doing well financially (2015)"},
-    {"url":"http://www.techrepublic.com/article/firefox-gains-serious-speed-and-reliability-and-loses-some-bloat/","title":"Firefox gains serious speed and reliability and loses some bloat - TechRepublic"},
-    {"url":"http://www.ghacks.net/2015/07/30/mozilla-to-launch-64-bit-firefox-41-to-stable-channel/","title":"Mozilla to release 64 -bit Firefox to stable channel in version 41"},
-    {"url":"https://old.reddit.com/r/firefox/comments/a24td2/why_firefox_63_is_doing_this_on_linux/","title":"Why Firefox 63 is doing this on Linux?"},
-    {"url":"https://discourse.mozilla-community.org/t/massive-review-spam-from-anonymous-users/14499/2?u=particle","title":"AMO (Mozilla add-on store) is now allowing any star reviews with no feedback from mobile users with no account needed. Add-ons are now receiving a mass of review spam with no valuable feedback for developers and interested users."},
-    {"url":"https://old.reddit.com/r/firefox/comments/5pk7m2/the_real_firefox/","title":"The real Firefox"},
-    {"url":"https://old.reddit.com/r/firefox/comments/72jvm3/i_just_noticed_how_well_firefox_is_with_gtk/","title":"I just noticed how well Firefox is with GTK+ themes now."},
-    {"url":"https://blog.mozilla.org/blog/2019/01/15/evolving-firefoxs-culture-of-experimentation-a-thank-you-from-the-test-pilot-program/","title":"Evolving Firefox’s Culture of Experimentation: A Thank You from the Test Pilot Program – The Mozilla Blog"},
-    {"url":"https://old.reddit.com/r/firefox/comments/afkqzx/why_does_firefox_not_load_pages_as_in_app_browser/","title":"why does Firefox not load pages as in app browser?"},
-    {"url":"https://blog.torproject.org/new-alpha-release-tor-browser-android","title":"First official release of the Tor Browser for Android"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8y6o6z/on_this_day_two_years_ago_i_brought_this_cat_home/","title":"On this day two years ago I brought this cat home. Now I realize it looks like Firefox logo! Should have named him Firecat"},
-    {"url":"https://www.bleepingcomputer.com/news/security/mozilla-fixes-severe-flaw-in-firefox-ui-that-leads-to-remote-code-execution/","title":"Mozilla Fixes Severe Flaw in Firefox UI That Leads to Remote Code Execution"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-to-get-a-better-password-manager/","title":"Firefox to Get a Better Password Manager"},
-    {"url":"https://old.reddit.com/r/firefox/comments/591o0b/spaceballs_reference_in_the_firefox_video_controls/","title":"Spaceballs reference in the Firefox video controls. 😂"},
-    {"url":"http://www.ghacks.net/2014/07/12/mozilla-plans-release-electrolysis-multi-process-architecture-firefox-36/","title":"Mozilla plans to release Electrolysis (multi-process architecture) with Firefox 36"},
-    {"url":"http://i.imgur.com/xa0RgZD.png","title":"Dear Mozilla, I would like to have this in Firefox."},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/buster-captcha-solver/","title":"Buster – New CAPTCHA solver extension for humans and monsters 🦊"},
-    {"url":"https://www.zdnet.com/article/google-is-raiding-firefox-for-chromes-next-ui-features/","title":"Google is raiding Firefox for Chrome's next UI features | ZDNet"},
-    {"url":"https://blog.mozilla.org/firefox/email-tabs/","title":"Sharing links via email just got easier thanks to Email Tabs – The Firefox Frontier"},
-    {"url":"https://i.imgur.com/52ayLDR.png","title":"Since when did Windows 10 ask feedback for Firefox ?"},
-    {"url":"https://www.heise.de/newsticker/meldung/Kommentar-RSS-ist-tot-und-das-ist-eine-Schande-4127128.html","title":"RSS is dead and that's a shame"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6vyhx8/the_burst_has_finally_landed/","title":"The Burst has finally landed..."},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/tab-groups-panorama/","title":"Tab Groups Alternative released!"},
-    {"url":"http://i.imgur.com/cI4dw.jpg","title":"That's why, Firefox is so RAM fat, Developers spoiled so much!"},
-    {"url":"https://hensm.github.io/fx_cast/","title":"Chromecast Support for Firefox"},
-    {"url":"https://www.mozilla.org/en-US/firefox/fights-for-you/","title":"Firefox Fights For You. We keep your data safe, never sold."},
-    {"url":"https://www.gijsk.com/blog/2018/10/firefox-removes-core-product-support-for-rss-atom-feeds/","title":"Firefox removes core product support for RSS/Atom feeds"},
-    {"url":"https://www.ghacks.net/2018/04/22/firefox-notes-get-a-big-update-with-multi-note-support/","title":"Firefox Notes get a big update with multi-note support"},
-    {"url":"https://twitter.com/ehsanakhgari/status/972224912634064896","title":"Are you tired of seeing in-page popups?"},
-    {"url":"https://i.imgur.com/S563F7W.gifv","title":"This is fine."},
-    {"url":"http://www.omgubuntu.co.uk/2017/08/firefox-client-side-decoration-coming-soon","title":"Firefox using Client Side Decoration on Linux"},
-    {"url":"https://www.ghacks.net/2018/11/04/browser-history-sniffing-is-still-a-thing/","title":"Browser history sniffing is still a thing"},
-    {"url":"https://nakedsecurity.sophos.com/2018/11/02/popular-browsers-made-to-cough-up-browsing-history/","title":"Popular browsers made to cough up browsing history"},
-    {"url":"https://old.reddit.com/r/firefox/comments/76sojy/dear_mozilla_dont_let_it_die/","title":"Dear Mozilla, Don't Let It Die!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6rswb8/even_though_i_disabled_sending_anonymous_data_in/","title":"Even though I disabled sending anonymous data in KeeFox (KeePass Firefox extension) it is still doing a lot of requests in the background to the anonymousstats.keefox.org. And under two hours it made more than 300 queries. Is there anything wrong with such behaviour?"},
-    {"url":"https://old.reddit.com/r/firefox/comments/5cs8mv/help_sorry_but_is_it_possible_to_get_this_as_a/","title":"\"Help\" Sorry, but is it possible to get this as a standalone image for wallpaper?"},
-    {"url":"http://i.imgur.com/AIxYzl9.png","title":"Life of a Firefox user (from @wycats)"},
-    {"url":"https://medium.com/firefox-ux/written-by-amy-lee-eric-pang-79c2474d10b4","title":"Firefox has a motion team?! Yes we do!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6zjf5s/uh/","title":"Uh..."},
-    {"url":"https://github.com/gorhill/uMatrix/releases/tag/1.0.1b4","title":"uMatrix is now available as a pure Webextension!"},
-    {"url":"https://www.cnet.com/special-reports/mozilla-firefox-fights-back-against-google-chrome/","title":"Firefox fights back"},
-    {"url":"http://www.netmarketshare.com/?201504","title":"Mozilla Firefox market share grows for the first time since August"},
-    {"url":"http://www.ghacks.net/2014/10/03/yes-64-bit-firefox-for-windows-on-its-way/","title":"Yes! 64-bit Firefox for Windows on its way"},
-    {"url":"http://www.theverge.com/2013/3/9/4084710/mozilla-wont-bring-firefox-to-ios-until-apple-relaxes-third-party-stance","title":"Mozilla won't bring Firefox to iOS until it can use its own rendering engine"},
-    {"url":"http://i.imgur.com/mdWWR.png","title":"It's really the little things. [Firefox Beta Installation]"},
-    {"url":"https://www.howtogeek.com/fyi/mozilla-says-it-didnt-make-any-money-from-booking.com/","title":"Mozilla Says It Didn’t Make Any Money From Booking.com"},
-    {"url":"https://blog.mozilla.org/futurereleases/2018/10/22/testing-new-ways-to-keep-you-safe-online/","title":"Testing new ways to keep you safe online – Future Releases"},
-    {"url":"https://www.reddit.com/r/assholedesign/comments/7xvdkk/google_removed_the_view_image_button_on_google/","title":"Google removed the view image button from Google Images. Is there some workaround for Firefox?"},
-    {"url":"https://blog.mozilla.org/addons/2018/01/26/extensions-firefox-59/","title":"Extensions in Firefox 59"},
-    {"url":"http://www.downthemall.net/progress/","title":"DownThemAll Lite may be coming to Firefox (& Chrome)"},
-    {"url":"https://old.reddit.com/r/firefox/comments/5kosu1/new_mozilla_firefox_start_page/","title":"New Mozilla Firefox start page"},
-    {"url":"https://blog.mozilla.org/blog/2016/11/17/introducing-firefox-focus-a-free-fast-and-easy-to-use-private-browser-for-ios/","title":"Introducing Firefox Focus – a free, fast and easy to use private browser for iOS"},
-    {"url":"https://github.com/mozilla-mobile/firefox-ios/pull/4044","title":"Dark Theme Coming to Firefox for iOS this week!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7hc470/they_forgot_to_update_the_new_private_window_icon/","title":"they forgot to update the \"New private window\" icon (and the Open new tab & Open new window probably should get updated too)"},
-    {"url":"https://medium.com/firefox-ux/whats-new-in-firefox-preferences-54391f92971a","title":"What’s new in Firefox Preferences"},
-    {"url":"https://www.theinquirer.net/inquirer/news/3012791/protonmail-welcomes-eus-google-fine-says-search-giants-practices-almost-put-it-out-of-business","title":"ProtonMail lauds Google's EU fine after falling victim to firm's shady search practices - Firm says decision means no other firm will have to relive its 'nightmare scenario' - \"For nearly a year, Google was hiding ProtonMail from search results for queries such as secure email and 'encrypted email'\""},
-    {"url":"http://nakedsecurity.sophos.com/2013/09/23/firefox-burns-chrome-in-our-trustworthy-browser-poll/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+nakedsecurity+%28Naked+Security+-+Sophos%29","title":"Firefox burns Chrome in our trustworthy browser poll | Naked Security"},
-    {"url":"https://www.youtube.com/watch?v=ht5GqZ_ukIg","title":"Firefox 63.0b4 chew up >20% of a 3.2GHz CPU when I move the mouse or hover over top sites thumbnails. Does it log my mouse movements or what?"},
-    {"url":"https://blog.mozilla.org/blog/2017/12/20/firefox-is-now-on-amazon-fire-tv-happy-holiday-watching/","title":"Firefox is Now on Amazon Fire TV"},
-    {"url":"https://hacks.mozilla.org/2017/12/using-the-new-theming-api-in-firefox/","title":"Using the new theming API in Firefox"},
-    {"url":"http://robert.ocallahan.org/2017/12/maintaining-independent-browser-is.html","title":"Maintaining An Independent Browser Is Incredibly Expensive"},
-    {"url":"http://www.reuters.com/article/us-usa-internet/fcc-plans-to-vote-to-overturn-u-s-net-neutrality-rules-in-december-sources-idUSKBN1DG00H?utm_campaign=trueAnthem:+Trending+Content&utm_content=5a0d063e04d30148b0cd52dc&utm_medium=trueAnthem&utm_source=twitter","title":"FCC plans to vote to overturn U.S. net neutrality rules in December: sources"},
-    {"url":"https://github.com/Synzvato/decentraleyes/releases/tag/v2.0.0beta2","title":"Decentraleyes webextension now available for Firefox 56 onwards"},
-    {"url":"https://imgur.com/5gbxHE4","title":"Firefox Focus app icon on play store looks pretty cool"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6cgawm/i_love_my_firefox_even_more/","title":"🍪 I love my Firefox even more"},
-    {"url":"https://mspoweruser.com/firefox-52-will-last-version-firefox-windows-xp-vista/","title":"Firefox 52 will be the last version of Firefox for Windows XP and Vista"},
-    {"url":"http://www.ghacks.net/2015/11/30/firefoxs-tracking-protection-feature-gets-a-boost-soon/","title":"Firefox's Tracking Protection feature gets a boost soon"},
-    {"url":"https://blog.mozilla.org/futurereleases/2014/03/14/metro/","title":"Firefox for Metro has been cancelled"},
-    {"url":"http://www.zdnet.com/firefox-os-is-because-we-want-the-web-to-win-not-because-we-want-firefox-os-to-win-7000022628/","title":"'Firefox OS is because we want the web to win, not because we want Firefox OS to win' [x-post from /r/FirefoxOS]"},
-    {"url":"https://www.bleepingcomputer.com/news/software/firefox-gets-privacy-boost-by-disabling-proximity-and-ambient-light-sensor-apis/","title":"Firefox Gets Privacy Boost By Disabling Proximity and Ambient Light Sensor APIs"},
-    {"url":"https://techcrunch.com/2018/02/26/kaios/","title":"KaiOS, a feature phone platform built on the ashes of Firefox OS, adds Facebook, Twitter and Google apps"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7dri3o/so_we_meet_again_you_were_doing_so_well/","title":"So we meet again. You were doing so well."},
-    {"url":"https://old.reddit.com/r/firefox/comments/7dfm97/todays_nightly_for_linux_now_has_client_side/","title":"Today's Nightly for Linux now has Client Side Decorations!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/755unb/exciting_times_ahead/","title":"Exciting Times Ahead."},
-    {"url":"https://d3vv6lp55qjaqc.cloudfront.net/items/2a1J2x1x201d1K2f2C1d/firefox-nightly-wallpaper-1920x1080.png","title":"Nightly Wallpaper"},
-    {"url":"http://www.ghacks.net/2017/03/24/here-is-the-first-mockup-screenshot-of-firefox-57s-new-design/","title":"Here is the first mockup screenshot of Firefox 57's new design"},
-    {"url":"http://arstechnica.com/security/2015/04/new-firefox-version-says-might-as-well-to-encrypting-all-web-traffic/","title":"New Firefox version says “might as well” to encrypting all Web traffic"},
-    {"url":"https://blog.mozilla.org/addons/2018/07/05/extensions-in-firefox-62/","title":"Extensions in Firefox 62"},
-    {"url":"https://twitter.com/gorhill/status/934835662985064448","title":"uMatrix is incompatible with NoScript 10: NoScript uses script-src 'none' which unfortunately starves the webRequest API, preventing uMatrix from seeing/reporting all network requests. Any webRequest-using extension may end up crippled like this."},
-    {"url":"https://groups.google.com/forum/#!topic/mozilla.dev.platform/H_Sl_-hCF5w","title":"Stylo is now the default on Nightly!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/5hv4qs/the_advertisements_are_getting_smart_facebook_btw/","title":"The advertisements are getting smart.. (Facebook btw)"},
-    {"url":"https://blog.mozilla.org/blog/2016/09/02/fighting-back-against-secrecy-orders/","title":"Mozilla today is joining a coalition of technology companies, including Apple, Lithium, and Twilio, in filing an amicus brief in support of Microsoft’s case against the indiscriminate use of gag orders."},
-    {"url":"http://www.ghacks.net/2015/06/11/finally-mozilla-adds-working-html5-video-autoplay-blocking-to-firefox/","title":"Mozilla adds working HTML5 Video autoplay blocking to Firefox"},
-    {"url":"https://www.mozilla.org/firefox/33.0/releasenotes/","title":"Firefox — Notes (33.0)"},
-    {"url":"https://blog.mozilla.org/nnethercote/2014/05/14/adblock-pluss-effect-on-firefoxs-memory-usage/","title":"AdBlock Plus’s effect on Firefox’s memory usage"},
-    {"url":"https://www.mozilla.org/en-US/firefox/61.0.2/releasenotes/","title":"Firefox 61.0.2 got released (desktop and android) with some minor bug fixes"},
-    {"url":"https://www.ghacks.net/2018/05/07/privacy-possum-is-privacy-badger-on-steroids/","title":"Privacy Possum is Privacy Badger on Steroids"},
-    {"url":"https://blog.mozilla.org/blog/2017/12/12/early-returns-on-firefox-quantum-point-to-growth/","title":"Early Returns on Firefox Quantum Point to Growth – The Mozilla Blog"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7d5mb9/chrome_vs_firefox_with_the_same_tabs_open_and/","title":"Chrome VS Firefox with the same tabs open and chrome having more plugins enabled. Why is Firefox using abysmally more memory?"},
-    {"url":"https://blog.mozilla.org/blog/2017/09/11/copyright-vote-change-europes-internet/","title":"A Copyright Vote That Could Change the EU’s Internet – The Mozilla Blog"},
-    {"url":"https://noscript.net/?ver=2.9.5.1&prev=2.9.0.14","title":"NoScript's latest update - Full multi-process (e10s) compatibility."},
-    {"url":"http://i.imgur.com/7evJkum.jpg","title":"Addons.Mozilla.Org (AMO) New Look."},
-    {"url":"http://i.imgur.com/izohFxb.jpg","title":"The generic homepage gave me a good heartwarming vibe today in light of recent events. Thank you, Mozilla."},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1172126","title":"Bug: Remove Pocket integration"},
-    {"url":"http://i.imgur.com/tptAR5e.jpg","title":"Firefox doughnuts!"},
-    {"url":"http://i.imgur.com/gBZ03Cd.jpg","title":"CNN behind on their Firefox updates... [x-post from r/techsupportgore]"},
-    {"url":"http://www.mozilla.com/","title":"Firefox 8 is officially released."},
-    {"url":"https://www.mozilla.org/en-US/firefox/63.0a1/releasenotes/#note-787678","title":"The build infrastructure of Firefox on Windows moved to the Clang tool chain, bringing important performance gains"},
-    {"url":"http://news.softpedia.com/news/mozilla-firefox-51-0-promises-webgl-2-support-less-cpu-usage-and-flac-playback-510274.shtml","title":"Mozilla Firefox 51.0 Promises WebGL 2 Support, Less CPU Usage, and FLAC Playback"},
-    {"url":"https://advocacy.mozilla.org/encrypt/2/?ref=2016_Encryption&utm_campaign=2016_Encryption&utm_source=newsletter-mofo&utm_medium=email&utm_content=SSBtext1","title":"Mozilla has started a series of videos \"designed to help demystify privacy online\", this is the first of them."},
-    {"url":"https://blog.cloudflare.com/announcing-1111/","title":"CloudFare announced a privacy-centric DNS service that's now live. I wonder when Firefox will support DNS over HTTPS..."},
-    {"url":"https://medium.com/firefox-test-pilot/fun-with-themes-in-firefox-54a3180f16e4","title":"Fun with Themes in Firefox – Firefox Test Pilot"},
-    {"url":"https://s18.postimg.org/sgzvqys1l/firefoxhobbes.png","title":"For anyone who wants it, this is a high-resolution version of the Hobbes Nightly icon, extracted directly from the Mac app file."},
-    {"url":"https://framapic.org/xI3MldSvwNwF/yZ7d2HhUqEfH.png","title":"Little fluffy red pandas building the Qunatum, Photon, Electrolysis, WebExtension giant robot Firefox"},
-    {"url":"http://gfycat.com/MadeupHighlevelHoneyeater","title":"Firefox 41 lets you take screenshots of DOM nodes"},
-    {"url":"http://arstechnica.co.uk/information-technology/2015/07/big-changes-are-coming-to-firefox-to-win-back-users-and-developers/","title":"Big changes are coming to Firefox, to win back users and developers"},
-    {"url":"http://imgur.com/a/kmPoz","title":"My new favorite button. Reader view is great."},
-    {"url":"https://i.imgur.com/mv5VsbM.jpg","title":"When I read that Google has proposed changes to Chromium which would disable uBlock Origin"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6wmpd0/new_privacy_related_preference_in_nightly/","title":"New privacy related preference in Nightly"},
-    {"url":"https://www.netmarketshare.com/browser-market-share.aspx?qprid=1&qpcustomb=0&qpsp=192&qpnp=24&qptimeframe=M","title":"Netmarketshare: Firefox market share is at 12.22% (constant growth since August)"},
-    {"url":"https://developer.mozilla.org/Firefox/Multiprocess_Firefox","title":"Multiprocess Firefox"},
-    {"url":"https://www.mozilla.org/en-US/firefox/developer/","title":"Firefox Developer Edition"},
-    {"url":"https://www.mozilla.org/en-US/firefox/65.0/releasenotes/","title":"Firefox 65.0 released"},
-    {"url":"http://www.erahm.org/2017/09/25/firefox-memory-usage-in-the-quantum-era/","title":"Firefox Memory Usage in the Quantum Era"},
-    {"url":"https://blog.mozilla.org/security/2017/09/13/verified-cryptography-firefox-57/","title":"Verified cryptography for Firefox 57"},
-    {"url":"https://www.mozilla.org/en-US/firefox/59.0.1/releasenotes/","title":"Firefox — Notes (59.0.1)"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/panorama-view/","title":"Guess who I bumped into on AMO? Panorama View! v57 compatible! Experimental!"},
-    {"url":"https://www.servethehome.com/firefox-is-eating-your-ssd-here-is-how-to-fix-it/","title":"Firefox is eating your SSD - here is how to fix it"},
-    {"url":"http://imgur.com/331gLvn","title":"Firefox 42 Easter Egg - Hitchhiker's Guide to the Galaxy"},
-    {"url":"https://blog.mozilla.org/blog/2015/07/30/an-open-letter-to-microsofts-ceo-dont-roll-back-the-clock-on-choice-and-control/","title":"An Open Letter to Microsoft’s CEO: Don’t Roll Back the Clock on Choice and Control"},
-    {"url":"https://support.mozilla.org/en-US/kb/whats-new-firefox-focus-android-version-8?as=u&utm_source=inproduct","title":"What's new in Firefox Focus for Android (version 8)"},
-    {"url":"https://www.ghacks.net/2018/10/28/this-is-firefoxs-overhauled-privacy-interface/","title":"This is Firefox's overhauled Privacy interface - gHacks Tech News"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7a0p6x/dont_forget_to_update_the_installer_icon_for_v57/","title":"Don't forget to update the installer icon for v57!!!"},
-    {"url":"https://gfycat.com/ScaryHalfHerald","title":"TIL Holding the back button gives you quick access to history"},
-    {"url":"https://www.mozilla.org/en-US/firefox/42.0/releasenotes/","title":"Firefox — Notes (42.0)"},
-    {"url":"http://i.imgur.com/xSEiIBz.png?1","title":"Add this bookmark to be able to type \"r subreddit\" and redirect to \"http://www.reddit.com/r/subreddit\". Also works with u and /u/."},
-    {"url":"http://lifehacker.com/hola-better-internet-sells-your-bandwidth-turning-its-1707496872","title":"Hola Better Internet Sells Your Bandwidth, Turning Its VPN into a Botnet"},
-    {"url":"https://hacks.mozilla.org/2018/09/focus-with-geckoview/","title":"Focus with GeckoView – Mozilla Hacks - the Web developer blog"},
-    {"url":"https://old.reddit.com/r/firefox/comments/863gv4/just_noticed_you_can_add_menu_shortcuts_directly/","title":"Just noticed, you can add Menu Shortcuts directly to the Title bar."},
-    {"url":"https://www.ghacks.net/2018/01/11/mozilla-starts-to-publish-pocket-code/","title":"Mozilla starts to publish pocket code"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6xtm69/creating_and_editing_userchromecss/","title":"Creating and Editing userChrome.css"},
-    {"url":"https://blog.mozilla.org/firefox/firefox-fights-for-you/","title":"Firefox fights for you – The Firefox Frontier"},
-    {"url":"https://i.imgur.com/XTtc2WE.png","title":"Please correct me since im not an expert but why the hell does Firefox have 5 trackers? And three of them is from Google?!?!?"},
-    {"url":"https://blog.bitwarden.com/bitwarden-desktop-app-released-for-windows-macos-and-linux-37de846ea421","title":"Firefox password manager BitWarden releases a desktop client"},
-    {"url":"https://www.howtogeek.com/334716/how-to-customize-firefoxs-user-interface-with-userchrome.css/","title":"How to Customize Firefox’s User Interface With userChrome.css"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/tag/firefox57","title":"All 2,273 WebExtensions on AMO right now"},
-    {"url":"http://i.imgur.com/ljjlqb4.jpg","title":"Mockup of the changes to Customize mode as part of the upcoming design refresh"},
-    {"url":"https://blog.mozilla.org/tanvi/2016/06/16/contextual-identities-on-the-web/","title":"Contextual Identities on the Web"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1215694","title":"This is actually happening: 1215694 – move pocket to a built-in add-on"},
-    {"url":"http://arstechnica.com/security/2015/10/new-zero-day-exploit-hits-fully-patched-adobe-flash/","title":"New zero-day exploit hits fully patched Adobe Flash"},
-    {"url":"http://i.imgur.com/Zl3bxId.png","title":"TIL (by accident) that if you hit Ctrl Shift E you'll see a grid of all your tabs plus a preview image for each. Very Neat!"},
-    {"url":"http://i.imgur.com/tTeHb.png","title":"New Firefox Start Page as seen in latest Nightly"},
-    {"url":"https://old.reddit.com/r/StallmanWasRight/comments/adve2v/how_do_we_effectively_block_google_amp/","title":"How do we effectively block google amp?"},
-    {"url":"https://blog.mozilla.org/blog/2018/07/10/introducing-firefoxs-first-mobile-test-pilot-experiments-lockbox-and-notes/","title":"Introducing Firefox’s First Mobile Test Pilot Experiments: Lockbox and Notes – The Mozilla Blog"},
-    {"url":"https://i.imgur.com/fllb57h.png","title":"Custom Rainmeter Icon for Nightly"},
-    {"url":"https://old.reddit.com/r/firefox/comments/7flwdf/a_dark_theme_which_suitable_for_both_dark_light/","title":"A dark theme which suitable for both dark & light"},
-    {"url":"http://i.imgur.com/Dnk64v6.png","title":"what a great new feature in the Firefox 42.0"},
-    {"url":"http://www.mozilla.org/en-US/firefox/27.0/releasenotes/","title":"Firefox 27.0 released!"},
-    {"url":"http://blog.mozilla.com/nnethercote/2011/08/09/firefox-7-is-lean-and-fast-2/","title":"Firefox 7 is lean and fast: Firefox 7 uses less memory than Firefox 6 (and 5 and 4): often 20% to 30% less, and sometimes as much as 50% less."},
-    {"url":"https://www.bleepingcomputer.com/news/software/mozilla-is-adding-an-ad-blocker-to-firefox-focus-90/","title":"Mozilla is Adding an Ad Blocker to Firefox Focus 9.0"},
-    {"url":"https://old.reddit.com/r/firefox/comments/a3q2qw/excuse_me_wtf/","title":"Excuse me? WTF!"},
-    {"url":"https://www.mozilla.org/en-US/firefox/64.0beta/releasenotes/","title":"Firefox Beta 64.0 released, WebRender enabled by default for Desktop NVIDIA GPUs on Windows 10"},
-    {"url":"https://screenshots.firefox.com/2pfRaZQoJ8cbnaYi/null","title":"More Dark Theme progress in Nightly"},
-    {"url":"https://www.cnet.com/news/firefox-quantum-leader-mayo-takes-over-all-mozilla-products-in-reorg/","title":"Firefox Quantum leader takes over all Mozilla products - CNET"},
-    {"url":"http://www.ghacks.net/2016/10/31/mozilla-removes-battery-api-in-firefox-52/","title":"Mozilla cuts website access to Battery API in Firefox 52"},
-    {"url":"http://i.imgur.com/irbtDjc.png","title":"Messages like these make me sad :("},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/https-everywhere/?src=search","title":"HTTPS Everywhere is on AMO as signed add-on now!"},
-    {"url":"http://i.imgur.com/la1Ge.jpg","title":"Happy Birthday Firefox"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9l9xe5/i_have_come_a_long_way_with_firefox/","title":"I have come a long way with Firefox."},
-    {"url":"https://imgur.com/iemMWos","title":"Why is this a thing? How do I get around it with Firefox mobile?"},
-    {"url":"https://blog.mozilla.org/blog/2018/07/11/royalty-free-web-video-codecs/","title":"[Blog Mozilla] Modern codecs like AV1 can bring better quality video to the open web"},
-    {"url":"https://twitter.com/FxTestPilot/status/937892770865393665","title":"Teaser screenshot featuring Firefox with native(?) tiling"},
-    {"url":"https://www.howtogeek.com/334111/firefox-quantum-isnt-just-copying-chrome/","title":"Firefox Quantum Isn’t Just “Copying” Chrome: It’s Much More Powerful"},
-    {"url":"https://old.reddit.com/r/firefox/comments/73ak7p/another_reason_to_use_ublock_origin_over_adblock/","title":"Another reason to use uBlock Origin over Adblock Plus."},
-    {"url":"https://blog.mozilla.org/blog/2016/09/28/three-new-test-pilot-experiments/","title":"Firefox’s Test Pilot Program Launches Three New Experimental Features"},
-    {"url":"https://www.raymond.cc/blog/10-ad-blocking-extensions-tested-for-best-performance/view-all/","title":"10 Ad Blocking Extensions Tested for Best Performance"},
-    {"url":"https://wiki.mozilla.org/Addons/Extension_Signing","title":"Firefox 42 will not allow unsigned extensions"},
-    {"url":"http://arstechnica.com/open-source/news/2012/04/mozilla-may-make-flash-click-to-play-by-default-in-future-firefox.ars?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+arstechnica%2Findex+%28Ars+Technica+-+Featured+Content%29","title":"Mozilla may make Flash click-to-play by default in future Firefox"},
-    {"url":"https://www.ghacks.net/2018/07/10/ghostery-rewards-launches-in-germany/","title":"Ghostery now displaying Ads in Germany, marketed as \"Rewards\" program"},
-    {"url":"https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication","title":"Secure your Firefox Account with two-step authentication"},
-    {"url":"https://www.youtube.com/watch?v=RTQybYbR1ek&feature=youtu.be","title":"Does Mozilla Firefox Hold The Answer To Better Internet Security?"},
-    {"url":"https://old.reddit.com/r/firefox/comments/78x8xa/privacy_badger_asking_store_unlimited_amount_of/","title":"Privacy Badger asking \"Store unlimited amount of client-side data\". isn't that little bit too much?"},
-    {"url":"https://i.imgur.com/pr61DCS.png","title":"Another \"new\" Nightly icon"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6t899j/todays_nightly_icon/","title":"Today's Nightly icon"},
-    {"url":"http://www.zdnet.com/article/google-and-mozillas-message-to-av-and-security-firms-stop-trashing-https/","title":"Google and Mozilla's message to AV and security firms: Stop trashing HTTPS. Researchers call out antivirus and security appliance vendors for dangerous SSL inspection practices."},
-    {"url":"https://addons.mozilla.org/firefox/addon/chrome-store-foxified/","title":"Chrome Store Foxified - install Google Chrome Store addons for Firefox"},
-    {"url":"http://www.computerworld.com/s/article/9237847/Ad_industry_threatens_Firefox_users_with_more_ads_if_Mozilla_moves_on_tracking_plans","title":"Ad industry threatens Firefox users with more ads if Mozilla moves on tracking plans"},
-    {"url":"http://i.imgur.com/NoUBs.jpg","title":"The only browser worth trusting with the new installer options(landing soon)"},
-    {"url":"https://support.mozilla.org/en-US/kb/whats-new-firefox-focus-android-version-8","title":"Firefox Focus for Android now has Google Safe Browsing integrated without a way to disable it."},
-    {"url":"https://twitter.com/SenatorMenendez/status/1019991102647136258","title":"An open Internet is the great equalizer that lets the smallest of startups compete with the largest corporations - without having to pay for priority access online."},
-    {"url":"https://www.engadget.com/2018/06/12/firefox-12-ios-file-downloads-easier-syncing/","title":"Firefox 12 for iOS includes file downloads and easier syncing"},
-    {"url":"https://old.reddit.com/r/firefox/comments/78o5xs/mega_cloud_storage_service_firefox_has_an/","title":"Mega (cloud storage service): \"Firefox has an insufficient buffer to decrypt data in the browser\", use Google Chrome instead"},
-    {"url":"http://imgur.com/a/lWYru","title":"Some Firefox Photon mockup Images"},
-    {"url":"https://old.reddit.com/r/firefox/comments/5o5u4k/developer_edition_theme_is_now_called_compact/","title":"Developer Edition Theme is now called Compact Light/Dark in Nightly"},
-    {"url":"https://twitter.com/gorhill/status/694662117895639040","title":"Gorhill: tracking on Dailymotion"},
-    {"url":"https://xkcd.com/619/","title":"I think many will relate... (with or without flash)"},
-    {"url":"http://bitsup.blogspot.com/2015/02/http2-is-live-in-firefox.html","title":"HTTP/2 is live in Firefox"},
-    {"url":"http://www.theregister.co.uk/2015/02/02/google_amazon_taboola_microsoft_adplock_plus_unblock/","title":"Internet giants Google, Amazon, Microsoft and Taboola have reportedly paid AdBlock Plus to allow their ads to pass through its filter software."},
-    {"url":"https://old.reddit.com/r/firefox/comments/aap8wn/fullscreen_in_ff_is_notentirely_opaque_is_this_by/","title":"Fullscreen in FF is not....entirely opaque? Is this by design?"},
-    {"url":"https://www.bleepingcomputer.com/news/security/academics-discover-new-bypasses-for-browser-tracking-protections-and-ad-blockers/","title":"Academics Discover New Bypasses for Browser Tracking Protections and Ad Blockers"},
-    {"url":"https://old.reddit.com/r/BountySource/comments/8gox5c/50000_bounty_posted_by_education_first_for/","title":"$50,000 bounty posted by Education First for Mozilla WebRTC Issue"},
-    {"url":"https://arp242.net/weblog/browsers-conflict-interest.html","title":"Browsers and conflicts of interests"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1278282","title":"Firefox nightly drops GTK2"},
-    {"url":"https://www.howtogeek.com/333047/how-to-migrate-all-your-data-from-chrome-to-firefox/","title":"How to Migrate All Your Data From Chrome to Firefox"},
-    {"url":"https://www.mozilla.org/en-US/security/advisories/mfsa2017-08/","title":"Less than 24 hours after disclosure at pwn2own, security fix released in version 52.0.1"},
-    {"url":"http://www.ghacks.net/2015/06/30/firefox-41-ships-with-massive-memory-improvements-for-adblock-plus/","title":"Firefox 41 ships with massive memory improvements for Adblock Plus"},
-    {"url":"http://i.imgur.com/CBJ1iXP.png","title":"Mozilla, fix the play icon."},
-    {"url":"http://www.ghacks.net/2014/06/10/firefox-30-released-find-new/","title":"Firefox 30 released: Find out what is new"},
-    {"url":"http://www.mozilla.org/en-US/firefox/new/","title":"Firefox 19.0 is live"},
-    {"url":"https://blog.mozilla.org/blog/2018/11/14/firefox-monitor-launches-in-26-languages-and-adds-new-desktop-browser-feature/","title":"Firefox Monitor Launches in 26 Languages and Adds New Desktop Browser Feature – The Mozilla Blog"},
-    {"url":"https://chuttenblog.wordpress.com/2018/06/27/when-exactly-does-a-firefox-user-update-anyway/","title":"When, Exactly, does a Firefox User Update, Anyway?"},
-    {"url":"https://www.mozilla.org/en-US/firefox/54.0.1/releasenotes/","title":"Firefox — Notes (54.0.1)"},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/vivaldifox/","title":"Initial release of VivaldiFox with auto-colouring and custom themes"},
-    {"url":"https://www.mozilla.org/en-US/firefox/37.0/releasenotes/","title":"Firefox — Notes (37.0)"},
-    {"url":"https://www.mozilla.org/en-US/firefox/25.0/releasenotes/","title":"Firefox 25 is now available"},
-    {"url":"http://i.imgur.com/zHkWY.jpg","title":"Lego Firefox Logo"},
-    {"url":"https://old.reddit.com/r/firefox/comments/ahu704/fenix_now_can_load_mozillaorg_website/","title":"Fenix now can load mozilla.org website!"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9zdlq9/seriously_outperformed_v8_spidermonkey_makes_the/","title":"Seriously outperformed V8, SpiderMonkey makes the case for GeckoView"},
-    {"url":"https://blog.mozilla.org/addons/2018/07/12/upcoming-changes-for-themes/","title":"Upcoming changes for themes"},
-    {"url":"https://old.reddit.com/r/firefox/comments/73blx0/top_sites_inconsistentpoor_style/","title":"Top Sites Inconsistent/Poor Style"},
-    {"url":"https://blog.mozilla.org/blog/2017/09/06/mozilla-washington-post-reinventing-online-comments/","title":"Mozilla and the Washington Post Are Reinventing Online Comments"},
-    {"url":"https://old.reddit.com/r/firefox/comments/6i213a/i_remember_when_firefox_40_was_a_huge_update/","title":"I remember when Firefox 4.0 was a huge update."},
-    {"url":"http://gadgets.ndtv.com/apps/news/firefox-will-try-to-show-you-saved-archive-of-a-page-instead-of-404-error-869482","title":"Firefox Will Try to Show You Saved Archive of a Page Instead of 404 Error"},
-    {"url":"http://www.theverge.com/2016/6/20/11975514/microsoft-chrome-edge-browser-battery-life-tests","title":"Microsoft shows how bad Chrome is for your laptop's battery - FF 3rd"},
-    {"url":"http://www.ghacks.net/2016/03/29/mozilla-system-add-ons-controls/","title":"Please Mozilla, give me control over System Add-ons"},
-    {"url":"https://www.gnu.gl/blog/Posts/multiple-vulnerabilities-in-pocket/","title":"Multiple Vulnerabilities in Pocket"},
-    {"url":"https://github.com/gorhill/uBlock/wiki/Firefox-version:-benchmarking-memory-footprint","title":"uBlock Firefox version: benchmarking memory footprint"},
-    {"url":"https://www.ghacks.net/2018/09/23/firefox-65-new-cookie-jar-policy-to-block-tracking/","title":"Firefox 65: New Cookie Jar Policy to block tracking - gHacks"},
-    {"url":"https://twitter.com/pcwalton/status/971475785616797698","title":"Firefox rastorizing and rendering glyphs on the GPU using Pathfinder and WebRender"},
-    {"url":"https://groups.google.com/forum/#!msg/mozilla.dev.security.policy/Oaeqtddo_Cw/lN-Pp6h1AAAJ","title":"Google and Mozilla planning to distrust all Symantec Certificates"},
-    {"url":"https://github.com/Timvde/UserChrome-Tweaks","title":"I made a git repository to share userChrome.css tweaks. Pull requests welcome!"},
-    {"url":"https://www.ghacks.net/2017/08/30/firefox-webextensions-may-identify-you-on-the-internet/","title":"Firefox WebExtensions may be used to identify you on the Internet"},
-    {"url":"https://dolske.wordpress.com/2017/08/13/photon-engineering-newsletter-12/","title":"Photon Engineering Newsletter #12"},
-    {"url":"http://www.ghacks.net/2016/11/24/noscript-multi-process-compatible/","title":"NoScript is multi-process compatible now"},
-    {"url":"http://www.ghacks.net/2016/11/11/firefox-52-nightly-quantum-compositor-has-landed/","title":"Firefox 52 Nightly: Quantum Compositor has landed"},
-    {"url":"http://www.sitepoint.com/browser-trends-may-2016-firefox-finally-overtakes-ie/","title":"May 2016: Firefox Finally Overtakes IE"},
-    {"url":"http://venturebeat.com/2015/06/09/mozilla-responds-to-firefox-user-backlash-over-pocket-integration/","title":"Mozilla responds to Firefox user backlash over Pocket integration"},
-    {"url":"http://limpet.net/mbrubeck/2012/10/26/mozilla-ie10-cake.html","title":"Congratulations to the IE10 team, love Mozilla -- with cake!"},
-    {"url":"http://www.washingtonpost.com/business/technology/firefox-google-renew-search-deal/2011/12/20/gIQAdUKg7O_story.html","title":". Mozilla announced Tuesday that it and Google have agreed to renew an agreement that makes Google the default search engine in the Firefox browser."},
-    {"url":"https://www.reddit.com/r/Android/comments/9cvn39/psa_firefox_deletes_all_downloaded_files_when_its/","title":"PSA: Firefox deletes all downloaded files, when it's uninstalled"},
-    {"url":"https://changecopyright.org/","title":"Stand Up for Copyright in the Digital Age (EU)"},
-    {"url":"https://color.firefox.com/?theme=XQAAAALtAAAAAAAAAABBqYhm849SCiazH1KEGccwS-xNVAWBvL-5sLCGcUreQUNkXPsQ5ysXI7_X1OXyxzeap-MaXWPGaopg_aK3cFyj7d5T8BmV3UFTU778fAyoaI_r7zKr20SWayOem0M0Bc4L3HNlcd8j7IitWpgqaqMVIJj8-KHocKvIAuljwz-loX8cYquRIGMqhdgfSZbekr-vDmwUpVztS5FBWQCPRXVWTLr_oBBaD5qFr6Gpqd3p_Zg3AA","title":"[Color] Firefox XP"},
-    {"url":"https://mozilla.invisionapp.com/share/8GHTWQGUD5P#/screens","title":"Tab Manager & Multi-tab select coming soon to Firefox."},
-    {"url":"http://people.mozilla.org/~jgruen/test-pilot-art/testpilot-bg@2x.jpg","title":"Test Pilot Desktop Background"},
-    {"url":"http://www.networkworld.com/article/3021113/security/forbes-malware-ad-blocker-advertisements.html","title":"How Forbes inadvertently proved the anti-malware value of ad blocke"},
-    {"url":"https://old.reddit.com/r/firefox/comments/8xz4tg/can_we_flag_content_provided_by_pocket/","title":"Can we flag content provided by Pocket?"},
-    {"url":"https://www.stonetemple.com/mobile-vs-desktop-usage-study/","title":"Mobile web access will reach 2/3 of all traffic by the end of 2018. Yet Mozilla still treats the mobile browser like an afterthought. Why?"},
-    {"url":"https://mikeconley.ca/blog/2018/04/18/firefox-performance-update-6/","title":"Firefox Performance Update #6"},
-    {"url":"https://old.reddit.com/r/firefox/comments/89eftf/thats_how_i_like_it/","title":"That's how I like it!!"},
-    {"url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1423725","title":"[TabGroups] The tab hiding api is completed and it has landed on Nightly 59"},
-    {"url":"https://imgur.com/gallery/0xbkDgy","title":"When you're trying to help Mozilla with voice identification and it hits you with some hard s*it..."},
-    {"url":"https://addons.mozilla.org/en-US/firefox/addon/lastpass-password-manager/","title":"LastPass WebExtension Released!"},
-    {"url":"https://blog.mozilla.org/services/2016/10/06/device-management-coming-to-your-firefox-account/","title":"Device Management Coming to Firefox Sync"},
-    {"url":"https://mspoweruser.com/firefox-66-will-bring-a-solution-for-pages-lost-to-tab-overload/","title":"Firefox 66 will bring a solution for pages lost to tab overload - MSPoweruser"},
-    {"url":"https://www.theverge.com/circuitbreaker/2018/12/6/18129678/qualcomm-8cx-mozilla-firefox-windows-10-64-bit-arm","title":"Firefox running on a Qualcomm 8cx-powered PC feels surprisingly decent"},
-    {"url":"https://addons.mozilla.org/firefox/addon/youtube-pro4/","title":"User copied the original Iridium for YouTube add-on and posted under a different name, be wary of possible danger"},
-    {"url":"https://groups.google.com/forum/#!topic/mozilla.dev.platform/kaZojmUTd3M","title":"Firefox 57 going to Beta/DevEdition earlier!"},
-    {"url":"http://imgur.com/iL1ZfOq","title":"Got my menu set up"},
-    {"url":"https://blog.mozilla.org/addons/2016/04/29/webextensions-in-firefox-48/","title":"WebExtensions in Firefox 48"},
-    {"url":"http://techcrunch.com/2015/12/08/mozilla-will-stop-developing-and-selling-firefox-os-smartphones/?ncid=rss&utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+Techcrunch+%28TechCrunch%29","title":"Mozilla Will Stop Developing And Selling Firefox OS Smartphones"},
-    {"url":"http://www.mozilla.org/en-US/firefox/all.html","title":"Firefox 11.0 Released"},
-    {"url":"https://www.ghacks.net/2018/11/27/mozilla-changes-firefoxs-warn-on-quit-logic/","title":"Mozilla changes Firefox's Warn on Quit logic - gHacks Tech News"},
-    {"url":"https://www.chromestory.com/2018/11/how-to-enable-tab-groups-in-chrome/","title":"Chrome to Get \"Tab Groups\" to Organize Tabs Better like Firefox had and discontinued - Chrome Story"},
-    {"url":"https://old.reddit.com/r/firefox/comments/9atk02/so_what_theme_am_i_using_then/","title":"so what theme am I using then?"},
-    {"url":"https://www.reddit.com/r/foxes/comments/69eni0/finally_finished_putting_together_this_low_poly/","title":"Thought you guys could appreciate this. Paper fox"},
+  { "url": "https://i.imgur.com/AMitlCd.jpg", "title": "It's been a while." },
+  {
+    "url": "https://fossbytes.com/firefox-quantum-57-is-here-to-kill-google-chrome-download-for-windows-mac-linux/",
+    "title": "Firefox Quantum 57 Is Here To Kill Google Chrome: Download For Windows, Mac, Linux"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7dfgnr/youve_earned_it_firefox/",
+    "title": "You've earned it Firefox"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/776710/is_it_just_me_or_google_is_really_getting_worse/",
+    "title": "Is it just me, or Google is really getting worse even than Microsoft? Not allowed to use Firefox anymore?"
+  },
+  {
+    "url": "https://drewdevault.com/2017/12/16/Firefox-is-on-a-slippery-slope.html",
+    "title": "Firefox is on a slippery slope"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/74uc5c/evolution_of_the_fox/",
+    "title": "Evolution of the Fox"
+  },
+  {
+    "url": "https://i.imgur.com/EDYvlK4.png",
+    "title": "Shit like this should be illegal"
+  },
+  {
+    "url": "https://gfycat.com/DishonestDiscreteAfricanfisheagle",
+    "title": "ok"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6e9bk4/when_you_accidentally_open_a_new_window_instead/",
+    "title": "When you accidentally open a new window instead of new tab on firefox"
+  },
+  {
+    "url": "https://blog.mozilla.org/internetcitizen/2018/05/23/gdpr-mozilla/?utm_source=newsletter&utm_medium=email&utm_campaign=mih-05-24-18&utm_content=button",
+    "title": "Mozilla will not update its privacy policy : it doesn't need to"
+  },
+  {
+    "url": "https://i.redd.it/b9voq7d53jr01.jpg",
+    "title": "When my friends complain about Chrome"
+  },
+  {
+    "url": "https://archive.mozilla.org/pub/firefox/releases/57.0/",
+    "title": "Mozilla Firefox 57.0 Final"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7b70uz/internet_is_dark_and_full_of_terrors/",
+    "title": "Internet is dark and full of terrors"
+  },
+  {
+    "url": "https://robertheaton.com/2018/07/02/stylish-browser-extension-steals-your-internet-history/",
+    "title": "\"Stylish\" browser extension steals all your internet history"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6uhkuo/ahahaha_such_new_many_logo_wow_icon/",
+    "title": "Ahahaha such new many logo wow icon"
+  },
+  {
+    "url": "https://www.wired.com/story/firefox-quantum-the-browser-built-for-2017/",
+    "title": "Ciao, Chrome: Firefox Quantum Is The Browser Built for 2017"
+  },
+  {
+    "url": "https://mybroadband.co.za/news/software/269659-google-has-slowed-down-youtube-on-firefox-and-edge-mozilla-exec.html",
+    "title": "Google has slowed down YouTube on Firefox and Edge – Mozilla exec"
+  },
+  {
+    "url": "https://twitter.com/cpeterso/status/1021626510296285185",
+    "title": "YouTube page load is 5x slower in Firefox and Edge than in Chrome because YouTube's Polymer redesign relies on the deprecated Shadow DOM v0 API only implemented in Chrome"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/noscript/versions/",
+    "title": "NoScript 10.1.1 WebExtension is finally released!"
+  },
+  {
+    "url": "https://i.imgur.com/imlFOlO.png",
+    "title": "Current mood at /r/chrome"
+  },
+  {
+    "url": "https://twitter.com/GrouponHelpUS/status/934896721842225152",
+    "title": "Its 1995 again."
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/update-looking-glass-add/",
+    "title": "Update from Mozilla: Looking Glass Add-on"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6tuxbd/stay_classy_google/",
+    "title": "Stay classy, Google."
+  },
+  {
+    "url": "http://www.wired.co.uk/article/mozilla-firefox-quantum-browser-vs-google-chrome",
+    "title": "Firefox thinks Quantum can beat Chrome with ethics… and speed"
+  },
+  {
+    "url": "https://twitter.com/zcorpan/status/1090719253379104779",
+    "title": "Mozilla developer fixes Chromium bug because Google decided to break Chromium instead of fixing a Google site"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8aaduz/firefox_is_now_for_flatearthers/",
+    "title": "Firefox is now for flat-earthers"
+  },
+  {
+    "url": "https://imgur.com/a/EdTnI",
+    "title": "[OC] I redid the Thunderbird icon to look more quantum-y"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/",
+    "title": "Official AMO link for uBlock Origin"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8ogary/soon_githubcom_has_been_optimized_for_edge/",
+    "title": "Soon: Github.com has been optimized for Edge!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/aj6167/is_this_thebreal_reason/",
+    "title": "Is this thebreal reason?"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7lv0r2/what_a_lovely_scam/",
+    "title": "What a lovely scam."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5our4n/windows_10_now_has_builtin_adds_targeting_firefox/",
+    "title": "Windows 10 Now Has Built-In Adds Targeting FireFox... Seriously Microsoft???"
+  },
+  {
+    "url": "https://twitter.com/SeanKHoffman/status/1039573136168169475",
+    "title": "Microsoft engaging in anti-competitive practices again"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8bi6ld/firefox_looks_damn_great_on_linux_now_d/",
+    "title": "firefox looks damn great on linux now :D"
+  },
+  {
+    "url": "https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html",
+    "title": "Firefox Is Back. It’s Time to Give It a Try."
+  },
+  {
+    "url": "https://i.redd.it/jqkr3512ft501.jpg",
+    "title": "The most important gift"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9h6ogn/apple_blocking_firefox_from_accessing_their_new/",
+    "title": "Apple blocking Firefox from accessing their new portal for business users."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7bn59r/firefox_ublock_origin_is_like_a_premium_version/",
+    "title": "Firefox + uBlock Origin is like a premium version of the internet"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6yxy3h/monopolization_at_its_best/",
+    "title": "Monopolization at its best"
+  },
+  {
+    "url": "https://bugs.chromium.org/p/chromium/issues/detail?id=896897&desc=2#c23",
+    "title": "Raymond Hill creator of uBlock Origin (\"uBO\") and uMatrix said that they will not exist on Chrome in the next months if Chrome maintains this orientation, they would only be available on Firefox."
+  },
+  {
+    "url": "https://www.theverge.com/2018/4/15/17239548/firefox-chrome-safari-competition",
+    "title": "The Verge: 'It’s time to give Firefox a fresh chance'"
+  },
+  {
+    "url": "https://twitter.com/steveklabnik/status/941709048529014784",
+    "title": "\"I am pretty upset with my employer, @mozilla, today\""
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/facebook-container-extension/",
+    "title": "Facebook Container Extension: Take control of how you’re being tracked – The Firefox Frontier"
+  },
+  {
+    "url": "https://www.fastcodesign.com/90174010/bye-chrome-why-im-switching-to-firefox-and-you-should-too",
+    "title": "Bye, Chrome: Why I’m switching to Firefox and you should too"
+  },
+  {
+    "url": "https://www.tomshardware.com/news/google-killing-chrome-ad-blockers,38498.html",
+    "title": "People Are Mad That Google Chrome May Kill Ad Blockers"
+  },
+  {
+    "url": "https://i.imgur.com/bbaDjEA.png",
+    "title": "I'm not sure what I just did, but I'm glad Firefox has this feature"
+  },
+  {
+    "url": "https://github.com/mozilla-mobile/fenix/",
+    "title": "Mozilla is working on a new Android browser"
+  },
+  {
+    "url": "https://v.redd.it/rayxp1yvcj421",
+    "title": "Would you like to set firefox as your default browser?"
+  },
+  {
+    "url": "https://about.gitlab.com/images/blogimages/gitlab-blog-cover.png",
+    "title": "My wallpaper with the new FireFox logo. 👍"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8vg3r3/thank_you_firefox/",
+    "title": "Thank you Firefox!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6rnkn3/new_logo_on_the_last_firefox_nightly_release/",
+    "title": "New logo on the last Firefox Nightly release"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/85sdet/just_noticed_there_is_a_doorknob_in_the_home/",
+    "title": "Just noticed there is a doorknob in the home button"
+  },
+  {
+    "url": "https://imgur.com/a/oqzoM",
+    "title": "Firefox users of all countries, unite!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/afpxf4/firefox_with_webrender_vs_chrome_scrolling/",
+    "title": "Firefox with WebRender vs Chrome scrolling"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8nhkww/this_is_apples_gdpr_page_it_supports_chrome_ie11/",
+    "title": "This is Apple's GDPR page. It supports Chrome, IE11, and some releases of Safari. No mobile. No Firefox."
+  },
+  {
+    "url": "http://www.zdnet.com/article/firefox-59-will-stop-websites-snooping-on-where-youve-just-been/",
+    "title": "Firefox 59 will reduce how much information websites pass on about visitors in an attempt to improve privacy for users of its private browsing mode"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6l0zho/some_marketing_skills_firefox_repost_from_rfunny/",
+    "title": "Some marketing skills - Firefox [repost from r/funny]"
+  },
+  {
+    "url": "https://www.netmarketshare.com/browser-market-share.aspx?qprid=1&qpcustomb=0&qpsp=202&qpnp=25&qptimeframe=M",
+    "title": "Firefox hits 2year peak market share in October at 13.14%"
+  },
+  { "url": "https://i.imgur.com/aLLsqGm.png", "title": "Nice try Chrome!" },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/01/16/mozilla-files-suit-fcc-protect-net-neutrality/",
+    "title": "Mozilla Files Suit Against FCC to Protect Net Neutrality"
+  },
+  {
+    "url": "https://techcrunch.com/2017/11/14/mozilla-terminates-its-deal-with-yahoo-and-makes-google-the-default-in-firefox-again/",
+    "title": "Mozilla Terminates its Deal With Yahoo and Makes Google the Default in Firefox Again"
+  },
+  {
+    "url": "https://www.cnet.com/news/mozilla-revenue-jump-fuels-its-firefox-overhaul-plan/",
+    "title": "Mozilla revenue jump fuels its Firefox overhaul plan. The nonprofit pulled in an all-time high of $520 million"
+  },
+  {
+    "url": "https://medium.com/mozilla-tech/mozilla-celebrates-release-of-free-high-quality-video-compression-technology-av1-in-firefox-65-7c95f2b7e56",
+    "title": "Mozilla Celebrates Release of Free, High-Quality Video Compression Technology AV1 in Firefox 65"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/quantum/",
+    "title": "2x faster and 30% less memory | Firefox Quantum Browser"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/a7bbyb/i_hate_the_internet/",
+    "title": "I hate the internet."
+  },
+  {
+    "url": "https://www.reddit.com/r/webdev/comments/a8e5qo/i_may_not_be_a_web_developer_but_you_really_cant/",
+    "title": "I may not be a web developer, but you really can't call Google a supporter of open standards when they're basically defining the standards and forcing other browsers to use them for fear of losing Google compatibility."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6vqk30/rip_firedoge_we_hardly_knew_you/",
+    "title": "R.I.P. Firedoge: We hardly knew you."
+  },
+  {
+    "url": "https://www.techspot.com/news/77765-mozilla-ceo-edge-chromium-switch-hands-over-control.html",
+    "title": "Mozilla CEO: Edge's Chromium switch hands over control of 'even more' online life to Google"
+  },
+  {
+    "url": "https://i.imgur.com/aPDtv64.png",
+    "title": "Cliqz-owned Ghostery just leaked user email addresses in the process of notifying them about GDPR changes."
+  },
+  {
+    "url": "http://i.imgur.com/4i64UJa.png",
+    "title": "Anyone else get this as their new Firefox Nightly icon?"
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/facebook-container-extension-now-includes-instagram-and-facebook-messenger/",
+    "title": "Facebook Container extension now includes Instagram and Facebook Messenger – The Firefox Frontier"
+  },
+  {
+    "url": "https://www.reddit.com/r/europe/comments/8q9bw3/polish_inventor_says_google_is_patenting_work_he/",
+    "title": "Polish inventor says Google is patenting work he put in the public domain, Creator of a breakthrough compression algorithm fights to keep it patent-free"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7rlj8e/really_appreciate_this_feature/",
+    "title": "Really appreciate this feature!"
+  },
+  {
+    "url": "https://itsfoss.com/barcelona-open-source/",
+    "title": "City of Barcelona will migrate to Linux, and Firefox/LibreOffice will be the default Browser and Office Suite..."
+  },
+  {
+    "url": "https://i.imgur.com/ONnvspj.png",
+    "title": "A day in the life of an add-on author"
+  },
+  {
+    "url": "https://www.ghacks.net/2019/01/22/chrome-extension-manifest-v3-could-end-ublock-origin-for-chrome/",
+    "title": "Chrome Extension Manifest V3 could end uBlock Origin for Chromium (Potentially moving more users to Firefox)"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/akfzbv/fun_fact_about_firefox_users/",
+    "title": "Fun fact about Firefox users"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7bshls/why_does_the_page_called_get_addons_in_firefox/",
+    "title": "Why does the page called \"Get Add-ons\" (in Firefox settings) not have a search option for addons? Would be so frustrated as a new user."
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/https-everywhere/",
+    "title": "HTTPS Everywhere WebExtension released to AMO stable!"
+  },
+  {
+    "url": "https://www.theverge.com/2017/12/16/16784628/mozilla-mr-robot-arg-plugin-firefox-looking-glass",
+    "title": "Mozilla faces blowback after slipping Mr Robot plugin into Firefox"
+  },
+  {
+    "url": "https://twitter.com/search?q=Firefox&src=tren",
+    "title": "Firefox is trending globally on Twitter right now"
+  },
+  {
+    "url": "https://blogs.adobe.com/conversations/2017/07/adobe-flash-update.html",
+    "title": "Adobe is announcing EOL plans for its Flash plugin - huge win for the web :-D"
+  },
+  {
+    "url": "https://i.imgur.com/enS60o9.png",
+    "title": "Firefox 12 running inside modern Firefox via a JS-powered Windows 2000 Virtual Machine"
+  },
+  {
+    "url": "https://medium.com/firefox-test-pilot/introducing-firefox-color-and-side-view-20fa66c01ff4",
+    "title": "Test Pilot: Introducing Firefox Color and Side View"
+  },
+  {
+    "url": "https://i.imgur.com/1ySs9NQ.png",
+    "title": "Finally, the dark theme feels like a real dark theme in 61.0"
+  },
+  {
+    "url": "https://i.imgur.com/fici1qY.png",
+    "title": "Interesting Firefox is appearing on Chrome's top stories. It made me laugh, in a good way."
+  },
+  {
+    "url": "https://trac.torproject.org/projects/tor/wiki/org/meetings/2018Rome/Notes/FusionProject",
+    "title": "Mozilla Project Fusion: Tor Integration into Firefox"
+  },
+  {
+    "url": "http://img06.deviantart.net/ec29/i/2011/163/3/f/114_firefox_vs_chrome_by_foice-d3ipqiu.jpg",
+    "title": "Soon, we will be ready"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-63-to-get-improved-tracking-protection-that-blocks-in-browser-miners/",
+    "title": "Firefox 63 to Get Improved Tracking Protection That Blocks In-Browser Miners"
+  },
+  {
+    "url": "https://www.techradar.com/news/the-best-web-browser",
+    "title": "TechRadar: Firefox is #1 browser of 2018: faster and more secure"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/93ij56/when_firefox_is_going_to_have_a_new_logo/",
+    "title": "When firefox is going to have a new logo."
+  },
+  {
+    "url": "https://asadotzler.com/2018/03/31/mozilla-org-is-20-years-old/",
+    "title": "mozilla.org is 20 years old"
+  },
+  {
+    "url": "https://i.redd.it/d6t3g75dvf721.png",
+    "title": "Firefox is now placing ads on your home page."
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/all/",
+    "title": "Firefox 58.0 Final is out now"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/firefox-will-warn-users-when-visiting-sites-that-suffered-a-data-breach/",
+    "title": "Firefox Will Warn Users When Visiting Sites That Suffered a Data Breach"
+  },
+  {
+    "url": "https://www.reddit.com/r/privacy/comments/92ndkf/be_careful_adblock_bought_ublock_not_confuse_with/",
+    "title": "Be careful: Adblock bought uBlock (not confuse with uBlock Origin) • r/privacy"
+  },
+  {
+    "url": "https://twitter.com/auchenberg/status/1088587621721231361?s=19",
+    "title": "Microsoft engineer: \"Thought: It's time for @mozilla to get down from their philosophical ivory tower. The web is dominated by Chromium, if they really *cared* about the web they would be contributing instead of building a parallel universe that's used by less than 5%?\""
+  },
+  {
+    "url": "https://i.imgur.com/MmmFEHf.png",
+    "title": "\"You've been hacked?\" is not really a great email subject to receive. How about \"Find out if you've been hacked.\" instead"
+  },
+  {
+    "url": "https://sonniesedge.co.uk/posts/amp-urls/",
+    "title": "The mysterious case of missing URLs and Google's AMP - Google has a monopoly on search rankings. We can't let them obtain a monopoly on websites."
+  },
+  {
+    "url": "https://boingboing.net/2018/09/12/vichy-nerds-2.html",
+    "title": "Europe just voted to wreck the internet, spying on everything and censoring vast swathes of our communications - Cory Doctorow"
+  },
+  {
+    "url": "https://imgur.com/a/4KsFFBK",
+    "title": "Hey guys im a long time Google Chrome user and just started using Firefox the other day. Ive made a lot of little changes to make the transition easier and thought it would be cool to share what I've done with others who might be going through something similar, so I made a very in-depth imgur album"
+  },
+  {
+    "url": "https://andregarzia.com/2018/12/while-we-blink-we-loose-the-web.html",
+    "title": "While we Blink, we lose the Web"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7xnmkd/this_is_blatant_discrimination_against_firefox/",
+    "title": "This is blatant discrimination against Firefox and also bullcrap"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/896oqv/built_in_dark_theme_now_works_with_new_tab/",
+    "title": "Built in dark theme now works with new tab"
+  },
+  {
+    "url": "https://www.ghacks.net/2017/10/28/firefox-58-warns-you-if-sites-use-canvas-image-data/",
+    "title": "Firefox 58 warns you if sites use Canvas image data - which could be used to uniquely identify your computer"
+  },
+  {
+    "url": "https://arstechnica.com/gadgets/2018/12/the-web-now-belongs-to-google-and-that-should-worry-us-all/",
+    "title": "Google isn’t the company that we should have handed the Web over to"
+  },
+  {
+    "url": "https://techcrunch.com/2017/12/15/mozillas-mr-robot-promo-backfires-after-it-installs-firefox-extension-without-permission/amp/",
+    "title": "Mozilla’s Mr. Robot promo backfires after it installs a Firefox extension without permission"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7ek2au/not_even_a_month_of_web_browsing_and_over_1000/",
+    "title": "Not even a month of web browsing and over 1000 sites have tried tracking me..."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9z0dju/didnt_know_firefox_can_warn_user_for_breached/",
+    "title": "Didn't know Firefox can warn user for breached account, is this new?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/12/12/mozilla-joins-net-neutrality-blackout-for-break-the-internet-day/",
+    "title": "Mozilla Joins Net Neutrality Blackout for ‘Break the Internet’ Day"
+  },
+  {
+    "url": "https://danielmiessler.com/blog/google-amp-not-good-thing/",
+    "title": "Google AMP is Not a Good Thing - \"If this were to become widely adopted, you’d search for something, get results, consume the content, and you’d never leave Google.\""
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/61.0/releasenotes/",
+    "title": "Firefox 61.0 got released — Release Notes"
+  },
+  {
+    "url": "https://i.imgur.com/aMHz2px.png",
+    "title": "Firefox 57 has reached Developer Edition!"
+  },
+  {
+    "url": "https://www.reddit.com/personalization?done=true",
+    "title": "Reddit now tracks and sells individual user behavior by default (including outbound clicks). Here's the setting to disallow it."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/817juo/gif_vs_jif_how_about_yif/",
+    "title": "“GIF” vs “JIF”? How about “YIF”?"
+  },
+  {
+    "url": "https://boingboing.net/2015/11/20/assad-government-secretly-sent.html",
+    "title": "Syria secretly sentenced developer and Firefox contributor Bassel Khartabil to death"
+  },
+  {
+    "url": "https://www.cnn.com/2018/03/29/opinions/tech-backlash-facebook-google-opinion-baker/index.html",
+    "title": "Backlash against tech companies is a wake-up call - By Mozilla Founder Mitchell Baker"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8ra5oi/there_is_now_an_option_in_nightly_to_reopen_tab/",
+    "title": "There is now an option in nightly to reopen tab in a container."
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/09/26/firefox-quantum-beta-developer-edition/",
+    "title": "Firefox Quantum Lands in Beta, Developer Edition – The Mozilla Blog"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/02/27/mozilla-acquires-pocket/",
+    "title": "Mozilla Acquires Pocket"
+  },
+  {
+    "url": "http://imgur.com/SJF8e0i",
+    "title": "Loving this new Firefox advertising"
+  },
+  {
+    "url": "https://i.imgur.com/ERQbQrW.png",
+    "title": "Almost updated Firefox, then noticed something is A BIT suspicious. Where can I send/report this?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/12/06/goodbye-edge/",
+    "title": "Goodbye, EdgeHTML – The Mozilla Blog"
+  },
+  {
+    "url": "https://www.cnet.com/news/microsoft-windows-removes-warning-about-installing-chrome-firefox/",
+    "title": "Good news : Microsoft Windows U-turn removes warning about installing other browsers"
+  },
+  {
+    "url": "https://techcrunch.com/2017/09/29/its-time-to-give-firefox-another-chance/",
+    "title": "It’s time to give Firefox another chance"
+  },
+  {
+    "url": "https://www.zdnet.com/article/firefox-and-the-4-year-battle-to-have-google-to-treat-it-as-a-first-class-citizen/",
+    "title": "Firefox and the 4-year battle to have Google to treat it as a first-class citizen"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/88a2sf/so_i_was_looking_for_an_extension_to_edit/",
+    "title": "So I was looking for an extension to edit keyboard shortcuts"
+  },
+  {
+    "url": "https://www.polemicdigital.com/google-amp-go-to-hell/ants_websites_to_adopt_amp_as_the_default/",
+    "title": "Google wants websites to adopt AMP as the default approach to building webpages. Tell them no."
+  },
+  {
+    "url": "https://youtu.be/6fcrKa0mk0k",
+    "title": "Color: a brand new extension by Firefox"
+  },
+  {
+    "url": "https://arstechnica.co.uk/information-technology/2017/06/firefox-multiple-content-processes/",
+    "title": "Firefox 54 finally goes multi-process, eight years after work began"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-implements-another-privacy-preserving-feature-taken-from-the-tor-browser/",
+    "title": "Firefox Implements Another Privacy-Preserving Feature Taken From the Tor Browser"
+  },
+  {
+    "url": "https://www.nytimes.com/2018/06/11/technology/net-neutrality-repeal.html",
+    "title": "Net Neutrality Repeal is now official"
+  },
+  {
+    "url": "https://www.fxsitecompat.com/en-CA/docs/2018/third-party-tracking-cookies-are-now-blocked-by-default/",
+    "title": "Third-party tracking cookies are now blocked by default"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/75y9ii/menus_are_blindingly_white_in_the_dark_theme/",
+    "title": "Menus are blindingly white in the dark theme"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/a5sqsi/wow_impressive/",
+    "title": "Wow impressive."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7hq44o/as_if_i_didnt_dislike_spotify_enough_already/",
+    "title": "As if I didn't dislike Spotify enough already..."
+  },
+  {
+    "url": "https://groups.google.com/forum/#!topic/mozilla.governance/81gMQeMEL0w",
+    "title": "Firefox planning to anonymously collect browsing data"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-prepares-to-mark-all-http-sites-not-secure-after-https-adoption-rises/",
+    "title": "Firefox Prepares to Mark All HTTP Sites \"Not Secure\" After HTTPS Adoption Rises"
+  },
+  {
+    "url": "https://www.reddit.com/r/talesfromtechsupport/comments/7k7wum/when_all_online_tests_are_invalidated_blame_mr/",
+    "title": "Real world effects of the Looking Glass experiment."
+  },
+  {
+    "url": "https://liliputing.com/2017/11/mozilla-releases-open-source-speech-recognition-tools.html",
+    "title": "Mozilla releases open source speech recognition tools"
+  },
+  {
+    "url": "https://lifehacker.com/why-you-should-switch-from-google-chrome-to-firefox-1821879163",
+    "title": "Why You Should Switch From Google Chrome to Firefox"
+  },
+  {
+    "url": "https://i.imgur.com/5IBXo0u.png",
+    "title": "TIP: You can add keywords to any search bar and then use them in the main URL bar for faster access"
+  },
+  { "url": "https://i.imgur.com/Rx42mAn.jpg", "title": "Happy Halloween!" },
+  {
+    "url": "https://psyq123.wordpress.com/2015/11/26/to-defend-the-free-web-you-must-save-mozilla/",
+    "title": "To defend the free web, you must save Mozilla"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/",
+    "title": "Introducing the New Firefox: Firefox Quantum – The Mozilla Blog"
+  },
+  {
+    "url": "https://i.imgur.com/2kW3vGD.png",
+    "title": "New Developer Edition (aurora) icon for 57"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=Am4pKF5T_jU",
+    "title": "It's time to root for underdog browser Firefox again"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/amp2html/",
+    "title": "Seeing more and more AMP links being shared around on social media lately. Don't let this become normal, install this extension to redirect to non-AMP sites and help save the web."
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/10/privacy-badger-now-fights-more-sneaky-google-tracking",
+    "title": "Privacy Badger Now Fights More Sneaky Google Tracking"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/91yebi/firefox_needs_to_clear_cookies/",
+    "title": "Firefox needs to clear cookies"
+  },
+  {
+    "url": "https://www.extremetech.com/computing/282685-google-denies-crippling-edge-to-chromes-advantage",
+    "title": "Google Denies Crippling Edge to Chrome's Advantage"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9g4h0c/in_finnish_mythology_its_believed_that_the_aurora/",
+    "title": "In Finnish mythology , it's believed that the Aurora Borealis is caused by a firefox who ran so quickly across the snow that it's tail caused sparks to fly into the night sky creating the Aurora. The Finnish word “Revontulet” literally translates as \"Fox flames\""
+  },
+  {
+    "url": "https://twitter.com/mike_conley/status/978991881337081856",
+    "title": "Dark themes in Firefox Nightly now affect the URL and search dropdowns"
+  },
+  {
+    "url": "http://i.imgur.com/StabbzB.jpg",
+    "title": "Today at Mozilla (x-post from /r/geek)"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/96r74c/ive_never_seen_a_major_website_recommend_firefox/",
+    "title": "I've never seen a major website recommend Firefox over Chrome in such an open way."
+  },
+  {
+    "url": "https://blog.mozilla.org/services/2018/05/22/two-step-authentication-in-firefox-accounts/",
+    "title": "Firefox Accounts getting two-step authentication"
+  },
+  {
+    "url": "https://i.imgur.com/bSwEDvo.png",
+    "title": "Just hit my millionth element blocked. Could never do this on IE"
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/firefox-64-default-64-bit-windows/",
+    "title": "64-bit Firefox is the new default on 64-bit Windows"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/ag8uyv/you_can_now_manage_keyboard_shortcuts_of/",
+    "title": "You can now manage keyboard shortcuts of extensions at about:addons"
+  },
+  {
+    "url": "https://twitter.com/ctavan/status/1044282084020441088",
+    "title": "Chrome 69 will keep Google Cookies when you tell it to delete all cookies"
+  },
+  {
+    "url": "https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#html-filters",
+    "title": "HTML filtering is coming to uBO 1.14.25, capable of preventing the execution of specific inline scripts, only supported on Firefox 57+"
+  },
+  {
+    "url": "https://cbsi.secure.force.com/CBSi/ViewArticle_allaccess?popup=true&aId=kA00L000000Hfaq&categories=CBS_Entertainment%3AAll_Access&template=template_cbsvod&referer=cbs.com/vod&data=&cfs=SFS_FT",
+    "title": "CBS site requires Firefox users turn off anti-tracking to see content"
+  },
+  {
+    "url": "https://www.theverge.com/2017/12/30/16829804/browser-password-manager-adthink-princeton-research",
+    "title": "Ad targeters are pulling data from your browser’s password manager"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6mue3v/thanks_mozilla_for_spreading_awareness_about_net/",
+    "title": "Thanks Mozilla for spreading awareness about Net Neutrality!"
+  },
+  {
+    "url": "http://venturebeat.com/2015/07/24/firefox-is-getting-audio-indicators-to-show-noisy-tabs-and-will-let-you-mute-them/",
+    "title": "Firefox Will Soon Show You Which Tabs Are Making Noise, and Let You Mute Them"
+  },
+  {
+    "url": "https://twitter.com/mozilla/status/994216229593284608",
+    "title": "Mozilla is joining 🚨 RED ALERT for NetNeutrality because you deserve to know what YOU stand to lose if the FCC repeal of net neutrality becomes the law of the land."
+  },
+  {
+    "url": "https://advocacy.mozilla.org/en-US/net-neutrality-comments?sample_rate=0.01&snippet_name=6819#utm_source=desktop-snippet&utm_medium=snippet&utm_campaign=net-neutrality",
+    "title": "The beginning of the end of the open internet? Not if we do something about it."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7dc0fc/how_long_have_you_been_using_firefox/",
+    "title": "How long have you been using Firefox?"
+  },
+  {
+    "url": "https://9to5google.com/2018/04/22/google-chrome-canary-reveals-new-refreshed-material-design-look-gallery/",
+    "title": "Chrome’s new design looks strangely familiar. 🤔"
+  },
+  {
+    "url": "https://www.troyhunt.com/were-baking-have-i-been-pwned-into-firefox-and-1password/",
+    "title": "We're Baking Have I Been Pwned into Firefox and 1Password"
+  },
+  {
+    "url": "https://i.imgur.com/r3pbGfJ.png",
+    "title": "Came into work and my laptop went straight to this when logging in....good try Microsoft."
+  },
+  {
+    "url": "https://discourse.mozilla.org/t/support-ublock-origin/6746/451",
+    "title": "uBlock Origin developer on Chrome vs Firefox WebExtensions"
+  },
+  {
+    "url": "https://twitter.com/asadotzler/status/1088617089974251522",
+    "title": "Firefox Product Manager on Twitter: Firefox isn't going to do anything with ad blockers"
+  },
+  {
+    "url": "https://www.zdnet.com/article/google-and-mozilla-are-right-av-firms-do-need-to-stop-breaking-https-security/",
+    "title": "Google and Mozilla are right: AV firms do need to stop breaking HTTPS security"
+  },
+  { "url": "https://i.imgur.com/jXyCaaQ.png", "title": "Firefox 58!" },
+  {
+    "url": "https://www.howtogeek.com/333230/why-firefox-had-to-kill-your-favorite-extension/",
+    "title": "Why Firefox Had to Kill Your Favorite Extension"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2016/04/save-firefox",
+    "title": "Save Firefox!"
+  },
+  {
+    "url": "https://i.imgur.com/GYPwJKd.jpg",
+    "title": "Why does Progressive Insurance hate Firefox?"
+  },
+  {
+    "url": "https://i.imgur.com/c01C86Q.png",
+    "title": "You can't download anymore from MEGA without additional software."
+  },
+  {
+    "url": "https://www.zdnet.com/article/malicious-sites-abuse-11-year-old-firefox-bug-that-mozilla-failed-to-fix/",
+    "title": "Malicious sites abuse 11-year-old Firefox bug that Mozilla failed to fix"
+  },
+  {
+    "url": "https://www.howtogeek.com/335712/update-why-you-shouldnt-use-waterfox-pale-moon-or-basilisk/",
+    "title": "How-To Geek recommends against using Waterfox, Pale Moon, and Basilisk"
+  },
+  {
+    "url": "https://gizmodo.com/after-blowback-firefox-will-move-mr-robot-extension-t-1821354314",
+    "title": "After Blowback, Firefox Will Move Mr. Robot Extension to Store"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/55.0/releasenotes/",
+    "title": "Firefox — Notes (55.0)"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/mozilla-removes-23-firefox-add-ons-that-snooped-on-users/",
+    "title": "Mozilla Removes 23 Firefox Add-Ons That Snooped on Users"
+  },
+  {
+    "url": "https://twitter.com/letsencrypt/status/1020058447922978816",
+    "title": "Let's Encrypt: \"The percentage of Web pages loaded by Firefox using HTTPS has reached over 80% among U.S. users! We are thrilled to help secure the Web. (Stats via @firefox telemetry)\""
+  },
+  {
+    "url": "https://www.reddit.com/r/privacy/comments/8poozr/facebook_reportedly_sold_user_data_to_businesses/",
+    "title": "Facebook reportedly sold user data to businesses in secret deals - Developing • r/privacy"
+  },
+  {
+    "url": "https://i.imgur.com/UA82pHS.png",
+    "title": "Google Blog blocks Firefox mobile but recommends Firefox..."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8grw52/one_youtube_video_running_6gb_memory_41_cpu/",
+    "title": "One Youtube video running. 6GB memory 41% CPU"
+  },
+  {
+    "url": "https://www.quora.com/Does-Chrome-have-a-feature-similar-to-Firefox-container-tabs",
+    "title": "Does Google literally pay \"shills\" to bash Firefox and promote Chrome?"
+  },
+  {
+    "url": "https://www.wordfence.com/blog/2016/11/emergency-bulletin-firefox-0-day-wild/?utm_source=list&utm_campaign=113016&utm_medium=email",
+    "title": "Bulletin: Firefox 0 day in the wild."
+  },
+  {
+    "url": "https://hg.mozilla.org/mozilla-central/raw-file/7c50f0c999c5/browser/branding/nightly/VisualElements_150.png",
+    "title": "Next Nighty Logo. Let's see if it stays like this."
+  },
+  {
+    "url": "https://np.reddit.com/r/wow/comments/5exq2d/wowheadcom_sucking_bandwidth/dagbmie/",
+    "title": "uBlock Origin developer Raymond Hill on wowhead.com: \"It's like the site is designed to fire a lot of obfuscated garbage network requests along with a few legitimate ones, as a punishment for using a blocker\""
+  },
+  {
+    "url": "http://www.ghacks.net/2017/01/28/firefox-add-on-quicksaver-quits/",
+    "title": "Firefox loses yet another high profile add-on author: Quicksaver quits"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/59.0/releasenotes/",
+    "title": "Firefox 59 Release Notes"
+  },
+  {
+    "url": "https://www.zdnet.com/article/mozilla-will-match-all-donations-to-the-tor-project/",
+    "title": "Mozilla will match all donations to the Tor Project | ZDNet"
+  },
+  {
+    "url": "https://venturebeat.com/2018/12/31/mozilla-ad-on-firefoxs-new-tab-page-was-just-another-experiment/",
+    "title": "Mozilla on Firefox's Booking.com Snippet: “It was not a paid placement or advertisement. We are continually looking for more ways to say thanks for using Firefox.\""
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7h24ra/firefox_lost_its_1_position_on_the_desktop_in/",
+    "title": "Firefox lost its #1 position on the desktop in Germany in the last two months -- what happened?"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7whdv4/googlecom_in_firefox_for_android_normal_vs_w/",
+    "title": "Google.com in Firefox for Android, normal vs w/ UserAgent spoofing"
+  },
+  {
+    "url": "https://blog.mozilla.org/advancingcontent/2015/12/04/advancing-content/",
+    "title": "Mozilla to stop advertising through new tab tiles"
+  },
+  {
+    "url": "https://tamebay.com/2018/08/firefox-to-distrust-all-tls-certificates-issued-by-symantec.html",
+    "title": "Firefox to distrust all SSL/TLS certificates issued by Symantec"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8kq47d/acrylic_photon_firefox_mockup/",
+    "title": "Acrylic photon Firefox mock-up"
+  },
+  { "url": "https://i.imgur.com/dgTgfqO.png", "title": "Spell \"Antitrust\"" },
+  {
+    "url": "https://www.firefox.net.cn/read-54613",
+    "title": "Mining codes been discovered in two reviewed add-ons from \"Add-ons for Firefox\" site."
+  },
+  {
+    "url": "https://blog.torproject.org/new-release-tor-browser-80",
+    "title": "New Release: Tor Browser 8.0 based on Firefox Quantum"
+  },
+  {
+    "url": "https://www.cnet.com/news/firefox-to-support-googles-webp-image-format-for-a-faster-web/",
+    "title": "Firefox to support Google's WebP image format for a faster web"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/788fmc/few_more_customizations_for_default_dark_theme/",
+    "title": "Few More Customizations for Default Dark Theme"
+  },
+  {
+    "url": "https://ferdychristant.com/the-state-of-web-browsers-f5a83a41c1cb",
+    "title": "\"The State of Web Browsers\" - Firefox's the long road to irrelevance"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/06/20/10615/",
+    "title": "Firefox Focus New to Android, blocks annoying ads and protects your privacy"
+  },
+  {
+    "url": "https://imgur.com/a/uJXUT",
+    "title": "Firefox Wallpapers All Versions 27 high res. Images"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6teno8/another_new_firefox_nightly_icon/",
+    "title": "Another new Firefox Nightly icon"
+  },
+  {
+    "url": "http://i.imgur.com/L0xBM0B.png",
+    "title": "Really disappointed in Directv Now..."
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/50.0/releasenotes/",
+    "title": "Firefox 50.0 out today, with better startup improvements."
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2019/jan/28/eu-data-watchdog-raises-concerns-facebook-integration",
+    "title": "EU data watchdog raises concerns over Facebook’s plan to merge WhatsApp, Instagram and Facebook Messenger"
+  },
+  {
+    "url": "https://blog.cryptographyengineering.com/2018/09/23/why-im-leaving-chrome/",
+    "title": "Why I’m done with Chrome – A Few Thoughts on Cryptographic Engineering"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/decentraleyes/#detail-relnotes",
+    "title": "Decentraleyes 2.0 (Webextension) released to AMO stable"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6z4kv6/seems_legit/",
+    "title": "Seems legit."
+  },
+  {
+    "url": "https://send.firefox.com/",
+    "title": "Firefox Send - You can now share up to 1 GB files with Firefox via any browser"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7kzj0z/i_didnt_expect_firefox_to_support_this_kind_of/",
+    "title": "I didn't expect Firefox to support this kind of device 😳"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7cn208/firefox_quantum_57_final_out_now/",
+    "title": "Firefox Quantum 57 final out now"
+  },
+  { "url": "https://i.imgur.com/fIrkllM.gif", "title": "I like this" },
+  {
+    "url": "https://github.com/mozilla/multi-account-containers/issues/339#issuecomment-434534754",
+    "title": "Mozilla plans to spend some full-time on Containers add-on; synchronization feature discussed"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/10/21/mozilla-tests-premium-vpn-service/",
+    "title": "Mozilla tests Premium VPN Service"
+  },
+  {
+    "url": "https://www.pcmag.com/news/357788/mozilla-yahoo-sue-each-other-over-firefoxs-default-search",
+    "title": "Mozilla, Yahoo Sue Each Other Over Firefox's Default Search"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/08/30/firefox-51-flac-audio-codec-support/",
+    "title": "Firefox 51 will have FLAC audio codec support out of the box"
+  },
+  {
+    "url": "https://venturebeat.com/2018/07/30/mozilla-is-rebranding-firefox-and-wants-your-opinion/",
+    "title": "Mozilla is rebranding Firefox and wants your opinion"
+  },
+  {
+    "url": "https://i.imgur.com/Vip6WBC.jpg",
+    "title": "Opera Touch (android app) icon colours seem familiar... Where have I seen those gradients before... 🤔"
+  },
+  {
+    "url": "https://forum.f-droid.org/t/making-it-easier-for-f-droid-to-package-mozilla-firefox/1649/8",
+    "title": "Firefox Android may get a F-Droid build, without GCM"
+  },
+  {
+    "url": "https://i.imgur.com/SM0GNye.png",
+    "title": "Firefox Screenshots finally has a \"copy to clipboard\" option!"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/microsoft/microsoft-has-effectively-banned-third-party-browsers-from-the-windows-store/",
+    "title": "Microsoft Has Effectively Banned Third-Party Browsers From the Windows Store"
+  },
+  {
+    "url": "https://github.com/vladikoff/netflix-1080p-firefox/pull/14",
+    "title": "The Netflix 1080p add-on for Firefox has been updated and should be working again"
+  },
+  {
+    "url": "https://newfirefox.mozilla.community/",
+    "title": "Firefox Quantum Release Campaign - Support Mozilla in Announcing Firefox!"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/12/03/ublock-origin-performance-improvements-thanks-to-wasm-firefox-only-for-now/",
+    "title": "uBlock Origin performance improvements thanks to WASM (Firefox only, for now) - gHacks Tech News"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9lpe9l/nightly_is_sending_notificions_to_action_center/",
+    "title": "Nightly is sending notificions to Action Center in Windows"
+  },
+  {
+    "url": "https://soylentnews.org/article.pl?sid=18/05/17/028245",
+    "title": "Privacy Tool uBlock (NOT uBlock Origin) Adds User Tracking Feature"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/aa1age/didnt_age_well/",
+    "title": "Didn't age well"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9wukkn/how_does_firefox_decide_that_extension_with_0/",
+    "title": "How does Firefox decide that extension with 0 users is \"Trending\"?"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/60.0.2/releasenotes/",
+    "title": "Firefox 60.0.2 released, security and bug fixes."
+  },
+  {
+    "url": "https://github.com/devunt/make-gis-great-again#make-google-image-search-great-again",
+    "title": "\"So this web extension simply adds \"View Image\" button to Google Image Search results again.\" Yay!"
+  },
+  {
+    "url": "https://www.popularmechanics.com/technology/a22887479/firefox-block-third-party-trackers/",
+    "title": "Firefox To Block Third-Party Trackers That Harvest Your Data and Slow Down Your Internet"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/a2zirb/cristal_fox_part_of_my_art_everyday_art_project/",
+    "title": "Cristal fox. Part of my art everyday art project. CC1"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/dedicated-profiles/",
+    "title": "Starting with Firefox 67, Firefox Nightly will run a dedicated profile"
+  },
+  {
+    "url": "https://twitter.com/letsencrypt/status/1043291536400805891",
+    "title": "Let's Encrypt: 75% of Web pages loaded by @firefox use HTTPS!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8mwhnm/bank_of_america_finds_firefox_quantum_600_as_an/",
+    "title": "Bank of America finds Firefox Quantum 60.0 as an Old & Outdated Browser!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8msjvg/so_is_this_the_ultimate_privacy_firefox_am_i/",
+    "title": "So is this the ultimate Privacy Firefox? Am I missing something?"
+  },
+  {
+    "url": "https://arstechnica.com/gadgets/2018/05/firefox-will-show-sponsored-content-thats-personalized-but-private/",
+    "title": "Firefox will show sponsored content that’s personalized but private"
+  },
+  {
+    "url": "https://imgur.com/gallery/agD1McH",
+    "title": "I love these fun facts"
+  },
+  {
+    "url": "https://savecodeshare.eu/",
+    "title": "EU Parliament is planning new copyright rules which threatens Open-Source code platforms like Github, Gitlab and others. Sign the FSFE open letter now!"
+  },
+  {
+    "url": "https://venturebeat.com/2018/01/26/probeat-google-chrome-and-mozilla-firefox-are-bringing-back-the-browser-wars/",
+    "title": "ProBeat: Google Chrome and Mozilla Firefox are bringing back the browser wars"
+  },
+  {
+    "url": "https://twitter.com/slac/status/943474837766524928",
+    "title": "Google Hangouts finally supports Firefox"
+  },
+  {
+    "url": "https://blog.torproject.org/powering-digital-resistance-help-mozilla",
+    "title": "Mozilla is matching donations to the Tor Project up to a total of $500,000"
+  },
+  {
+    "url": "http://sourceforge.net/projects/firefox.mirror/",
+    "title": "Ownership of Firefox on sourceforge Was transfered to sf-editor1 (SourceForge Staff)"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1450784",
+    "title": "Firefox 65 to show ‘Mozilla_PKIX_ERROR_ MITM_Detected’ when antivirus interferes with SSL connections"
+  },
+  {
+    "url": "https://blog.mozilla.org/futurereleases/2018/08/30/changing-our-approach-to-anti-tracking/",
+    "title": "Changing Our Approach to Anti-tracking – Future Releases"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/07/13/firefox-will-support-windows-10s-dark-mode/",
+    "title": "Firefox will support Windows 10's dark mode"
+  },
+  {
+    "url": "https://imgur.com/gallery/6b6NOHL",
+    "title": "Firefox has encountered a bug"
+  },
+  {
+    "url": "https://user-images.githubusercontent.com/4400286/51053095-b233bb80-15a6-11e9-95f4-decdc82d1b7a.png",
+    "title": "New Firefox Logo?"
+  },
+  {
+    "url": "https://twitter.com/gorhill/status/1018484996212969472",
+    "title": "How can we be expected to trust extensions when this is allowed?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/07/20/firefox-focus-android-hits-one-million-downloads-today-launching-three-new-user-requested-features/",
+    "title": "Firefox Focus for Android Hits One Million Downloads! Today We’re Launching Three New User-Requested Features"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1358372#c45",
+    "title": "Firefox Nightly finally only creates one process in Windows volume mixer (coming with Firefox 60)"
+  },
+  {
+    "url": "http://i.imgur.com/buzWpgg.png",
+    "title": "The new Nightly icon has landed on Android"
+  },
+  {
+    "url": "http://i.imgur.com/HAPwCQG.png",
+    "title": "I'll take my business else where, then."
+  },
+  {
+    "url": "https://www.ghacks.net/2018/10/11/this-is-firefoxs-upcoming-aboutperformance-page-huge-improvements/",
+    "title": "This is Firefox's upcoming about:performance page (huge improvements) - gHacks Tech News"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/view-image/",
+    "title": "Have you noticed disappearance of \"view image\" button on Google? Firefox add-on brings it back"
+  },
+  {
+    "url": "https://twitter.com/NicolasPetton/status/884694176515936256",
+    "title": "Security Fuckup: about:addons uses Google Analytics"
+  },
+  {
+    "url": "https://imgur.com/a/D4LCn",
+    "title": "For Night Owls! The Dark Mode ;)"
+  },
+  {
+    "url": "http://www.dailydot.com/technology/hola-vpn-security/?tw=dd",
+    "title": "Stop using the Hola VPN right now. The company behind Hola is turning your computer into a node on a botnet, and selling your network to anyone who is willing to pay. [X-post from /r/Chrome]"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/62.0/releasenotes/",
+    "title": "Firefox 62.0 got released — Release Notes"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/10/23/latest-firefox-rolls-out-enhanced-tracking-protection/",
+    "title": "Latest Firefox Rolls Out Enhanced Tracking Protection – The Mozilla Blog"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8hrb78/firefox_62_reaches_the_nightly_channel/",
+    "title": "Firefox 62 reaches the Nightly channel"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7yvrkw/popular_chrome_extension_dark_reader_now_supports/",
+    "title": "Popular Chrome extension Dark Reader now supports for Firefox"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/05/08/next-10-days-critical-internets-future/",
+    "title": "Why the Next 10 Days Are Critical to the Internet’s Future"
+  },
+  {
+    "url": "https://screenshots.firefox.com/YnyWizx6ulrPZ23e/null",
+    "title": "New Firefox logo lands in Nightly"
+  },
+  {
+    "url": "https://news.fastcompany.com/mozilla-is-crowdsourcing-a-massive-speech-recognition-system-4043612",
+    "title": "Mozilla is crowdsourcing a massive speech-recognition system"
+  },
+  {
+    "url": "https://www.google.com/earth/",
+    "title": "New version of Google Earth runs on Chrome only"
+  },
+  {
+    "url": "https://theintercept.com/2017/06/05/be-careful-celebrating-googles-new-ad-blocker-heres-whats-really-going-on/",
+    "title": "Be Careful Celebrating Google’s New Ad Blocker. Here’s What’s Really Going On."
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/36.0/releasenotes/",
+    "title": "Firefox 36.0 released!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/90jgd2/nightly_now_lets_you_allow_or_block_autoplay_per/",
+    "title": "Nightly now lets you allow or block autoplay per website"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/80lzun/nightly_now_supports_theming_arrow_panels/",
+    "title": "Nightly now supports theming arrow panels"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2017/10/the-whole-web-at-maximum-fps-how-webrender-gets-rid-of-jank/",
+    "title": "The whole web at maximum FPS: How WebRender gets rid of jank"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7rgro4/firefox_nightly_590a1_finally_properly_hides/",
+    "title": "Firefox Nightly (59.0a1) finally properly hides title bar on Ubuntu Mate"
+  },
+  {
+    "url": "https://i.imgur.com/LNz4VBY.jpg",
+    "title": "Our beloved browser's logo in real life (x-post from /r/redpandas)"
+  },
+  {
+    "url": "https://www.thurrott.com/cloud/197417/chromes-new-ad-blocker-goes-worldwide-in-july",
+    "title": "Chrome’s Ad Blocker Goes Worldwide in July"
+  },
+  {
+    "url": "https://www.trustedreviews.com/news/google-kaios-firefox-os-3497173",
+    "title": "Google just spent $22m on what used to be Firefox OS"
+  },
+  {
+    "url": "https://www.theverge.com/2018/6/13/17446660/mozilla-firefox-pocket-recommendations-ceo-nate-weiner-interview-converge-podcast",
+    "title": "How Firefox is using Pocket to try to build a better news feed than Facebook"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/aifypn/is_there_a_plugin_to_block_this_style_of_email/",
+    "title": "Is there a plugin to block this style of email sign-up overlay messages? I get them constantly on sites these days and it drives me nuts."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/07/net-neutrality-rules-are-illegal-according-to-trumps-supreme-court-pick/",
+    "title": "Trump’s Supreme Court pick: ISPs have 1st Amendment right to block websites"
+  },
+  {
+    "url": "https://streamable.com/gy45e",
+    "title": "Firefox's new reload/stop animation for Photon just hit Nightly"
+  },
+  {
+    "url": "http://i.imgur.com/u8TvSJo.png",
+    "title": "Mozilla should do something about these malware ads that appear as the first two results in a Google search for \"firefox\""
+  },
+  {
+    "url": "https://boingboing.net/2018/11/29/but-not-chrome.html",
+    "title": "Mozilla pulls a popular paywall circumvention tool from Firefox add-ons store"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9w3azf/thunderbird_is_seperate_from_mozilla/",
+    "title": "Thunderbird is seperate from mozilla?"
+  },
+  {
+    "url": "http://www.theverge.com/2016/9/13/12890050/adblock-plus-now-sells-ads",
+    "title": "Adblock Plus now sells ads"
+  },
+  {
+    "url": "https://i.imgur.com/OeI0IBy.png",
+    "title": "Photon Rectangular tabs have landed in Nightly!"
+  },
+  {
+    "url": "http://www.wired.com/wiredenterprise/2014/01/mozilla/",
+    "title": "Mozilla Calls On World To Protect Firefox Browser From the NSA"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/09/25/introducing-firefox-monitor-helping-people-take-control-after-a-data-breach/",
+    "title": "Introducing Firefox Monitor, Helping People Take Control After a Data Breach – The Mozilla Blog"
+  },
+  {
+    "url": "http://www.motherjones.com/mojo/2014/04/okcupid-ceo-donate-anti-gay-firefox",
+    "title": "And now irony: OkCupid's CEO Donated to an Anti-Gay Campaign Once, Too"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/11/05/mozilla-and-google-remove-wot-extension/",
+    "title": "Mozilla and Google remove WOT (Web of Trust) extension from browser's addon stores"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1405971",
+    "title": "Webextensions in Firefox suffer from a privacy leak. Calls done by the extension attach a `Origin: moz-extension://<internal-uuid>` header, thereby allowing servers, CDNs to track the user based on this persistent user identifier."
+  },
+  {
+    "url": "https://www.reddit.com/r/Windows10/comments/8uhw99/its_official_microsoft_acknowledged_firefox_as/",
+    "title": "It's official! Microsoft acknowledged Firefox as being faster than Chrome"
+  },
+  {
+    "url": "https://techcrunch.com/2016/09/02/multi-process-firefox-brings-400-700-improvement-in-responsiveness/?ncid=rss&utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+Techcrunch+%28TechCrunch%29",
+    "title": "Multi-process Firefox brings 400-700% improvement in responsiveness"
+  },
+  {
+    "url": "http://www.engadget.com/2015/07/22/twitch-starts-dumping-flash-for-html5/",
+    "title": "Twitch starts dumping Flash for HTML5"
+  },
+  {
+    "url": "http://i.imgur.com/jeMduiZ.gif",
+    "title": "Firefox is still king of customization"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/11/28/mozilla-revenue-rose-by-over-40-million-in-2017/",
+    "title": "Mozilla revenue rose by over $40 million in 2017"
+  },
+  {
+    "url": "https://www.nbcnews.com/tech/tech-news/apple-firefox-browsers-aim-thwart-facebook-google-tracking-n909671",
+    "title": "Apple, Firefox browsers aim to thwart Facebook, Google tracking"
+  },
+  {
+    "url": "https://wccftech.com/firefox-damaged-user-trust-promote-mr-robot/",
+    "title": "Firefox May Have Damaged Its Own Name to Promote Mr. Robot"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/57.0.1/releasenotes/",
+    "title": "Firefox — Notes (57.0.1)"
+  },
+  {
+    "url": "http://www.ghacks.net/2017/03/07/firefox-52-0-released-find-out-what-is-new/",
+    "title": "Firefox 52.0 released: find out what is new"
+  },
+  {
+    "url": "https://www.reddit.com/r/Windows10/comments/a74z95/edgehtml_engineer_says_part_of_the_reason_why/",
+    "title": "EdgeHTML engineer says part of the reason why Microsoft gave up on Edge is because of Google intentionally making changes to their sites that broke other browsers"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/38.0/releasenotes/",
+    "title": "Firefox v38.0 Released"
+  },
+  {
+    "url": "http://i.imgur.com/UxzUYqp.png",
+    "title": "Not sure why this is needed"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/60.0/releasenotes/",
+    "title": "Firefox — Notes (60.0)"
+  },
+  {
+    "url": "https://nakedsecurity.sophos.com/2017/11/12/firefox-to-offer-tracking-protection-for-all-in-its-next-update/",
+    "title": "Firefox to offer tracking protection for all in its next update"
+  },
+  {
+    "url": "https://hg.mozilla.org/mozilla-central/raw-file/54ad22b649e5/browser/branding/nightly/VisualElements_150.png",
+    "title": "Today's (August 18) Nighty icon"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2015/08/privacy-badger-10-here-stop-online-tracking",
+    "title": "EFF is excited to announce that today we are releasing version 1.0 of Privacy Badger for Chrome and Firefox. Privacy Badger is a browser extension that automatically blocks hidden trackers that would otherwise spy on your browsing habits as you surf the Web."
+  },
+  {
+    "url": "http://i.imgur.com/MMtWaIK.png",
+    "title": "Firefox forcing children into a block (from r/proprammerhumor)"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=14421237",
+    "title": "Mozilla won"
+  },
+  {
+    "url": "http://imgur.com/a/3D2cP",
+    "title": "Firefox + uBlock Origin is 2x faster than Chrome on Android"
+  },
+  {
+    "url": "http://i.imgur.com/8hE2nfg.jpg",
+    "title": "Microsoft tells me I'll get better battery life if I use Microsoft Edge. How can they get away with this?"
+  },
+  {
+    "url": "http://robert.ocallahan.org/2014/08/choose-firefox-now-or-later-you-wont.html",
+    "title": "Choose Firefox Now, Or Later You Won't Get A Choice"
+  },
+  {
+    "url": "https://www.reddit.com/r/linux/comments/9hh3gc/to_unsuspecting_admins_firefox_continues_to_send/",
+    "title": "To unsuspecting admins: Firefox continues to send telemetry to Mozilla even when explicitly disabled."
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/64.0.2/releasenotes/?utm_source=firefox-browser&utm_medium=firefox-browser&utm_campaign=whatsnew",
+    "title": "Firefox v64.0.2 Released."
+  },
+  {
+    "url": "http://imgur.com/a/7I0MP",
+    "title": "All I really want from Firefox."
+  },
+  {
+    "url": "http://i.imgur.com/Wi6rM.jpg",
+    "title": "Found this costume on r/cosplay, but it belongs here."
+  },
+  {
+    "url": "https://twitter.com/MkllSUMO/status/1085281415095308289",
+    "title": "The ability to upload your Firefox Screenshots to a Mozilla hosted site is being removed, along with the blue upload button"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/04/https-everywhere-introduces-new-feature-continual-ruleset-updates",
+    "title": "HTTPS Everywhere Introduces New Feature: Continual Ruleset Updates"
+  },
+  {
+    "url": "https://github.com/Synzvato/decentraleyes/releases",
+    "title": "Decentraleyes now officially supports upcoming versions of Firefox."
+  },
+  {
+    "url": "https://www.ghacks.net/2018/09/09/mozilla-working-on-google-translate-integration-in-firefox/",
+    "title": "Mozilla working on Google Translate integration in Firefox - gHacks"
+  },
+  {
+    "url": "https://blog.mozilla.org/opendesign/evolving-the-firefox-brand/",
+    "title": "Evolving the Firefox Brand – Mozilla Open Design"
+  },
+  {
+    "url": "https://www.mozilla.org/firefox/60.0.1/releasenotes/",
+    "title": "Firefox 60.0.1 got released - fixes lags/performance issues caused by some addons"
+  },
+  {
+    "url": "https://www.reddit.com/r/BrowserWar/comments/7ob0zo/chrome_is_turning_into_the_new_internet_explorer_6/?utm_source=reddit-android",
+    "title": "Chrome is turning into the new Internet Explorer 6"
+  },
+  {
+    "url": "https://imgur.com/a/EIurE",
+    "title": "Just wanted to warn Firefox devs and community about this page using Firefox name to spread potential malware"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6pp2gi/new_test_pilot_experiments_coming/",
+    "title": "New test pilot experiments coming"
+  },
+  {
+    "url": "http://monica-at-mozilla.blogspot.ca/2015/05/tracking-protection-for-firefox-at-web.html",
+    "title": "Firefox Tracking Protection decreases page load time by 44%"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/12/how-https-everywhere-keeps-protecting-users-increasingly-encrypted-web",
+    "title": "How HTTPS Everywhere Keeps Protecting Users On An Increasingly Encrypted Web"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/7/18172170/htc-vive-mozilla-firefox-reality-virtual-reality-browser-vr-ces-2019",
+    "title": "HTC partners with Mozilla to bring Firefox’s virtual reality web browser to the Vive headset"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/72xzl9/firefoxs_thanks_message/",
+    "title": "Firefox's thanks message"
+  },
+  {
+    "url": "http://www.omgubuntu.co.uk/2017/08/firefox-to-get-new-logo",
+    "title": "Firefox 57 is shaping up to be one of the browser’s biggest and most important releases in its history"
+  },
+  {
+    "url": "http://www.businessinsider.de/former-mozilla-ceo-brendan-eich-launches-ad-blocking-web-browser-brave-2016-1?utm_source=twitterfeed&utm_medium=twitter&utm_campaign=Feed%3A+typepad%2Falleyinsider%2Fsilicon_alley_insider+%28Silicon+Alley+Insider%29?r=US&IR=T",
+    "title": "The former CEO of Mozilla is launching a web browser that blocks all ads by default"
+  },
+  {
+    "url": "https://twitter.com/gorhill/status/1033706103782170625",
+    "title": "Seriously: Do NOT use similar-purposed blocker(s) along with uBlock Origin: this will cripple uBO's ability to defuse anti-blocker mechanisms and its ability to minimize likelihood of site breakage. (\"similar-purposed\" = any other blocker making use of EasyList)"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/07/25/mozilla-plans-to-remove-rss-feed-reader-and-live-bookmarks-support-from-firefox/",
+    "title": "Mozilla plans to remove RSS feed reader and Live Bookmarks support from Firefox"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-working-on-protection-against-in-browser-cryptojacking-scripts/",
+    "title": "Firefox Working on Protection Against In-Browser Cryptojacking Scripts"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7q8bjl/some_pages_are_icons_some_thumbnails_but_why/",
+    "title": "some pages are icons, some thumbnails but why???"
+  },
+  {
+    "url": "http://imgur.com/a/it35o",
+    "title": "Firefox.com background image as wallpaper. Versions with and without the fox. [1920x1200]"
+  },
+  {
+    "url": "http://i.imgur.com/y7XGLdB.png",
+    "title": "This is the kind of customization I enjoy in Firefox"
+  },
+  {
+    "url": "http://techcrunch.com/2014/12/12/yahoo-starts-prompting-chrome-users-to-upgrade-to-firefox/",
+    "title": "Yahoo Starts Prompting Chrome Users To “Upgrade” To Firefox"
+  },
+  {
+    "url": "http://imgur.com/SnmLl",
+    "title": "In Firefox 11, you can see 3D View of Web Page Structure. Holy shit."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8x4s6k/ebay_says_latest_version_of_firefox_on_ios_is_an/",
+    "title": "eBay says latest version of Firefox on iOS is an out of date browser"
+  },
+  {
+    "url": "https://ma.ttias.be/firefox-nightly-starts-marking-login-forms-in-http-as-insecure/",
+    "title": "Firefox Nightly starts marking login-forms in HTTP as insecure"
+  },
+  {
+    "url": "https://www.engadget.com/2017/11/23/firefox-notification-breached-sites/",
+    "title": "Firefox will soon flag sites that have been hacked"
+  },
+  {
+    "url": "https://www.ghacks.net/2019/01/12/firefox-69-flash-disabled-by-default/",
+    "title": "Firefox 69: Flash disabled by default - gHacks Tech News"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1294490",
+    "title": "Firefox now supports WebP image format"
+  },
+  {
+    "url": "https://github.com/containers-everywhere/contain-google",
+    "title": "Google Container for Firefox | Put Google Services in a sandbox"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=366559#c147",
+    "title": "Firefox developers discuss why they can't use '.bro' file extension for 'brotli' files because of feminism - they'll use '.br' instead"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Usage_share_of_web_browsers#Summary_tables",
+    "title": "Firefox's market share continues to decline since it fell below 10% in May of this year. Chrome is leading with 60%."
+  },
+  {
+    "url": "https://blog.mozilla.org/webrtc/firefox-is-now-supported-by-google-hangouts-and-meet/",
+    "title": "Firefox is now supported by Google Hangouts and Meet"
+  },
+  {
+    "url": "https://www.ctrl.blog/entry/firefox-reintroduces-opensearch",
+    "title": "Firefox to reintroduce OpenSearch discovery and installs in Firefox 61"
+  },
+  { "url": "https://i.imgur.com/Fk0xB1v.jpg", "title": "Soon 30K subscribers" },
+  {
+    "url": "https://www.phoronix.com/scan.php?page=news_item&px=Google-Servo-Perf-Comparison",
+    "title": "Mozilla's Servo Is Whooping The Other Browsers In Performance"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=tBhfU0Cr6X0",
+    "title": "Remember when Mozilla livestreamed Red Pandas cubs to promote Firefox 4?"
+  },
+  {
+    "url": "https://i.imgur.com/urzqEJg.png",
+    "title": "I chose \"happy\", but this did make me feel a bit sad"
+  },
+  {
+    "url": "https://mozilla.invisionapp.com/share/7XG2P3JSY46#/screens/281059637",
+    "title": "\"New bookmark\" panel is getting a redesign"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/57.0/releasenotes/",
+    "title": "Firefox — Notes (57.0)"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/tree-style-tab/",
+    "title": "Tree Style Tab - It's finally here!!!"
+  },
+  {
+    "url": "https://twitter.com/EmilyKager/status/1010197494242791424",
+    "title": "Firefox Focus with GeckoView can now be tested"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8jm25h/firefox_wallpaper/",
+    "title": "Firefox Wallpaper"
+  },
+  {
+    "url": "https://imgur.com/a/IPmtGqL",
+    "title": "Google now looks nice and modern on Firefox Nightly"
+  },
+  {
+    "url": "https://www.theverge.com/2017/7/27/16019222/open-source-data-ai-mozilla-common-voice-project",
+    "title": "Mozilla is crowdsourcing voice recognition to make AI work for the people"
+  },
+  {
+    "url": "https://testpilot.firefox.com/experiments/firefox-lockbox",
+    "title": "Firefox Lockbox for iOS and Notes for Android are out today from your friends at Test Pilot!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5d5i2x/when_i_start_firefox_i_sometimes_get_this_message/",
+    "title": "When I start Firefox, I sometimes get this message. Aww, Microsoft, you so cute<3"
+  },
+  {
+    "url": "http://www.reddit.com/r/youtube/comments/34cyca/firefox_is_now_using_the_html5_player_by_default/",
+    "title": "YouTube is now using HTML5 by default for Firefox"
+  },
+  {
+    "url": "https://wiki.mozilla.org/Firefox/Roadmap?duplicate",
+    "title": "Firefox 2018 Roadmap"
+  },
+  {
+    "url": "https://i.imgur.com/UZ32KzA.png",
+    "title": "My Chrome breakup didn't go so well."
+  },
+  {
+    "url": "https://i.imgur.com/ezlIYIl.png",
+    "title": "Guess it's time to upgrade then..."
+  },
+  {
+    "url": "http://www.downthemall.net/the-likely-end-of-downthemall/",
+    "title": "DownThemAll! » The likely end of DownThemAll? - August 21, 2015"
+  },
+  {
+    "url": "https://chrome.google.com/webstore/search/stylish?_category=extensions",
+    "title": "Stylish appears to have been removed from the Google Chrome store"
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/retrospective-looking-glass/",
+    "title": "Retrospective: Looking Glass"
+  },
+  {
+    "url": "http://arstechnica.com/business/2016/05/firefox-overtakes-microsoft-internet-explorer-edge-browsers-first-time-statcounter/",
+    "title": "Firefox tops Microsoft browser market share for first time"
+  },
+  {
+    "url": "http://www.theverge.com/2016/1/27/10840480/flash-dead-in-two-years-webm",
+    "title": "Flash is expected to be dead in two years"
+  },
+  {
+    "url": "https://www.zdnet.com/article/mozilla-wipes-23-firefox-add-ons-off-the-map-for-tracking-user-activity/",
+    "title": "Mozilla wipes 23 Firefox add-ons off the map for tracking user activity"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/07/18/mozilla-responds-to-european-commissions-google-android-decision/",
+    "title": "Mozilla Responds to European Commission’s Google Android Decision – The Mozilla Blog"
+  },
+  {
+    "url": "https://twitter.com/firefox/status/451797073936269312",
+    "title": "Brendan Eich has stepped down as Mozilla's CEO"
+  },
+  {
+    "url": "https://selfie.votefornetneutrality.com/",
+    "title": "Big Cable’s lobbyists are telling Congress that no one cares about net neutrality."
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1427928#c45",
+    "title": "Several new WebExtensions APIs confirmed, including support for session management, userScripts, topSites, declarativeContent, bookmarks, clipboard, visual overlays"
+  },
+  {
+    "url": "http://gs.statcounter.com/browser-market-share/desktop/worldwide/#monthly-201612-201712",
+    "title": "Firefox continues to lose market share after Quantum release (Dec 2018)"
+  },
+  {
+    "url": "https://www.eff.org/files/https-everywhere-test/index.html",
+    "title": "HTTPS Everywhere WebExtension Updated"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/firefox-65-to-show-certificates-used-in-man-in-the-middle-ssl-attacks/",
+    "title": "Firefox 65 to Show Certificates Used in Man-in-the-Middle SSL Attacks"
+  },
+  {
+    "url": "https://techcrunch.com/2018/10/12/fcc-resorts-to-the-usual-malarkey-defending-itself-against-mozilla-lawsuit/",
+    "title": "FCC resorts to the usual malarkey defending itself against Mozilla lawsuit"
+  },
+  {
+    "url": "https://blog.mozilla.org/addons/2017/11/20/extensions-in-firefox-58/",
+    "title": "Extensions in Firefox 58"
+  },
+  {
+    "url": "https://youtu.be/YIywpvHewc0",
+    "title": "Firefox Quantum (Beta) vs Chrome"
+  },
+  { "url": "http://imgur.com/D3feLeK", "title": "Fuck this" },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/adbzp9/why_is_my_duckduckgo_icon_on_the_new_tab_page_low/",
+    "title": "Why is my DuckDuckGo icon on the New Tab page low res?"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/firefox-master-password-system-has-been-poorly-secured-for-the-past-9-years/",
+    "title": "Firefox Master Password System Has Been Poorly Secured for the Past 9 Years"
+  },
+  {
+    "url": "http://tonsky.me/blog/chrome-intervention/",
+    "title": "Chrome breaks the Web"
+  },
+  {
+    "url": "https://twitter.com/Sesivany/status/908628645299748865",
+    "title": "Firefox with client side decorations on Linux coming soon"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/google/google-chrome-adding-support-for-signed-http-exchanges/",
+    "title": "Google Chrome Adding Support for Signed HTTP Exchanges (but Mozilla Firefox considers it harmful)"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/717h0j/i_love_firefox_easter_eggs_aboutrobots/",
+    "title": "I love Firefox Easter Eggs! (about:robots)"
+  },
+  {
+    "url": "http://www.pcworld.com/article/3138031/browsers/another-40-million-people-bolt-from-microsofts-browsers-as-mass-exodus-continues.html",
+    "title": "Good to see Firefox gaining back lost market share."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7f8hbw/webrender_is_amazing/",
+    "title": "Webrender is amazing"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=15696184",
+    "title": "Why the move to WebExtensions was so important for Firefox development"
+  },
+  {
+    "url": "https://searchsecurity.techtarget.com/news/252454489/Mozilla-distrusts-all-Symantec-certificates-with-Firefox-64-release",
+    "title": "Mozilla distrusts all Symantec certificates with Firefox 64 release"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/01/making-webassembly-even-faster-firefoxs-new-streaming-and-tiering-compiler/",
+    "title": "Making WebAssembly even faster: Firefox’s new streaming and tiering compiler"
+  },
+  {
+    "url": "https://i.imgur.com/PogWRzD.gif",
+    "title": "So they introduced this new drop down menu so that you have to click one more time to see who verified the SSL connection"
+  },
+  {
+    "url": "https://www.zdnet.com/article/half-of-the-tor-projects-funding-now-comes-from-the-private-sector/",
+    "title": "Half of the Tor Project's funding now comes from the private sector | ZDNet"
+  },
+  {
+    "url": "https://www.ctrl.blog/entry/lastpass-deprecates-firefox-android",
+    "title": "LastPass quietly deprecates their Firefox for Android extension"
+  },
+  {
+    "url": "https://arstechnica.com/security/2017/03/firefox-gets-complaint-for-labeling-unencrypted-login-page-insecure/",
+    "title": "Firefox gets complaint for labeling unencrypted login page insecure"
+  },
+  { "url": "http://arewetenyet.com/", "title": "Happy Birthday, Firefox" },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/akitmg/brave_gone_too_far/",
+    "title": "Brave gone too far?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/08/20/mozilla-files-arguments-against-the-fcc-latest-step-in-fight-to-save-net-neutrality/",
+    "title": "Mozilla files arguments against the FCC – latest step in fight to save net neutrality – The Mozilla Blog"
+  },
+  {
+    "url": "https://imgur.com/QEfxExh",
+    "title": "Left phone in pocket at work (locked and screen off) and Firefox pretty much destroyed my battery. Anyway to disable Firefox processes when phone locked?"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7stcul/nightly_has_a_veryinteresting_bug_this_time_around/",
+    "title": "Nightly has a very...interesting bug this time around."
+  },
+  {
+    "url": "https://redditenhancementsuite.com/releases/5.8.0/",
+    "title": "Reddit Enhancement Suite for Firefox is now a WebExtension."
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-will-add-a-settings-section-that-lets-you-control-performance-/",
+    "title": "Firefox Will Add a \"Performance\" Settings Section And Will Let You Control Number Of Processes and Memory"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/40.0/releasenotes/",
+    "title": "Firefox 40 now available"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/android/64.0.1/releasenotes/",
+    "title": "Firefox for Android 64.0.1, See All New Features, Updates and Fixes"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/12/12/buster-promises-to-solve-captchas-automatically/",
+    "title": "Buster promises to solve captchas automatically"
+  },
+  {
+    "url": "http://thenextweb.com/apps/2012/12/01/ie10-grabs-0-51-market-share-firefox-passes-20-again-chrome-loses-users-third-month-in-a-row/",
+    "title": "Firefox Above 20% Again, Chrome Loses More Users"
+  },
+  {
+    "url": "https://medium.com/drill/the-internet-changes-http-3-will-not-use-tcp-anymore-427e82eeadc0",
+    "title": "The Internet changes: HTTP/3 will not use TCP anymore"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/62.0.2/releasenotes/",
+    "title": "Firefox 62.0.2 Release Notes"
+  },
+  { "url": "https://i.imgur.com/dud9aNf.jpg", "title": "Firefox in the wild." },
+  {
+    "url": "https://superuser.com/questions/1250944/how-can-this-website-reidentify-me-even-after-deleting-all-of-my-browsers-histo",
+    "title": "Firefox not deleting IndexedDB storage, allowing websites to set persistent cookies"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2013/06/11/stopwatching-us-mozilla-launches-massive-campaign-on-digital-surveillance/",
+    "title": "StopWatching.Us: Mozilla launches massive campaign on digital surveillance"
+  },
+  {
+    "url": "https://i.imgur.com/2fXtbvF.jpg",
+    "title": "We did boys, Firefox Android finally shows Google's \"new\" card view"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9d3tde/what_a_nice_design_good_job_guys/",
+    "title": "What a nice design! Good job guys!"
+  },
+  {
+    "url": "https://groups.google.com/forum/#!topic/mozilla.dev.platform/hlCGG_Hib1w",
+    "title": "Mozilla plans to migrate users to 64 bit builds on Win64 in Firefox 56"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/09/15/mozilla-plans-to-reduce-power-consumption-of-firefox/",
+    "title": "Mozilla plans to reduce power consumption of Firefox"
+  },
+  {
+    "url": "https://github.com/gorhill/uBlock/releases/tag/0.9.1.0",
+    "title": "uBlock 0.9.1.0 was just released and it now officially includes Firefox Mobile support."
+  },
+  {
+    "url": "https://github.com/hackademix/noscript",
+    "title": "NoScript is on GitHub now."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5v3g8b/why_does_my_about_firefox_mention_facebook/",
+    "title": "Why does my \"About Firefox\" mention Facebook?"
+  },
+  {
+    "url": "http://gizmodo.com/fuck-it-im-going-back-to-firefox-1685425815",
+    "title": "Fuck It, I'm Going Back to Firefox"
+  },
+  {
+    "url": "http://i.imgur.com/kfdys.png",
+    "title": "Nice Try Fake Firefox Update"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/01/07/firefox-59-ui-options-to-block-notifications-microphone-camera-and-location/",
+    "title": "Firefox 59: UI options to block notifications, microphone, camera and location - gHacks Tech News"
+  },
+  {
+    "url": "https://www.flickr.com/photos/42178139@N06/24825255690/in/photostream/lightbox/",
+    "title": "Saw this last night in Chinatown (Photo)"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/12/firefox-64-released/",
+    "title": "New interface, CSS, add-ons, and privacy features in Firefox 64 – Mozilla Hacks - the Web developer blog"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/05/new-in-firefox-61-developer-edition/",
+    "title": "New in Firefox 61: Developer Edition"
+  },
+  {
+    "url": "https://www.wired.com/story/ghostery-open-source-new-business-model/",
+    "title": "Ad-Blocker Ghostery Just Went Open Source—And Has a New Business Model"
+  },
+  {
+    "url": "https://hackernoon.com/firefox-ffe71d0e16c3",
+    "title": "Is Firefox Quantum Worth it?"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7j3xyp/ok_now_this_is_just_straight_ads/",
+    "title": "OK now this is just straight ads"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6r5l3z/firefox_doesnt_support_send_please_try_firefox/",
+    "title": "Firefox doesn't support Send, please try Firefox"
+  },
+  {
+    "url": "http://i.imgur.com/CJ7Ugl6.png",
+    "title": "Firefox is now even with Chrome on Google's own benchmark"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/10/eu-internet-censorship-will-censor-whole-worlds-internet",
+    "title": "EU Internet Censorship Will Censor the Whole World's Internet"
+  },
+  {
+    "url": "https://pspdfkit.com/blog/2018/a-real-world-webassembly-benchmark/",
+    "title": "Firefox won a \"Real-World WebAssembly Benchmark\""
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6uuvh7/whats_up_with_doge_meme_in_nightly_logo/",
+    "title": "What's up with doge meme in nightly logo"
+  },
+  {
+    "url": "https://metafluff.com/2017/07/21/i-am-a-tab-hoarder/",
+    "title": "The New Firefox and Ridiculous Numbers of Tabs"
+  },
+  {
+    "url": "https://i.imgur.com/dX1MNSR.png",
+    "title": "Mozilla should merge the Preferences and Add-ons pages (concept) [OC]"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/10/02/new-firefox-focus-comes-with-search-suggestions-revamped-visual-design-and-an-under-the-hood-surprise-for-android-users/",
+    "title": "New Firefox Focus comes with search suggestions, revamped visual design and an under-the-hood surprise for Android users – The Mozilla Blog"
+  },
+  {
+    "url": "https://imgur.com/a/5LoAcTh",
+    "title": "New autoplay icon in Firefox is misaligned"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8j9uo6/is_this_the_new_design_for_firefox_nightly_on/",
+    "title": "is this the new design for FireFox Nightly on Android? looks cool!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7n9z7x/anyone_experienced_something_like_this_ad_is/",
+    "title": "Anyone experienced something like this? Ad is unclosable and CPU use jumped to 100% until I force-closed Firefox"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/70alt3/new_option_in_firefox_search_settings/",
+    "title": "New Option in Firefox Search Settings"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-52-borrows-one-more-privacy-feature-from-the-tor-browser/",
+    "title": "Firefox 52 Borrows One More Privacy Feature from the Tor Browser"
+  },
+  {
+    "url": "http://i.imgur.com/MuXDlat.png",
+    "title": "Firefox knows you. ( ͡° ͜ʖ ͡°)"
+  },
+  {
+    "url": "https://github.com/spikespaz/Firefox-NativeDark",
+    "title": "I made a really nice adaptive theme for Windows 10, that doubles as a dark theme for other systems."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7fvpve/medieval_firefox_hours_of_joanna_the_mad_bruges/",
+    "title": "Medieval Firefox ('Hours of Joanna the Mad', Bruges, 1486-1506, via @Zweder_Masters)"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7aygyv/just_noticed_that_it_doesnt_say_firefox_beta/",
+    "title": "Just noticed that it doesn't say Firefox Beta anymore in the about dialog, but says Firefox Quantum"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8wu2h8/is_there_any_convenient_way_to_know_what_the_6/",
+    "title": "Is there any convenient way to know what the \"6 other domains\" are for this addon's permission request?"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/57.0.4/releasenotes/",
+    "title": "Firefox — Notes (57.0.4)"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/11/08/mozilla-plans-to-remove-support-for-heavyweight-themes-in-firefox/",
+    "title": "Mozilla plans to remove support for heavyweight themes in Firefox"
+  },
+  {
+    "url": "http://i.imgur.com/XO0qTKY.png",
+    "title": "Thank you, Firefox. From Haiyan victims."
+  },
+  {
+    "url": "http://i.imgur.com/vh8Q7AI.png",
+    "title": "You can now see which tabs are playing audio and mute each one in the most recent Nightly"
+  },
+  {
+    "url": "http://i.imgur.com/2ptEuXf.png",
+    "title": "Is Dell allowed to sell Firefox?"
+  },
+  {
+    "url": "https://i.imgur.com/w5vwYp7.png",
+    "title": "German free mailer GMX says Firefox 62.0 is outdated and asks the user to install GMX Browser"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7iiycr/looks_like_this_dinosaur_should_have_taken_that/",
+    "title": "Looks like this dinosaur should have taken that left turn!"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/11/20/firefox-private-browsing-vs-chrome-incognito/",
+    "title": "Firefox Private Browsing vs. Chrome Incognito: Which is Faster? – The Mozilla Blog"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7dcr92/an_adorable_family_picture_is_hiding_in_quantums/",
+    "title": "An adorable family picture is hiding in Quantums preferences :)"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/10/03/mozilla-awards-half-million-open-source-projects/",
+    "title": "Mozilla Awards Over Half a Million to Open Source Projects"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/03/03/beware-firefox-add-on-youtube-unblocker-put-on-blocklist/",
+    "title": "Popular add-on YouTube Unblocker blocked by Mozilla as it tampers with Firefox security preferences (using user.js manipulations) and downloads and installs an unrelated add-on from an unofficial website"
+  },
+  {
+    "url": "http://opensource.com/life/15/11/happy-birthday-eleven-mozilla-firefox",
+    "title": "Happy birthday Firefox!"
+  },
+  {
+    "url": "http://i.imgur.com/jU13JiX.png",
+    "title": "Firefox Developer Edition (Aurora) now supports Youtube videos at 60 fps"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/59.0.2/releasenotes/",
+    "title": "Firefox v59.0.2 - Release Notes"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1446404",
+    "title": "Cave: Mozilla is about to launch a shield study that will send your visited sites to a Cloudflare server"
+  },
+  {
+    "url": "https://imgur.com/ft53FvS",
+    "title": "[Idea] Instead of \"Recommended by Pocket\", there could be \"From your Pocket\". This would show links that you have saved to Pocket. I think it would be a nice reminder to not forget about certain things that you have saved."
+  },
+  {
+    "url": "https://www.ghacks.net/2017/04/19/firefox-53-0-release-find-out-what-is-new/",
+    "title": "Firefox 53.0 Release: Find out what is new."
+  },
+  {
+    "url": "http://arstechnica.com/security/2015/11/dell-does-superfish-ships-pcs-with-self-signed-root-certificates/",
+    "title": "Dell does a Superfish, ships PCs with easily cloneable root certificates. Chrome/IE vulnerable, Firefox unaffected."
+  },
+  {
+    "url": "http://imgur.com/CvTfoVc",
+    "title": "Firefox fixes HP 0 day initiative's pwn2own contest's security bug."
+  },
+  {
+    "url": "http://www.ghacks.net/2013/04/02/firefox-20-0-find-out-what-is-new/",
+    "title": "Firefox 20.0 comes today, find out what's new right away (very comprehensive)."
+  },
+  {
+    "url": "https://hacks.mozilla.org/2017/11/entering-the-quantum-era-how-firefox-got-fast-again-and-where-its-going-to-get-faster/",
+    "title": "Entering the Quantum Era—How Firefox got fast again and where it’s going to get faster"
+  },
+  {
+    "url": "https://imgur.com/a/njUdP",
+    "title": "wait I just literally turn on my computer"
+  },
+  {
+    "url": "https://letsencrypt.org/",
+    "title": "Let's Encrypt: Fast, Simple, Free SSL/TLS sponsored by Mozilla (and others)"
+  },
+  {
+    "url": "https://hg.mozilla.org/releases/mozilla-release/rev/0746f89a5aee",
+    "title": "Mozilla adds DuckDuckGo as a search engine option in Firefox"
+  },
+  {
+    "url": "https://www.reddit.com/r/phishing/comments/9b315f/youtube_video_downloader_firefox_addon_injecting/",
+    "title": "[X-Post] \"Youtube Video Downloader\" Firefox add-on injecting malicious JavaScript everywhere"
+  },
+  {
+    "url": "https://winaero.com/blog/firefox-65-memory-column-in-built-in-task-manager/",
+    "title": "Firefox 65: Memory column in Built-in Task Manager, and Performance/Memory section in Site Information flyout"
+  },
+  {
+    "url": "https://ha.x0r.be/posts/chrome-is-a-google-service/",
+    "title": "Wow, I think a lot of people are going to switch to Firefox because of this"
+  },
+  {
+    "url": "https://arstechnica.com/information-technology/2018/07/stylish-extension-with-2m-downloads-banished-for-tracking-every-site-visit/",
+    "title": "“Stylish” extension with 2M downloads banned for tracking every site visit"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7yfydd/i_like_this_feature_reader_mode_firefox_nightly/",
+    "title": "I like this feature. Reader mode (Firefox Nightly) shows the amount of time to read the document. Haven't noticed this anywhere else."
+  },
+  { "url": "https://xkcd.com/1770/", "title": "relevant XKCD" },
+  {
+    "url": "https://github.com/gorhill/uBlock/commit/6d44605c0c1e04de15bbf7a57fd546b42e8a9daf",
+    "title": "uBlock Origin 1.13.9b0 Has been released as a webextension to AMO dev channel!"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/46.0/releasenotes/",
+    "title": "Firefox 46.0 has been released!"
+  },
+  {
+    "url": "https://lh6.googleusercontent.com/-3INB5vq6XWQ/VdXVK6brWFI/AAAAAAAAHAk/AQDX9t5JeBc/w754-h565-no/firefoxos.PNG",
+    "title": "Mozilla just sent me an email about Firefox OS, and this was at the bottom. I think they forgot something..."
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/mozilla-to-provide-msi-installers-starting-with-firefox-65/",
+    "title": "Mozilla to Provide MSI Installers Starting with Firefox 65"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1368744",
+    "title": "Latest Nightly (finally) has a way to deny \"Allow notifications\" prompts!"
+  },
+  {
+    "url": "http://www.tomshardware.com/reviews/chrome-27-firefox-21-opera-next,3534-12.html",
+    "title": "Firefox beats Chrome in Performance for the first time in a few years."
+  },
+  {
+    "url": "https://betanews.com/2017/09/29/mozilla-firefox-privcy-notice/",
+    "title": "Mozilla updates Firefox Privacy Notice with greater detail, transparency and prominence"
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/introducing-firefox-multi-account-containers/",
+    "title": "Announcing The Firefox Multi-Account Containers Extension"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6uiwwn/this_is_why_ill_always_use_firefox/",
+    "title": "This is why I'll always use Firefox"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/54.0/releasenotes/",
+    "title": "Firefox — Notes (54.0)"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8en3og/testing_dead_switch_and_found_this_does_this_cute/",
+    "title": "Testing dead switch and found this. Does this cute little guy have a name?"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1356334",
+    "title": "Message about a slow script will now tell you which addon is causing it. (Nightly)"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/google/google-bans-adnauseam-from-chrome-the-ad-blocker-that-clicks-on-all-ads/",
+    "title": "Google Bans AdNauseam from Chrome Store, the Ad Blocker That Clicks on All Ads"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9v9813/how_to_keep_the_old_icon_on_android_81/",
+    "title": "How to keep the old icon on Android 8.1"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9eq0v6/why_is_firefoxs_contextmenu_autocorrect_so/",
+    "title": "Why is Firefox’s context-menu autocorrect so inaccurate? Do I need to change something in the settings?"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/08/giving-privacy-badger-jump-start",
+    "title": "Giving Privacy Badger a Jump Start ."
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/60.0beta/releasenotes/",
+    "title": "Firefox 60.0 beta has been released"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/03/12/firefox-59-firefox-screenshots-gets-image-editing-functionality/",
+    "title": "Firefox 59: Firefox Screenshots gets image editing functionality"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/56.0/releasenotes",
+    "title": "Firefox — Notes (56.0)"
+  },
+  {
+    "url": "https://fosspost.org/news/bassel-khartabil-oss-contributor-confirmed-dead-syria",
+    "title": "Bassel Khartabil, Firefox Contributor, Confirmed Dead in Syria"
+  },
+  {
+    "url": "http://imgur.com/BQjfd",
+    "title": "DAE Hate playing \"Which one of these is going to let me do what I want?\""
+  },
+  { "url": "http://i.imgur.com/ilui2.png", "title": "A Parafox." },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/73eenz/your_addon_tab_groups_has_been_discontinued/",
+    "title": "Your add-on Tab Groups has been discontinued! 🙀😾😿"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/imagus/?src=search",
+    "title": "Firefox 57+ compatible version of Imagus is out"
+  },
+  {
+    "url": "https://i.imgur.com/YhJ8fE8.png",
+    "title": "Nightly is now tagging non-WebExtensions as \"LEGACY\""
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2015/04/09/firefox-for-android-crosses-100-million-downloads/",
+    "title": "Firefox for Android Crosses 100 Million Downloads"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/",
+    "title": "Greasemonkey webextension released"
+  },
+  {
+    "url": "https://www.netmarketshare.com/browser-market-share.aspx?qprid=1&qpcustomb=0&qpsp=198&qpnp=25&qptimeframe=M",
+    "title": "NetMarketShare shows Firefox at the highest percentage in the last two years - 12.32%"
+  },
+  {
+    "url": "https://www.nytimes.com/2017/01/31/technology/ad-blocking-internet.html?mabReward=A3&recp=0&action=click&pgtype=Homepage&region=CColumn&module=Recommendation&src=rechp&WT.nav=RecEngine&_r=0",
+    "title": "Use of Ad-Blocking Software Rises by 30% Worldwide"
+  },
+  {
+    "url": "http://techblog.netflix.com/2015/12/html5-video-is-now-supported-in-firefox.html",
+    "title": "The Netflix Tech Blog: HTML5 Video is now supported in Firefox"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/12/11/firefox-64-0-release-information/",
+    "title": "Firefox 64.0 Release Information - gHacks Tech News"
+  },
+  {
+    "url": "https://www.mozilla.org/firefox/57.0.2/releasenotes/",
+    "title": "Firefox — Notes (57.0.2)"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/blocked/i1523",
+    "title": "The Web of Trust (WOT) Add-on has been blocked due to security and privacy issues"
+  },
+  {
+    "url": "https://blog.mozilla.org/addons/2015/08/21/the-future-of-developing-firefox-add-ons/",
+    "title": "The Future of Developing Firefox Add-ons"
+  },
+  {
+    "url": "http://arstechnica.com/information-technology/2015/07/windows-10-upgrade-resets-your-default-browser-to-edge-mozilla-is-very-unhappy/",
+    "title": "Windows 10 upgrade resets your default browser to Edge; Mozilla is very unhappy | Ars Technica"
+  },
+  {
+    "url": "https://www.ghacks.net/2019/01/30/skypes-for-web-does-not-support-firefox/",
+    "title": "Skype's for Web does not support Firefox - gHacks Tech News"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/10/calls-between-javascript-and-webassembly-are-finally-fast-%F0%9F%8E%89/",
+    "title": "Calls between JavaScript and WebAssembly are finally fast 🎉 – Mozilla Hacks - the Web developer blog"
+  },
+  {
+    "url": "https://www.zdnet.com/article/firefox-62-appears-as-mozilla-ends-support-for-windows-xp/",
+    "title": "Firefox 62 appears as Mozilla ends support for Windows XP | ZDNet"
+  },
+  {
+    "url": "https://www.phoronix.com/scan.php?page=news_item&px=Firefox-59-Wayland-Possibility",
+    "title": "Firefox 59 Might Ship With Working Wayland Support"
+  },
+  {
+    "url": "http://imgur.com/a/PFGSa",
+    "title": "Google Taking Steps to Counter Firefox's Change of Default Search Engines"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/10/introducing-opus-1-3/",
+    "title": "Introducing Opus 1.3 – Mozilla Hacks - the Web developer blog"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9ewvb7/firefox_logo_concept_by_mark_forge/",
+    "title": "Firefox logo concept by Mark Forge"
+  },
+  {
+    "url": "https://www.reddit.com/r/privacy/comments/8t2x93/the_internet_is_angry_protest_for_net_neutrality/",
+    "title": "The Internet is Angry: Protest for Net Neutrality on June 26th • r/privacy"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/63lgn5/thank_you_firefox_for_proper_tabs_on_the_ipad/",
+    "title": "Thank You Firefox for Proper Tabs on the iPad!"
+  },
+  {
+    "url": "https://boingboing.net/2017/01/30/google-quietly-makes-optiona.html",
+    "title": "Google quietly makes \"optional\" web DRM mandatory in Chrome (x-post /r/Chrome)"
+  },
+  {
+    "url": "https://vimeo.com/167239422",
+    "title": "Firefox is finally getting dimmed find!"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2016/05/10/you-can-help-build-the-future-of-firefox-with-the-new-test-pilot-program/",
+    "title": "You Can Help Build the Future of Firefox with the New Test Pilot Program"
+  },
+  {
+    "url": "http://imgur.com/HIEdj",
+    "title": "So... this has been possible for four years and nobody told me?"
+  },
+  {
+    "url": "https://www.mozilla.org/firefox/61.0.1/releasenotes/",
+    "title": "Firefox 61.0.1 got released (desktop only) - fixes some page loading issues, blank new tab page & more..."
+  },
+  {
+    "url": "https://vote.webbyawards.com/PublicVoting#/2018/podcasts-digital-audio/features/best-branded-podcast-or-segment",
+    "title": "Mozilla's podcast is nominated for a Webby Award!"
+  },
+  {
+    "url": "https://www.yubico.com/2017/09/firefox-nightly-enables-support-fido-u2f-security-keys/",
+    "title": "Firefox Nightly enables support for FIDO U2F Security Keys"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6bojw2/bet_you_didnt_know_there_was_a_third_option_on/",
+    "title": "Bet you didn't know there was a third option on the feedback page all along :p"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/06/07/mozilla-needs-to-make-up-its-mind/",
+    "title": "Mozilla needs to make up its mind"
+  },
+  {
+    "url": "https://www.downthemall.net/delays/",
+    "title": "DownThemAll WebExtension is delayed"
+  },
+  {
+    "url": "https://blog.mozilla.org/addons/2016/08/02/multi-process-firefox-and-add-ons-a-call-to-action/",
+    "title": "Multi-process Firefox and Add-ons: A Call to Action"
+  },
+  {
+    "url": "https://blog.mozilla.org/data/2018/01/26/improving-privacy-without-breaking-the-web/",
+    "title": "Improving privacy without breaking the web"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/75docu/wow_just_found_abouthealthreport_interesting_stuff/",
+    "title": "Wow, just found about:healthreport. Interesting stuff!"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/10/29/firefox-50-delayed/",
+    "title": "Firefox 50 delayed by a week; will ship with noticeable start-up improvements, especially for users with several add-ons"
+  },
+  {
+    "url": "http://i.imgur.com/sNxqkca.png",
+    "title": "Another release another icon I can remove from the toolbar"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/beta/all/",
+    "title": "64-bit now available for Firefox Beta"
+  },
+  {
+    "url": "http://i.imgur.com/q4XoC9Y.jpg",
+    "title": "Thank you Firefox for being pretty much the only browser that can render fonts properly on Windows"
+  },
+  {
+    "url": "http://imgur.com/MrypD36",
+    "title": "The new MEGA says Firefox isn't good enough?"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/09/12/microsoft-intercepting-firefox-chrome-installation-on-windows-10/",
+    "title": "Microsoft intercepting Firefox and Chrome installation on Windows 10 - gHacks"
+  },
+  {
+    "url": "https://github.com/mozilla/infernyx",
+    "title": "The Tiles on Mozilla Firefox's \"New Tab\" page record the time, IP Address, and useragent of anyone that clicks on them to the Infernyx server. LPT: Just because something is opensource does not mean it is privacy friendly."
+  },
+  {
+    "url": "https://arstechnica.com/gadgets/2018/04/google-chromes-major-redesign-shows-a-lighter-rounder-ui/",
+    "title": "Chrome is becoming a Firefox clone (/s)"
+  },
+  {
+    "url": "https://youtu.be/cEzrFYG0114",
+    "title": "Switch from Chrome to Firefox in less than 30 seconds"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/01/16/firefox-to-convert-old-youtube-flash-code-to-html5-video/",
+    "title": "Firefox to convert old YouTube Flash code to HTML5 Video"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/06/28/mozilla-removes-option-to-change-new-tab-page-from-firefox/",
+    "title": "Mozilla removes option to change New Tab Page from Firefox"
+  },
+  {
+    "url": "https://www.omgubuntu.co.uk/2018/08/out-of-process-extensions-firefox-linux",
+    "title": "Firefox is (Finally) Bringing Out-of-Process Extensions to Linux"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/02/how-to-build-your-own-private-smart-home-with-a-raspberry-pi-and-mozillas-things-gateway/",
+    "title": "How to build your own private smart home with a Raspberry Pi and Mozilla’s Things Gateway"
+  },
+  {
+    "url": "https://hackademix.net/2017/11/14/double-noscript/",
+    "title": "Double NoScript"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/12/02/mozilla-is-doing-well-financially/",
+    "title": "Mozilla is doing well financially (2015)"
+  },
+  {
+    "url": "http://www.techrepublic.com/article/firefox-gains-serious-speed-and-reliability-and-loses-some-bloat/",
+    "title": "Firefox gains serious speed and reliability and loses some bloat - TechRepublic"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/07/30/mozilla-to-launch-64-bit-firefox-41-to-stable-channel/",
+    "title": "Mozilla to release 64 -bit Firefox to stable channel in version 41"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/a24td2/why_firefox_63_is_doing_this_on_linux/",
+    "title": "Why Firefox 63 is doing this on Linux?"
+  },
+  {
+    "url": "https://discourse.mozilla-community.org/t/massive-review-spam-from-anonymous-users/14499/2?u=particle",
+    "title": "AMO (Mozilla add-on store) is now allowing any star reviews with no feedback from mobile users with no account needed. Add-ons are now receiving a mass of review spam with no valuable feedback for developers and interested users."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5pk7m2/the_real_firefox/",
+    "title": "The real Firefox"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/72jvm3/i_just_noticed_how_well_firefox_is_with_gtk/",
+    "title": "I just noticed how well Firefox is with GTK+ themes now."
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2019/01/15/evolving-firefoxs-culture-of-experimentation-a-thank-you-from-the-test-pilot-program/",
+    "title": "Evolving Firefox’s Culture of Experimentation: A Thank You from the Test Pilot Program – The Mozilla Blog"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/afkqzx/why_does_firefox_not_load_pages_as_in_app_browser/",
+    "title": "why does Firefox not load pages as in app browser?"
+  },
+  {
+    "url": "https://blog.torproject.org/new-alpha-release-tor-browser-android",
+    "title": "First official release of the Tor Browser for Android"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8y6o6z/on_this_day_two_years_ago_i_brought_this_cat_home/",
+    "title": "On this day two years ago I brought this cat home. Now I realize it looks like Firefox logo! Should have named him Firecat"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/mozilla-fixes-severe-flaw-in-firefox-ui-that-leads-to-remote-code-execution/",
+    "title": "Mozilla Fixes Severe Flaw in Firefox UI That Leads to Remote Code Execution"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-to-get-a-better-password-manager/",
+    "title": "Firefox to Get a Better Password Manager"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/591o0b/spaceballs_reference_in_the_firefox_video_controls/",
+    "title": "Spaceballs reference in the Firefox video controls. 😂"
+  },
+  {
+    "url": "http://www.ghacks.net/2014/07/12/mozilla-plans-release-electrolysis-multi-process-architecture-firefox-36/",
+    "title": "Mozilla plans to release Electrolysis (multi-process architecture) with Firefox 36"
+  },
+  {
+    "url": "http://i.imgur.com/xa0RgZD.png",
+    "title": "Dear Mozilla, I would like to have this in Firefox."
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/buster-captcha-solver/",
+    "title": "Buster – New CAPTCHA solver extension for humans and monsters 🦊"
+  },
+  {
+    "url": "https://www.zdnet.com/article/google-is-raiding-firefox-for-chromes-next-ui-features/",
+    "title": "Google is raiding Firefox for Chrome's next UI features | ZDNet"
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/email-tabs/",
+    "title": "Sharing links via email just got easier thanks to Email Tabs – The Firefox Frontier"
+  },
+  {
+    "url": "https://i.imgur.com/52ayLDR.png",
+    "title": "Since when did Windows 10 ask feedback for Firefox ?"
+  },
+  {
+    "url": "https://www.heise.de/newsticker/meldung/Kommentar-RSS-ist-tot-und-das-ist-eine-Schande-4127128.html",
+    "title": "RSS is dead and that's a shame"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6vyhx8/the_burst_has_finally_landed/",
+    "title": "The Burst has finally landed..."
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/tab-groups-panorama/",
+    "title": "Tab Groups Alternative released!"
+  },
+  {
+    "url": "http://i.imgur.com/cI4dw.jpg",
+    "title": "That's why, Firefox is so RAM fat, Developers spoiled so much!"
+  },
+  {
+    "url": "https://hensm.github.io/fx_cast/",
+    "title": "Chromecast Support for Firefox"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/fights-for-you/",
+    "title": "Firefox Fights For You. We keep your data safe, never sold."
+  },
+  {
+    "url": "https://www.gijsk.com/blog/2018/10/firefox-removes-core-product-support-for-rss-atom-feeds/",
+    "title": "Firefox removes core product support for RSS/Atom feeds"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/04/22/firefox-notes-get-a-big-update-with-multi-note-support/",
+    "title": "Firefox Notes get a big update with multi-note support"
+  },
+  {
+    "url": "https://twitter.com/ehsanakhgari/status/972224912634064896",
+    "title": "Are you tired of seeing in-page popups?"
+  },
+  { "url": "https://i.imgur.com/S563F7W.gifv", "title": "This is fine." },
+  {
+    "url": "http://www.omgubuntu.co.uk/2017/08/firefox-client-side-decoration-coming-soon",
+    "title": "Firefox using Client Side Decoration on Linux"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/11/04/browser-history-sniffing-is-still-a-thing/",
+    "title": "Browser history sniffing is still a thing"
+  },
+  {
+    "url": "https://nakedsecurity.sophos.com/2018/11/02/popular-browsers-made-to-cough-up-browsing-history/",
+    "title": "Popular browsers made to cough up browsing history"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/76sojy/dear_mozilla_dont_let_it_die/",
+    "title": "Dear Mozilla, Don't Let It Die!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6rswb8/even_though_i_disabled_sending_anonymous_data_in/",
+    "title": "Even though I disabled sending anonymous data in KeeFox (KeePass Firefox extension) it is still doing a lot of requests in the background to the anonymousstats.keefox.org. And under two hours it made more than 300 queries. Is there anything wrong with such behaviour?"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5cs8mv/help_sorry_but_is_it_possible_to_get_this_as_a/",
+    "title": "\"Help\" Sorry, but is it possible to get this as a standalone image for wallpaper?"
+  },
+  {
+    "url": "http://i.imgur.com/AIxYzl9.png",
+    "title": "Life of a Firefox user (from @wycats)"
+  },
+  {
+    "url": "https://medium.com/firefox-ux/written-by-amy-lee-eric-pang-79c2474d10b4",
+    "title": "Firefox has a motion team?! Yes we do!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6zjf5s/uh/",
+    "title": "Uh..."
+  },
+  {
+    "url": "https://github.com/gorhill/uMatrix/releases/tag/1.0.1b4",
+    "title": "uMatrix is now available as a pure Webextension!"
+  },
+  {
+    "url": "https://www.cnet.com/special-reports/mozilla-firefox-fights-back-against-google-chrome/",
+    "title": "Firefox fights back"
+  },
+  {
+    "url": "http://www.netmarketshare.com/?201504",
+    "title": "Mozilla Firefox market share grows for the first time since August"
+  },
+  {
+    "url": "http://www.ghacks.net/2014/10/03/yes-64-bit-firefox-for-windows-on-its-way/",
+    "title": "Yes! 64-bit Firefox for Windows on its way"
+  },
+  {
+    "url": "http://www.theverge.com/2013/3/9/4084710/mozilla-wont-bring-firefox-to-ios-until-apple-relaxes-third-party-stance",
+    "title": "Mozilla won't bring Firefox to iOS until it can use its own rendering engine"
+  },
+  {
+    "url": "http://i.imgur.com/mdWWR.png",
+    "title": "It's really the little things. [Firefox Beta Installation]"
+  },
+  {
+    "url": "https://www.howtogeek.com/fyi/mozilla-says-it-didnt-make-any-money-from-booking.com/",
+    "title": "Mozilla Says It Didn’t Make Any Money From Booking.com"
+  },
+  {
+    "url": "https://blog.mozilla.org/futurereleases/2018/10/22/testing-new-ways-to-keep-you-safe-online/",
+    "title": "Testing new ways to keep you safe online – Future Releases"
+  },
+  {
+    "url": "https://www.reddit.com/r/assholedesign/comments/7xvdkk/google_removed_the_view_image_button_on_google/",
+    "title": "Google removed the view image button from Google Images. Is there some workaround for Firefox?"
+  },
+  {
+    "url": "https://blog.mozilla.org/addons/2018/01/26/extensions-firefox-59/",
+    "title": "Extensions in Firefox 59"
+  },
+  {
+    "url": "http://www.downthemall.net/progress/",
+    "title": "DownThemAll Lite may be coming to Firefox (& Chrome)"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5kosu1/new_mozilla_firefox_start_page/",
+    "title": "New Mozilla Firefox start page"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2016/11/17/introducing-firefox-focus-a-free-fast-and-easy-to-use-private-browser-for-ios/",
+    "title": "Introducing Firefox Focus – a free, fast and easy to use private browser for iOS"
+  },
+  {
+    "url": "https://github.com/mozilla-mobile/firefox-ios/pull/4044",
+    "title": "Dark Theme Coming to Firefox for iOS this week!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7hc470/they_forgot_to_update_the_new_private_window_icon/",
+    "title": "they forgot to update the \"New private window\" icon (and the Open new tab & Open new window probably should get updated too)"
+  },
+  {
+    "url": "https://medium.com/firefox-ux/whats-new-in-firefox-preferences-54391f92971a",
+    "title": "What’s new in Firefox Preferences"
+  },
+  {
+    "url": "https://www.theinquirer.net/inquirer/news/3012791/protonmail-welcomes-eus-google-fine-says-search-giants-practices-almost-put-it-out-of-business",
+    "title": "ProtonMail lauds Google's EU fine after falling victim to firm's shady search practices - Firm says decision means no other firm will have to relive its 'nightmare scenario' - \"For nearly a year, Google was hiding ProtonMail from search results for queries such as secure email and 'encrypted email'\""
+  },
+  {
+    "url": "http://nakedsecurity.sophos.com/2013/09/23/firefox-burns-chrome-in-our-trustworthy-browser-poll/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+nakedsecurity+%28Naked+Security+-+Sophos%29",
+    "title": "Firefox burns Chrome in our trustworthy browser poll | Naked Security"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=ht5GqZ_ukIg",
+    "title": "Firefox 63.0b4 chew up >20% of a 3.2GHz CPU when I move the mouse or hover over top sites thumbnails. Does it log my mouse movements or what?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/12/20/firefox-is-now-on-amazon-fire-tv-happy-holiday-watching/",
+    "title": "Firefox is Now on Amazon Fire TV"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2017/12/using-the-new-theming-api-in-firefox/",
+    "title": "Using the new theming API in Firefox"
+  },
+  {
+    "url": "http://robert.ocallahan.org/2017/12/maintaining-independent-browser-is.html",
+    "title": "Maintaining An Independent Browser Is Incredibly Expensive"
+  },
+  {
+    "url": "http://www.reuters.com/article/us-usa-internet/fcc-plans-to-vote-to-overturn-u-s-net-neutrality-rules-in-december-sources-idUSKBN1DG00H?utm_campaign=trueAnthem:+Trending+Content&utm_content=5a0d063e04d30148b0cd52dc&utm_medium=trueAnthem&utm_source=twitter",
+    "title": "FCC plans to vote to overturn U.S. net neutrality rules in December: sources"
+  },
+  {
+    "url": "https://github.com/Synzvato/decentraleyes/releases/tag/v2.0.0beta2",
+    "title": "Decentraleyes webextension now available for Firefox 56 onwards"
+  },
+  {
+    "url": "https://imgur.com/5gbxHE4",
+    "title": "Firefox Focus app icon on play store looks pretty cool"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6cgawm/i_love_my_firefox_even_more/",
+    "title": "🍪 I love my Firefox even more"
+  },
+  {
+    "url": "https://mspoweruser.com/firefox-52-will-last-version-firefox-windows-xp-vista/",
+    "title": "Firefox 52 will be the last version of Firefox for Windows XP and Vista"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/11/30/firefoxs-tracking-protection-feature-gets-a-boost-soon/",
+    "title": "Firefox's Tracking Protection feature gets a boost soon"
+  },
+  {
+    "url": "https://blog.mozilla.org/futurereleases/2014/03/14/metro/",
+    "title": "Firefox for Metro has been cancelled"
+  },
+  {
+    "url": "http://www.zdnet.com/firefox-os-is-because-we-want-the-web-to-win-not-because-we-want-firefox-os-to-win-7000022628/",
+    "title": "'Firefox OS is because we want the web to win, not because we want Firefox OS to win' [x-post from /r/FirefoxOS]"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/firefox-gets-privacy-boost-by-disabling-proximity-and-ambient-light-sensor-apis/",
+    "title": "Firefox Gets Privacy Boost By Disabling Proximity and Ambient Light Sensor APIs"
+  },
+  {
+    "url": "https://techcrunch.com/2018/02/26/kaios/",
+    "title": "KaiOS, a feature phone platform built on the ashes of Firefox OS, adds Facebook, Twitter and Google apps"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7dri3o/so_we_meet_again_you_were_doing_so_well/",
+    "title": "So we meet again. You were doing so well."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7dfm97/todays_nightly_for_linux_now_has_client_side/",
+    "title": "Today's Nightly for Linux now has Client Side Decorations!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/755unb/exciting_times_ahead/",
+    "title": "Exciting Times Ahead."
+  },
+  {
+    "url": "https://d3vv6lp55qjaqc.cloudfront.net/items/2a1J2x1x201d1K2f2C1d/firefox-nightly-wallpaper-1920x1080.png",
+    "title": "Nightly Wallpaper"
+  },
+  {
+    "url": "http://www.ghacks.net/2017/03/24/here-is-the-first-mockup-screenshot-of-firefox-57s-new-design/",
+    "title": "Here is the first mockup screenshot of Firefox 57's new design"
+  },
+  {
+    "url": "http://arstechnica.com/security/2015/04/new-firefox-version-says-might-as-well-to-encrypting-all-web-traffic/",
+    "title": "New Firefox version says “might as well” to encrypting all Web traffic"
+  },
+  {
+    "url": "https://blog.mozilla.org/addons/2018/07/05/extensions-in-firefox-62/",
+    "title": "Extensions in Firefox 62"
+  },
+  {
+    "url": "https://twitter.com/gorhill/status/934835662985064448",
+    "title": "uMatrix is incompatible with NoScript 10: NoScript uses script-src 'none' which unfortunately starves the webRequest API, preventing uMatrix from seeing/reporting all network requests. Any webRequest-using extension may end up crippled like this."
+  },
+  {
+    "url": "https://groups.google.com/forum/#!topic/mozilla.dev.platform/H_Sl_-hCF5w",
+    "title": "Stylo is now the default on Nightly!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5hv4qs/the_advertisements_are_getting_smart_facebook_btw/",
+    "title": "The advertisements are getting smart.. (Facebook btw)"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2016/09/02/fighting-back-against-secrecy-orders/",
+    "title": "Mozilla today is joining a coalition of technology companies, including Apple, Lithium, and Twilio, in filing an amicus brief in support of Microsoft’s case against the indiscriminate use of gag orders."
+  },
+  {
+    "url": "http://www.ghacks.net/2015/06/11/finally-mozilla-adds-working-html5-video-autoplay-blocking-to-firefox/",
+    "title": "Mozilla adds working HTML5 Video autoplay blocking to Firefox"
+  },
+  {
+    "url": "https://www.mozilla.org/firefox/33.0/releasenotes/",
+    "title": "Firefox — Notes (33.0)"
+  },
+  {
+    "url": "https://blog.mozilla.org/nnethercote/2014/05/14/adblock-pluss-effect-on-firefoxs-memory-usage/",
+    "title": "AdBlock Plus’s effect on Firefox’s memory usage"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/61.0.2/releasenotes/",
+    "title": "Firefox 61.0.2 got released (desktop and android) with some minor bug fixes"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/05/07/privacy-possum-is-privacy-badger-on-steroids/",
+    "title": "Privacy Possum is Privacy Badger on Steroids"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/12/12/early-returns-on-firefox-quantum-point-to-growth/",
+    "title": "Early Returns on Firefox Quantum Point to Growth – The Mozilla Blog"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7d5mb9/chrome_vs_firefox_with_the_same_tabs_open_and/",
+    "title": "Chrome VS Firefox with the same tabs open and chrome having more plugins enabled. Why is Firefox using abysmally more memory?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/09/11/copyright-vote-change-europes-internet/",
+    "title": "A Copyright Vote That Could Change the EU’s Internet – The Mozilla Blog"
+  },
+  {
+    "url": "https://noscript.net/?ver=2.9.5.1&prev=2.9.0.14",
+    "title": "NoScript's latest update - Full multi-process (e10s) compatibility."
+  },
+  {
+    "url": "http://i.imgur.com/7evJkum.jpg",
+    "title": "Addons.Mozilla.Org (AMO) New Look."
+  },
+  {
+    "url": "http://i.imgur.com/izohFxb.jpg",
+    "title": "The generic homepage gave me a good heartwarming vibe today in light of recent events. Thank you, Mozilla."
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1172126",
+    "title": "Bug: Remove Pocket integration"
+  },
+  { "url": "http://i.imgur.com/tptAR5e.jpg", "title": "Firefox doughnuts!" },
+  {
+    "url": "http://i.imgur.com/gBZ03Cd.jpg",
+    "title": "CNN behind on their Firefox updates... [x-post from r/techsupportgore]"
+  },
+  {
+    "url": "http://www.mozilla.com/",
+    "title": "Firefox 8 is officially released."
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/63.0a1/releasenotes/#note-787678",
+    "title": "The build infrastructure of Firefox on Windows moved to the Clang tool chain, bringing important performance gains"
+  },
+  {
+    "url": "http://news.softpedia.com/news/mozilla-firefox-51-0-promises-webgl-2-support-less-cpu-usage-and-flac-playback-510274.shtml",
+    "title": "Mozilla Firefox 51.0 Promises WebGL 2 Support, Less CPU Usage, and FLAC Playback"
+  },
+  {
+    "url": "https://advocacy.mozilla.org/encrypt/2/?ref=2016_Encryption&utm_campaign=2016_Encryption&utm_source=newsletter-mofo&utm_medium=email&utm_content=SSBtext1",
+    "title": "Mozilla has started a series of videos \"designed to help demystify privacy online\", this is the first of them."
+  },
+  {
+    "url": "https://blog.cloudflare.com/announcing-1111/",
+    "title": "CloudFare announced a privacy-centric DNS service that's now live. I wonder when Firefox will support DNS over HTTPS..."
+  },
+  {
+    "url": "https://medium.com/firefox-test-pilot/fun-with-themes-in-firefox-54a3180f16e4",
+    "title": "Fun with Themes in Firefox – Firefox Test Pilot"
+  },
+  {
+    "url": "https://s18.postimg.org/sgzvqys1l/firefoxhobbes.png",
+    "title": "For anyone who wants it, this is a high-resolution version of the Hobbes Nightly icon, extracted directly from the Mac app file."
+  },
+  {
+    "url": "https://framapic.org/xI3MldSvwNwF/yZ7d2HhUqEfH.png",
+    "title": "Little fluffy red pandas building the Qunatum, Photon, Electrolysis, WebExtension giant robot Firefox"
+  },
+  {
+    "url": "http://gfycat.com/MadeupHighlevelHoneyeater",
+    "title": "Firefox 41 lets you take screenshots of DOM nodes"
+  },
+  {
+    "url": "http://arstechnica.co.uk/information-technology/2015/07/big-changes-are-coming-to-firefox-to-win-back-users-and-developers/",
+    "title": "Big changes are coming to Firefox, to win back users and developers"
+  },
+  {
+    "url": "http://imgur.com/a/kmPoz",
+    "title": "My new favorite button. Reader view is great."
+  },
+  {
+    "url": "https://i.imgur.com/mv5VsbM.jpg",
+    "title": "When I read that Google has proposed changes to Chromium which would disable uBlock Origin"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6wmpd0/new_privacy_related_preference_in_nightly/",
+    "title": "New privacy related preference in Nightly"
+  },
+  {
+    "url": "https://www.netmarketshare.com/browser-market-share.aspx?qprid=1&qpcustomb=0&qpsp=192&qpnp=24&qptimeframe=M",
+    "title": "Netmarketshare: Firefox market share is at 12.22% (constant growth since August)"
+  },
+  {
+    "url": "https://developer.mozilla.org/Firefox/Multiprocess_Firefox",
+    "title": "Multiprocess Firefox"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/developer/",
+    "title": "Firefox Developer Edition"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/65.0/releasenotes/",
+    "title": "Firefox 65.0 released"
+  },
+  {
+    "url": "http://www.erahm.org/2017/09/25/firefox-memory-usage-in-the-quantum-era/",
+    "title": "Firefox Memory Usage in the Quantum Era"
+  },
+  {
+    "url": "https://blog.mozilla.org/security/2017/09/13/verified-cryptography-firefox-57/",
+    "title": "Verified cryptography for Firefox 57"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/59.0.1/releasenotes/",
+    "title": "Firefox — Notes (59.0.1)"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/panorama-view/",
+    "title": "Guess who I bumped into on AMO? Panorama View! v57 compatible! Experimental!"
+  },
+  {
+    "url": "https://www.servethehome.com/firefox-is-eating-your-ssd-here-is-how-to-fix-it/",
+    "title": "Firefox is eating your SSD - here is how to fix it"
+  },
+  {
+    "url": "http://imgur.com/331gLvn",
+    "title": "Firefox 42 Easter Egg - Hitchhiker's Guide to the Galaxy"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2015/07/30/an-open-letter-to-microsofts-ceo-dont-roll-back-the-clock-on-choice-and-control/",
+    "title": "An Open Letter to Microsoft’s CEO: Don’t Roll Back the Clock on Choice and Control"
+  },
+  {
+    "url": "https://support.mozilla.org/en-US/kb/whats-new-firefox-focus-android-version-8?as=u&utm_source=inproduct",
+    "title": "What's new in Firefox Focus for Android (version 8)"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/10/28/this-is-firefoxs-overhauled-privacy-interface/",
+    "title": "This is Firefox's overhauled Privacy interface - gHacks Tech News"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7a0p6x/dont_forget_to_update_the_installer_icon_for_v57/",
+    "title": "Don't forget to update the installer icon for v57!!!"
+  },
+  {
+    "url": "https://gfycat.com/ScaryHalfHerald",
+    "title": "TIL Holding the back button gives you quick access to history"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/42.0/releasenotes/",
+    "title": "Firefox — Notes (42.0)"
+  },
+  {
+    "url": "http://i.imgur.com/xSEiIBz.png?1",
+    "title": "Add this bookmark to be able to type \"r subreddit\" and redirect to \"http://www.reddit.com/r/subreddit\". Also works with u and /u/."
+  },
+  {
+    "url": "http://lifehacker.com/hola-better-internet-sells-your-bandwidth-turning-its-1707496872",
+    "title": "Hola Better Internet Sells Your Bandwidth, Turning Its VPN into a Botnet"
+  },
+  {
+    "url": "https://hacks.mozilla.org/2018/09/focus-with-geckoview/",
+    "title": "Focus with GeckoView – Mozilla Hacks - the Web developer blog"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/863gv4/just_noticed_you_can_add_menu_shortcuts_directly/",
+    "title": "Just noticed, you can add Menu Shortcuts directly to the Title bar."
+  },
+  {
+    "url": "https://www.ghacks.net/2018/01/11/mozilla-starts-to-publish-pocket-code/",
+    "title": "Mozilla starts to publish pocket code"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6xtm69/creating_and_editing_userchromecss/",
+    "title": "Creating and Editing userChrome.css"
+  },
+  {
+    "url": "https://blog.mozilla.org/firefox/firefox-fights-for-you/",
+    "title": "Firefox fights for you – The Firefox Frontier"
+  },
+  {
+    "url": "https://i.imgur.com/XTtc2WE.png",
+    "title": "Please correct me since im not an expert but why the hell does Firefox have 5 trackers? And three of them is from Google?!?!?"
+  },
+  {
+    "url": "https://blog.bitwarden.com/bitwarden-desktop-app-released-for-windows-macos-and-linux-37de846ea421",
+    "title": "Firefox password manager BitWarden releases a desktop client"
+  },
+  {
+    "url": "https://www.howtogeek.com/334716/how-to-customize-firefoxs-user-interface-with-userchrome.css/",
+    "title": "How to Customize Firefox’s User Interface With userChrome.css"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/tag/firefox57",
+    "title": "All 2,273 WebExtensions on AMO right now"
+  },
+  {
+    "url": "http://i.imgur.com/ljjlqb4.jpg",
+    "title": "Mockup of the changes to Customize mode as part of the upcoming design refresh"
+  },
+  {
+    "url": "https://blog.mozilla.org/tanvi/2016/06/16/contextual-identities-on-the-web/",
+    "title": "Contextual Identities on the Web"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1215694",
+    "title": "This is actually happening: 1215694 – move pocket to a built-in add-on"
+  },
+  {
+    "url": "http://arstechnica.com/security/2015/10/new-zero-day-exploit-hits-fully-patched-adobe-flash/",
+    "title": "New zero-day exploit hits fully patched Adobe Flash"
+  },
+  {
+    "url": "http://i.imgur.com/Zl3bxId.png",
+    "title": "TIL (by accident) that if you hit Ctrl Shift E you'll see a grid of all your tabs plus a preview image for each. Very Neat!"
+  },
+  {
+    "url": "http://i.imgur.com/tTeHb.png",
+    "title": "New Firefox Start Page as seen in latest Nightly"
+  },
+  {
+    "url": "https://old.reddit.com/r/StallmanWasRight/comments/adve2v/how_do_we_effectively_block_google_amp/",
+    "title": "How do we effectively block google amp?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/07/10/introducing-firefoxs-first-mobile-test-pilot-experiments-lockbox-and-notes/",
+    "title": "Introducing Firefox’s First Mobile Test Pilot Experiments: Lockbox and Notes – The Mozilla Blog"
+  },
+  {
+    "url": "https://i.imgur.com/fllb57h.png",
+    "title": "Custom Rainmeter Icon for Nightly"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/7flwdf/a_dark_theme_which_suitable_for_both_dark_light/",
+    "title": "A dark theme which suitable for both dark & light"
+  },
+  {
+    "url": "http://i.imgur.com/Dnk64v6.png",
+    "title": "what a great new feature in the Firefox 42.0"
+  },
+  {
+    "url": "http://www.mozilla.org/en-US/firefox/27.0/releasenotes/",
+    "title": "Firefox 27.0 released!"
+  },
+  {
+    "url": "http://blog.mozilla.com/nnethercote/2011/08/09/firefox-7-is-lean-and-fast-2/",
+    "title": "Firefox 7 is lean and fast: Firefox 7 uses less memory than Firefox 6 (and 5 and 4): often 20% to 30% less, and sometimes as much as 50% less."
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/software/mozilla-is-adding-an-ad-blocker-to-firefox-focus-90/",
+    "title": "Mozilla is Adding an Ad Blocker to Firefox Focus 9.0"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/a3q2qw/excuse_me_wtf/",
+    "title": "Excuse me? WTF!"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/64.0beta/releasenotes/",
+    "title": "Firefox Beta 64.0 released, WebRender enabled by default for Desktop NVIDIA GPUs on Windows 10"
+  },
+  {
+    "url": "https://screenshots.firefox.com/2pfRaZQoJ8cbnaYi/null",
+    "title": "More Dark Theme progress in Nightly"
+  },
+  {
+    "url": "https://www.cnet.com/news/firefox-quantum-leader-mayo-takes-over-all-mozilla-products-in-reorg/",
+    "title": "Firefox Quantum leader takes over all Mozilla products - CNET"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/10/31/mozilla-removes-battery-api-in-firefox-52/",
+    "title": "Mozilla cuts website access to Battery API in Firefox 52"
+  },
+  {
+    "url": "http://i.imgur.com/irbtDjc.png",
+    "title": "Messages like these make me sad :("
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/https-everywhere/?src=search",
+    "title": "HTTPS Everywhere is on AMO as signed add-on now!"
+  },
+  { "url": "http://i.imgur.com/la1Ge.jpg", "title": "Happy Birthday Firefox" },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9l9xe5/i_have_come_a_long_way_with_firefox/",
+    "title": "I have come a long way with Firefox."
+  },
+  {
+    "url": "https://imgur.com/iemMWos",
+    "title": "Why is this a thing? How do I get around it with Firefox mobile?"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/07/11/royalty-free-web-video-codecs/",
+    "title": "[Blog Mozilla] Modern codecs like AV1 can bring better quality video to the open web"
+  },
+  {
+    "url": "https://twitter.com/FxTestPilot/status/937892770865393665",
+    "title": "Teaser screenshot featuring Firefox with native(?) tiling"
+  },
+  {
+    "url": "https://www.howtogeek.com/334111/firefox-quantum-isnt-just-copying-chrome/",
+    "title": "Firefox Quantum Isn’t Just “Copying” Chrome: It’s Much More Powerful"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/73ak7p/another_reason_to_use_ublock_origin_over_adblock/",
+    "title": "Another reason to use uBlock Origin over Adblock Plus."
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2016/09/28/three-new-test-pilot-experiments/",
+    "title": "Firefox’s Test Pilot Program Launches Three New Experimental Features"
+  },
+  {
+    "url": "https://www.raymond.cc/blog/10-ad-blocking-extensions-tested-for-best-performance/view-all/",
+    "title": "10 Ad Blocking Extensions Tested for Best Performance"
+  },
+  {
+    "url": "https://wiki.mozilla.org/Addons/Extension_Signing",
+    "title": "Firefox 42 will not allow unsigned extensions"
+  },
+  {
+    "url": "http://arstechnica.com/open-source/news/2012/04/mozilla-may-make-flash-click-to-play-by-default-in-future-firefox.ars?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+arstechnica%2Findex+%28Ars+Technica+-+Featured+Content%29",
+    "title": "Mozilla may make Flash click-to-play by default in future Firefox"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/07/10/ghostery-rewards-launches-in-germany/",
+    "title": "Ghostery now displaying Ads in Germany, marketed as \"Rewards\" program"
+  },
+  {
+    "url": "https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication",
+    "title": "Secure your Firefox Account with two-step authentication"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=RTQybYbR1ek&feature=youtu.be",
+    "title": "Does Mozilla Firefox Hold The Answer To Better Internet Security?"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/78x8xa/privacy_badger_asking_store_unlimited_amount_of/",
+    "title": "Privacy Badger asking \"Store unlimited amount of client-side data\". isn't that little bit too much?"
+  },
+  {
+    "url": "https://i.imgur.com/pr61DCS.png",
+    "title": "Another \"new\" Nightly icon"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6t899j/todays_nightly_icon/",
+    "title": "Today's Nightly icon"
+  },
+  {
+    "url": "http://www.zdnet.com/article/google-and-mozillas-message-to-av-and-security-firms-stop-trashing-https/",
+    "title": "Google and Mozilla's message to AV and security firms: Stop trashing HTTPS. Researchers call out antivirus and security appliance vendors for dangerous SSL inspection practices."
+  },
+  {
+    "url": "https://addons.mozilla.org/firefox/addon/chrome-store-foxified/",
+    "title": "Chrome Store Foxified - install Google Chrome Store addons for Firefox"
+  },
+  {
+    "url": "http://www.computerworld.com/s/article/9237847/Ad_industry_threatens_Firefox_users_with_more_ads_if_Mozilla_moves_on_tracking_plans",
+    "title": "Ad industry threatens Firefox users with more ads if Mozilla moves on tracking plans"
+  },
+  {
+    "url": "http://i.imgur.com/NoUBs.jpg",
+    "title": "The only browser worth trusting with the new installer options(landing soon)"
+  },
+  {
+    "url": "https://support.mozilla.org/en-US/kb/whats-new-firefox-focus-android-version-8",
+    "title": "Firefox Focus for Android now has Google Safe Browsing integrated without a way to disable it."
+  },
+  {
+    "url": "https://twitter.com/SenatorMenendez/status/1019991102647136258",
+    "title": "An open Internet is the great equalizer that lets the smallest of startups compete with the largest corporations - without having to pay for priority access online."
+  },
+  {
+    "url": "https://www.engadget.com/2018/06/12/firefox-12-ios-file-downloads-easier-syncing/",
+    "title": "Firefox 12 for iOS includes file downloads and easier syncing"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/78o5xs/mega_cloud_storage_service_firefox_has_an/",
+    "title": "Mega (cloud storage service): \"Firefox has an insufficient buffer to decrypt data in the browser\", use Google Chrome instead"
+  },
+  {
+    "url": "http://imgur.com/a/lWYru",
+    "title": "Some Firefox Photon mockup Images"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/5o5u4k/developer_edition_theme_is_now_called_compact/",
+    "title": "Developer Edition Theme is now called Compact Light/Dark in Nightly"
+  },
+  {
+    "url": "https://twitter.com/gorhill/status/694662117895639040",
+    "title": "Gorhill: tracking on Dailymotion"
+  },
+  {
+    "url": "https://xkcd.com/619/",
+    "title": "I think many will relate... (with or without flash)"
+  },
+  {
+    "url": "http://bitsup.blogspot.com/2015/02/http2-is-live-in-firefox.html",
+    "title": "HTTP/2 is live in Firefox"
+  },
+  {
+    "url": "http://www.theregister.co.uk/2015/02/02/google_amazon_taboola_microsoft_adplock_plus_unblock/",
+    "title": "Internet giants Google, Amazon, Microsoft and Taboola have reportedly paid AdBlock Plus to allow their ads to pass through its filter software."
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/aap8wn/fullscreen_in_ff_is_notentirely_opaque_is_this_by/",
+    "title": "Fullscreen in FF is not....entirely opaque? Is this by design?"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/academics-discover-new-bypasses-for-browser-tracking-protections-and-ad-blockers/",
+    "title": "Academics Discover New Bypasses for Browser Tracking Protections and Ad Blockers"
+  },
+  {
+    "url": "https://old.reddit.com/r/BountySource/comments/8gox5c/50000_bounty_posted_by_education_first_for/",
+    "title": "$50,000 bounty posted by Education First for Mozilla WebRTC Issue"
+  },
+  {
+    "url": "https://arp242.net/weblog/browsers-conflict-interest.html",
+    "title": "Browsers and conflicts of interests"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1278282",
+    "title": "Firefox nightly drops GTK2"
+  },
+  {
+    "url": "https://www.howtogeek.com/333047/how-to-migrate-all-your-data-from-chrome-to-firefox/",
+    "title": "How to Migrate All Your Data From Chrome to Firefox"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/security/advisories/mfsa2017-08/",
+    "title": "Less than 24 hours after disclosure at pwn2own, security fix released in version 52.0.1"
+  },
+  {
+    "url": "http://www.ghacks.net/2015/06/30/firefox-41-ships-with-massive-memory-improvements-for-adblock-plus/",
+    "title": "Firefox 41 ships with massive memory improvements for Adblock Plus"
+  },
+  {
+    "url": "http://i.imgur.com/CBJ1iXP.png",
+    "title": "Mozilla, fix the play icon."
+  },
+  {
+    "url": "http://www.ghacks.net/2014/06/10/firefox-30-released-find-new/",
+    "title": "Firefox 30 released: Find out what is new"
+  },
+  {
+    "url": "http://www.mozilla.org/en-US/firefox/new/",
+    "title": "Firefox 19.0 is live"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/11/14/firefox-monitor-launches-in-26-languages-and-adds-new-desktop-browser-feature/",
+    "title": "Firefox Monitor Launches in 26 Languages and Adds New Desktop Browser Feature – The Mozilla Blog"
+  },
+  {
+    "url": "https://chuttenblog.wordpress.com/2018/06/27/when-exactly-does-a-firefox-user-update-anyway/",
+    "title": "When, Exactly, does a Firefox User Update, Anyway?"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/54.0.1/releasenotes/",
+    "title": "Firefox — Notes (54.0.1)"
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/vivaldifox/",
+    "title": "Initial release of VivaldiFox with auto-colouring and custom themes"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/37.0/releasenotes/",
+    "title": "Firefox — Notes (37.0)"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/25.0/releasenotes/",
+    "title": "Firefox 25 is now available"
+  },
+  { "url": "http://i.imgur.com/zHkWY.jpg", "title": "Lego Firefox Logo" },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/ahu704/fenix_now_can_load_mozillaorg_website/",
+    "title": "Fenix now can load mozilla.org website!"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9zdlq9/seriously_outperformed_v8_spidermonkey_makes_the/",
+    "title": "Seriously outperformed V8, SpiderMonkey makes the case for GeckoView"
+  },
+  {
+    "url": "https://blog.mozilla.org/addons/2018/07/12/upcoming-changes-for-themes/",
+    "title": "Upcoming changes for themes"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/73blx0/top_sites_inconsistentpoor_style/",
+    "title": "Top Sites Inconsistent/Poor Style"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/09/06/mozilla-washington-post-reinventing-online-comments/",
+    "title": "Mozilla and the Washington Post Are Reinventing Online Comments"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/6i213a/i_remember_when_firefox_40_was_a_huge_update/",
+    "title": "I remember when Firefox 4.0 was a huge update."
+  },
+  {
+    "url": "http://gadgets.ndtv.com/apps/news/firefox-will-try-to-show-you-saved-archive-of-a-page-instead-of-404-error-869482",
+    "title": "Firefox Will Try to Show You Saved Archive of a Page Instead of 404 Error"
+  },
+  {
+    "url": "http://www.theverge.com/2016/6/20/11975514/microsoft-chrome-edge-browser-battery-life-tests",
+    "title": "Microsoft shows how bad Chrome is for your laptop's battery - FF 3rd"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/03/29/mozilla-system-add-ons-controls/",
+    "title": "Please Mozilla, give me control over System Add-ons"
+  },
+  {
+    "url": "https://www.gnu.gl/blog/Posts/multiple-vulnerabilities-in-pocket/",
+    "title": "Multiple Vulnerabilities in Pocket"
+  },
+  {
+    "url": "https://github.com/gorhill/uBlock/wiki/Firefox-version:-benchmarking-memory-footprint",
+    "title": "uBlock Firefox version: benchmarking memory footprint"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/09/23/firefox-65-new-cookie-jar-policy-to-block-tracking/",
+    "title": "Firefox 65: New Cookie Jar Policy to block tracking - gHacks"
+  },
+  {
+    "url": "https://twitter.com/pcwalton/status/971475785616797698",
+    "title": "Firefox rastorizing and rendering glyphs on the GPU using Pathfinder and WebRender"
+  },
+  {
+    "url": "https://groups.google.com/forum/#!msg/mozilla.dev.security.policy/Oaeqtddo_Cw/lN-Pp6h1AAAJ",
+    "title": "Google and Mozilla planning to distrust all Symantec Certificates"
+  },
+  {
+    "url": "https://github.com/Timvde/UserChrome-Tweaks",
+    "title": "I made a git repository to share userChrome.css tweaks. Pull requests welcome!"
+  },
+  {
+    "url": "https://www.ghacks.net/2017/08/30/firefox-webextensions-may-identify-you-on-the-internet/",
+    "title": "Firefox WebExtensions may be used to identify you on the Internet"
+  },
+  {
+    "url": "https://dolske.wordpress.com/2017/08/13/photon-engineering-newsletter-12/",
+    "title": "Photon Engineering Newsletter #12"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/11/24/noscript-multi-process-compatible/",
+    "title": "NoScript is multi-process compatible now"
+  },
+  {
+    "url": "http://www.ghacks.net/2016/11/11/firefox-52-nightly-quantum-compositor-has-landed/",
+    "title": "Firefox 52 Nightly: Quantum Compositor has landed"
+  },
+  {
+    "url": "http://www.sitepoint.com/browser-trends-may-2016-firefox-finally-overtakes-ie/",
+    "title": "May 2016: Firefox Finally Overtakes IE"
+  },
+  {
+    "url": "http://venturebeat.com/2015/06/09/mozilla-responds-to-firefox-user-backlash-over-pocket-integration/",
+    "title": "Mozilla responds to Firefox user backlash over Pocket integration"
+  },
+  {
+    "url": "http://limpet.net/mbrubeck/2012/10/26/mozilla-ie10-cake.html",
+    "title": "Congratulations to the IE10 team, love Mozilla -- with cake!"
+  },
+  {
+    "url": "http://www.washingtonpost.com/business/technology/firefox-google-renew-search-deal/2011/12/20/gIQAdUKg7O_story.html",
+    "title": ". Mozilla announced Tuesday that it and Google have agreed to renew an agreement that makes Google the default search engine in the Firefox browser."
+  },
+  {
+    "url": "https://www.reddit.com/r/Android/comments/9cvn39/psa_firefox_deletes_all_downloaded_files_when_its/",
+    "title": "PSA: Firefox deletes all downloaded files, when it's uninstalled"
+  },
+  {
+    "url": "https://changecopyright.org/",
+    "title": "Stand Up for Copyright in the Digital Age (EU)"
+  },
+  {
+    "url": "https://color.firefox.com/?theme=XQAAAALtAAAAAAAAAABBqYhm849SCiazH1KEGccwS-xNVAWBvL-5sLCGcUreQUNkXPsQ5ysXI7_X1OXyxzeap-MaXWPGaopg_aK3cFyj7d5T8BmV3UFTU778fAyoaI_r7zKr20SWayOem0M0Bc4L3HNlcd8j7IitWpgqaqMVIJj8-KHocKvIAuljwz-loX8cYquRIGMqhdgfSZbekr-vDmwUpVztS5FBWQCPRXVWTLr_oBBaD5qFr6Gpqd3p_Zg3AA",
+    "title": "[Color] Firefox XP"
+  },
+  {
+    "url": "https://mozilla.invisionapp.com/share/8GHTWQGUD5P#/screens",
+    "title": "Tab Manager & Multi-tab select coming soon to Firefox."
+  },
+  {
+    "url": "http://people.mozilla.org/~jgruen/test-pilot-art/testpilot-bg@2x.jpg",
+    "title": "Test Pilot Desktop Background"
+  },
+  {
+    "url": "http://www.networkworld.com/article/3021113/security/forbes-malware-ad-blocker-advertisements.html",
+    "title": "How Forbes inadvertently proved the anti-malware value of ad blocke"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/8xz4tg/can_we_flag_content_provided_by_pocket/",
+    "title": "Can we flag content provided by Pocket?"
+  },
+  {
+    "url": "https://www.stonetemple.com/mobile-vs-desktop-usage-study/",
+    "title": "Mobile web access will reach 2/3 of all traffic by the end of 2018. Yet Mozilla still treats the mobile browser like an afterthought. Why?"
+  },
+  {
+    "url": "https://mikeconley.ca/blog/2018/04/18/firefox-performance-update-6/",
+    "title": "Firefox Performance Update #6"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/89eftf/thats_how_i_like_it/",
+    "title": "That's how I like it!!"
+  },
+  {
+    "url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1423725",
+    "title": "[TabGroups] The tab hiding api is completed and it has landed on Nightly 59"
+  },
+  {
+    "url": "https://imgur.com/gallery/0xbkDgy",
+    "title": "When you're trying to help Mozilla with voice identification and it hits you with some hard s*it..."
+  },
+  {
+    "url": "https://addons.mozilla.org/en-US/firefox/addon/lastpass-password-manager/",
+    "title": "LastPass WebExtension Released!"
+  },
+  {
+    "url": "https://blog.mozilla.org/services/2016/10/06/device-management-coming-to-your-firefox-account/",
+    "title": "Device Management Coming to Firefox Sync"
+  },
+  {
+    "url": "https://mspoweruser.com/firefox-66-will-bring-a-solution-for-pages-lost-to-tab-overload/",
+    "title": "Firefox 66 will bring a solution for pages lost to tab overload - MSPoweruser"
+  },
+  {
+    "url": "https://www.theverge.com/circuitbreaker/2018/12/6/18129678/qualcomm-8cx-mozilla-firefox-windows-10-64-bit-arm",
+    "title": "Firefox running on a Qualcomm 8cx-powered PC feels surprisingly decent"
+  },
+  {
+    "url": "https://addons.mozilla.org/firefox/addon/youtube-pro4/",
+    "title": "User copied the original Iridium for YouTube add-on and posted under a different name, be wary of possible danger"
+  },
+  {
+    "url": "https://groups.google.com/forum/#!topic/mozilla.dev.platform/kaZojmUTd3M",
+    "title": "Firefox 57 going to Beta/DevEdition earlier!"
+  },
+  { "url": "http://imgur.com/iL1ZfOq", "title": "Got my menu set up" },
+  {
+    "url": "https://blog.mozilla.org/addons/2016/04/29/webextensions-in-firefox-48/",
+    "title": "WebExtensions in Firefox 48"
+  },
+  {
+    "url": "http://techcrunch.com/2015/12/08/mozilla-will-stop-developing-and-selling-firefox-os-smartphones/?ncid=rss&utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+Techcrunch+%28TechCrunch%29",
+    "title": "Mozilla Will Stop Developing And Selling Firefox OS Smartphones"
+  },
+  {
+    "url": "http://www.mozilla.org/en-US/firefox/all.html",
+    "title": "Firefox 11.0 Released"
+  },
+  {
+    "url": "https://www.ghacks.net/2018/11/27/mozilla-changes-firefoxs-warn-on-quit-logic/",
+    "title": "Mozilla changes Firefox's Warn on Quit logic - gHacks Tech News"
+  },
+  {
+    "url": "https://www.chromestory.com/2018/11/how-to-enable-tab-groups-in-chrome/",
+    "title": "Chrome to Get \"Tab Groups\" to Organize Tabs Better like Firefox had and discontinued - Chrome Story"
+  },
+  {
+    "url": "https://old.reddit.com/r/firefox/comments/9atk02/so_what_theme_am_i_using_then/",
+    "title": "so what theme am I using then?"
+  },
+  {
+    "url": "https://www.reddit.com/r/foxes/comments/69eni0/finally_finished_putting_together_this_low_poly/",
+    "title": "Thought you guys could appreciate this. Paper fox"
+  },
 
-    {"url":"https://www.congress.gov/bill/115th-congress/house-bill/4585","title":"Congress has set out a bill to stop the FCC taking away our internet. PLEASE SPREAD THIS AS MUCH AS YOU CAN."},
-    {"url":"https://motherboard.vice.com/en_us/article/wjzjv9/net-neutrality-fraud-ny-attorney-general-investigation?utm_source=mbtwitter","title":"The FCC Is Blocking a Law Enforcement Investigation Into Net Neutrality Comment Fraud"},
-    {"url":"https://www.alexa.com/topsites/countries/US","title":"Reddit just passed Facebook as #3 most popular website in US"},
-    {"url":"http://static.techspot.com/news/71865-congressmen-demand-investigation-fcc-chairman-ajit-pai-sinclair.html","title":"Congressmen demand investigation of FCC Chairman Ajit Pai, Sinclair Broadcast Group"},
-    {"url":"https://arstechnica.com/tech-policy/2018/08/verizon-throttled-fire-departments-unlimited-data-during-calif-wildfire/","title":"Verizon throttled fire department’s “unlimited” data during Calif. wildfire"},
-    {"url":"https://townhall.com/columnists/bobbarr/2017/12/20/massive-fraud-in-net-neutrality-process-is-a-crime-deserving-of-justice-department-attention-n2424724","title":"Massive Fraud in Net Neutrality Process is a Crime Deserving of Justice Department Attention"},
-    {"url":"https://www.thelocal.fr/20171228/french-lawsuit-launched-against-apple-for-alleged-crime-of-slowing-down-iphones","title":"A lawsuit against Apple is launched in France, one of the only countries where planned obsolescence is explicitly illegal"},
-    {"url":"https://motherboard.vice.com/en_us/article/j5vn9k/apple-blocking-net-neutrality-app-wehe","title":"Apple Is Blocking an App That Detects Net Neutrality Violations From the App Store: Apple told a university professor his app \"has no direct benefits to the user.\""},
-    {"url":"http://www.netimperative.com/2019/01/netflix-would-lose-57-of-their-subscribers-if-they-added-commercials/","title":"Netflix ‘would lose 57% of their subscribers if they added commercials’"},
-    {"url":"https://www.macrumors.com/2017/12/21/apple-lawsuit-slowing-down-old-iphone-models/","title":"Apple Being Sued for 'Purposefully Slowing Down Older iPhone Models'"},
-    {"url":"https://www.c-span.org/video/?445642-1/us-senate-vote-reinstating-net-neutrality-rules-3pm&live=","title":"Senate votes in favor of overturning FCC on Net Neutrality"},
-    {"url":"https://motherboard.vice.com/en_us/article/d3q45v/bittorrent-usage-increases-netflix-streaming-sites","title":"The rise of Netflix competitors has pushed consumers back toward piracy - BitTorrent usage has bounced back because there's too many streaming services, and too much exclusive content."},
-    {"url":"https://www.allflicks.net/74-of-netflix-subscribers-would-rather-cancel-their-subscription-than-see-ads/","title":"74% of Netflix Subscribers Would Rather Cancel Their Subscription Than See Ads"},
-    {"url":"https://www.inquisitr.com/4790689/reddits-the_donald-was-one-of-the-biggest-havens-for-russian-propaganda-during-2016-election-analysis-finds/","title":"Reddit’s The_Donald Was One Of The Biggest Havens For Russian Propaganda During 2016 Election, Analysis Finds"},
-    {"url":"https://www.dailydot.com/layer8/ajit-pai-resign-petition-white-house-we-the-people/","title":"White House must now respond to the people asking for FCC Chairman Ajit Pai’s resignation over net neutrality"},
-    {"url":"https://www.techdirt.com/articles/20171030/11255938512/dead-people-mysteriously-support-fccs-attack-net-neutrality.shtml","title":"Dead People Mysteriously Support The FCC's Attack On Net Neutrality"},
-    {"url":"http://resistancereport.com/news/cards-humanity-creator-just-pledged-buy-publish-congresss-browser-history/","title":"‘Cards Against Humanity’ Creator Just Pledged To Buy and Publish Congress’s Browser History"},
-    {"url":"https://www.nytimes.com/2017/12/14/technology/net-neutrality-repeal-vote.html","title":"F.C.C. Repeals Net Neutrality Rules"},
-    {"url":"https://www.inverse.com/article/39994-nebraska-proposes-reinstate-net-neutrality","title":"Nebraska Introduces Law to Re-Instate Net Neutrality - ‘The “Internet Neutrality Act” (LB856) would restore the former federal rules and prohibit broadband internet service providers from “limiting or restricting access to web sites, applications, or content.”’"},
-    {"url":"https://techcrunch.com/2018/08/06/fcc-admits-it-was-never-actually-hacked/","title":"FCC admits it was never actually hacked."},
-    {"url":"https://news.sky.com/story/scientist-stephen-hawking-has-died-aged-76-11289119","title":"Stephen Hawking has passed away at 76 years old"},
-    {"url":"https://www.techdirt.com/articles/20171120/11253438653/fcc-plan-to-use-thanksgiving-to-hide-attack-net-neutrality-vastly-underestimates-looming-backlash.shtml","title":"FCC Plan To Use Thanksgiving To 'Hide' Its Attack On Net Neutrality Vastly Underestimates The Looming Backlash"},
-    {"url":"https://www.inquisitr.com/4685704/fcc-has-reportedly-been-using-dead-peoples-social-media-accounts-to-spread-propaganda/","title":"FCC Has Reportedly Been Using Dead People’s Social Media Accounts To Spread Propaganda: The FCC might be making pro-repeal comments on your or even your dead relatives' behalf."},
-    {"url":"https://www.techdirt.com/articles/20171122/09473038669/fcc-releases-net-neutrality-killing-order-hopes-youre-too-busy-cooking-turkey-to-read-it.shtml","title":"FCC Releases Net Neutrality Killing Order, Hopes You're Too Busy Cooking Turkey To Read It"},
-    {"url":"https://www.thewrap.com/netflix-comes-out-in-support-for-net-neutrality-tells-fcc-we-will-see-you-in-court/","title":"Netflix comes out for net neutrality, tells FCC 'We will see you in court'."},
-    {"url":"http://www.verizonprotests.com/","title":"The new chairman of the FCC was a top lawyer at Verizon. Now he's calling for a vote to kill net neutrality. We’re protesting at retail stores across the U.S. to demand that Congress stop Verizon’s FCC from destroying the Internet as we know it."},
-    {"url":"https://motherboard.vice.com/en_us/article/mb4ezy/top-voting-machine-vendor-admits-it-installed-remote-access-software-on-systems-sold-to-states","title":"Top Voting Machine Vendor Admits It Installed Remote-Access Software on Systems Sold to States - Remote-access software and modems on election equipment 'is the worst decision for security short of leaving ballot boxes on a Moscow street corner.'"},
-    {"url":"https://arstechnica.com/tech-policy/2018/09/ajit-pai-calls-californias-net-neutrality-rules-illegal/","title":"Ajit Pai calls California’s net neutrality rules “illegal” - California senator replies: The rules are \"necessary and legal because Chairman Pai abdicated his responsibility to ensure an open Internet\""},
-    {"url":"http://thehill.com/policy/technology/363110-group-of-senators-calls-on-fcc-to-delay-net-neutrality-vote","title":"Group of 27 Dem senators calls on FCC to delay net neutrality vote"},
-    {"url":"https://www.techdirt.com/articles/20171214/09383738811/two-separate-studies-show-that-vast-majority-people-who-said-they-support-ajit-pais-plan-were-fake.shtml","title":"Two Separate Studies Show That The Vast Majority Of People Who Said They Support Ajit Pai's Plan... Were Fake"},
-    {"url":"https://medium.com/@fightfortheftr/i-know-youre-tired-of-hearing-about-net-neutrality-ba2ef1c51939","title":"I know you’re tired of hearing about net neutrality. I’m tired of writing about it. But the Senate is about to vote, and it’s time to pay attention"},
-    {"url":"https://www.cnbc.com/2017/11/22/n-y-attorney-general-slams-the-fcc-over-net-neutrality-investigation.html","title":"New York attorney general slams the FCC for 'refusal to assist' investigation into fake comments about net neutrality"},
-    {"url":"http://www.miaminewtimes.com/news/miami-frustrated-with-fpl-after-hurricane-irma-9666311","title":"Due to excessive lobbying from FPL, Florida residents without power due to the hurricane are not permitted to use their own solar panels"},
-    {"url":"http://www.popularmechanics.com/how-to/blog/what-you-need-to-know-about-rosettas-mission-to-land-on-a-comet-17416959","title":"It's now official - Humanity has landed a probe on a comet!"},
-    {"url":"https://gizmodo.com/35-states-tell-the-fcc-to-get-off-its-ass-and-do-someth-1829637040","title":"35 States Tell the FCC to Get Off Its Ass and Do Something About Spoofed Robocalls"},
-    {"url":"https://nationaleconomicseditorial.com/2017/11/27/americans-fiber-optic-internet/","title":"Americans Taxed $400 Billion For Fiber Optic Internet That Doesn’t Exist"},
-    {"url":"https://arstechnica.com/science/2018/07/elon-musk-making-kid-sized-submarine-to-rescue-teens-in-thailand-cave/","title":"Elon Musk making “kid-sized submarine” to rescue teens in Thailand cave: \"Construction complete in about 8 hours,\" the tech billionaire tweeted Saturday."},
-    {"url":"https://www.meo.pt/internet/internet-movel/telemovel/pacotes-com-telemovel","title":"In Portugal, with no net neutrality, internet providers are starting to split the net into packages. This is the future of the Internet if the FCC gets its way. It's not theory. It's happening already."},
-    {"url":"https://www.theverge.com/2018/4/16/17245010/elizabeth-pierce-fraud-charges-bdac-fcc-ajit-pai","title":"Broadband advisor picked by FCC Chairman Ajit Pai arrested on fraud charges"},
-    {"url":"https://www.usatoday.com/story/news/politics/2018/04/04/facebook-gave-most-contributions-house-committee-question-zuckerberg-also-got-most-contributions-fac/486313002/","title":"Facebook Donated to 46 of 55 Members on Committee that Will Question Zuckerberg"},
-    {"url":"http://www.theverge.com/2017/3/29/15100620/congress-fcc-isp-web-browsing-privacy-fire-sale?utm_source=dlvr.it&utm_medium=twitter","title":"The 265 members of Congress who sold you out to ISPs, and how much it cost to buy them - The Verge"},
-    {"url":"http://www.adweek.com/creativity/burger-king-deviously-explains-net-neutrality-by-making-people-wait-longer-for-whoppers/","title":"Burger King Deviously Explains Net Neutrality by Making People Wait Longer for Whoppers"},
-    {"url":"http://time.com/4770205/john-oliver-fcc-net-neutrality/","title":"John Oliver Is Calling on You to Save Net Neutrality, Again"},
-    {"url":"https://www.theregister.co.uk/2018/02/07/fidelity_astroturf_city_broadband/","title":"Mystery Website Attacking City-Run Broadband Was Run by a Telecom Company"},
-    {"url":"https://venturebeat.com/2017/09/14/chrome-will-no-longer-autoplay-content-with-sound-in-january-2018/","title":"Chrome will no longer autoplay content with sound in January 2018."},
-    {"url":"https://motherboard.vice.com/en_us/article/scotus-cell-location-privacy-op-ed","title":"The Supreme Court Phone Location Case Will Decide the Future of Privacy - Later this year, the Supreme Court will decide if police can track a person’s cell phone location without a warrant. It's the most important privacy case in a generation."},
-    {"url":"https://www.cnet.com/news/lyft-will-offer-discounted-rides-to-voters-during-midterm-elections/","title":"Lyft will offer discounted rides to voters during US midterm elections. Voters in underserved communities will get free rides."},
-    {"url":"https://act.represent.us/sign/Net_neutrality_lobbying_Comcast_Verizon/","title":"Comcast, Verizon, and AT&T have spent $572 MILLION on lobbying the government to kill net neutrality"},
-    {"url":"https://arstechnica.com/tech-policy/2017/12/ajit-pai-claims-net-neutrality-hurt-small-isps-but-data-says-otherwise/","title":"Ajit Pai claims net neutrality hurt small ISPs, but data says otherwise."},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/03/today-senators-will-vote-allow-isps-sell-internet-history-end-fcc-online-privacy-rules/","title":"Today, Senators will vote to allow ISPs to sell your internet history and end FCC online privacy rules"},
-    {"url":"https://www.thenation.com/article/if-trumps-fcc-repeals-net-neutrality-elites-will-rule-the-internet-and-the-future/","title":"If Trump’s FCC Repeals Net Neutrality, Elites Will Rule the Internet—and the Future"},
-    {"url":"https://www.nytimes.com/2018/02/15/technology/fcc-sinclair-ajit-pai.html?smid=tw-share","title":"Ajit Pai Being Investigated for Improper Coordination With Sinclair Broadcasting"},
-    {"url":"http://cnbc.com/id/105437071","title":"Twitter permanently bans Alex Jones and Infowars accounts"},
-    {"url":"https://www.buzzfeednews.com/article/kevincollier/feds-investigation-net-neutrality-comments","title":"The Feds Are Now Investigating The Millions Of Anti-Net Neutrality Comments Filed With Stolen Identities"},
-    {"url":"https://medium.com/@fightfortheftr/at-t-paid-200-000-to-trumps-attorney-michael-cohen-and-the-payments-stop-right-after-trump-s-3356687f4827","title":"AT&T paid $200,000 to Trump’s attorney, Michael Cohen, and the payments stop right after Trump’s FCC pick Ajit Pai repealed net neutrality"},
-    {"url":"http://www.slate.com/blogs/future_tense/2017/11/28/comcast_wants_you_to_think_it_supports_net_neutrality_while_it_pushes_for.html","title":"Comcast Wants You to Think It Supports Net Neutrality While It Pushes for Net Neutrality to Be Destroyed"},
-    {"url":"http://www.dslreports.com/shownews/26-Senators-Support-CRA-Reversal-of-FCC-Attack-on-Net-Neutrality-140933","title":"26 Senators Support CRA Reversal of FCC Attack on Net Neutrality: an uphill effort to reverse the FCC's repeal via the Congressional Review Act (CRA) is gaining steam."},
-    {"url":"https://motherboard.vice.com/en_us/article/wj3gx5/house-democrats-who-havent-supported-net-neutrality-yet-have-all-taken-money-from-telecoms","title":"House Democrats Who Haven’t Supported Net Neutrality Yet Have All Taken Money from Telecoms - The deadline to pass the piece of legislation that would allow Congress to overturn the repeal of net neutrality is quickly approaching, yet many Democrats are staying mum."},
-    {"url":"https://gizmodo.com/leaked-video-shows-fcc-chair-ajit-pai-roasting-himself-1821134881","title":"Leaked Video Shows FCC Chair Ajit Pai Roasting Himself With 'Jokes' About Being a Verizon Shill"},
-    {"url":"http://www.dslreports.com/shownews/ATT-Met-With-Ajit-Pai-in-Barcelona-Shortly-After-Cohen-Payment-141844","title":"AT&T Met With Ajit Pai in Barcelona Shortly After Cohen Payment"},
-    {"url":"http://news.sky.com/story/mps-formally-request-zuckerberg-answer-questions-11297936","title":"Mark Zuckerberg has been sent a formal request to appear before MPs and answer questions regarding a growing scandal about user data"},
-    {"url":"https://www.windowscentral.com/microsoft-please-stop-trying-install-third-party-apps-my-clean-windows-10-install","title":"Hey, Microsoft, stop installing third-party apps on clean Windows 10 installs!"},
-    {"url":"https://blog.mozilla.org/blog/2018/02/12/update-mozilla-will-re-file-suit-fcc-protect-net-neutrality/","title":"Update: Mozilla Will Re-File Suit Against FCC to Protect Net Neutrality"},
-    {"url":"http://www.thesocialmemo.org/2015/07/reddit-ceo-ellen-pao-vast-majority-of.html","title":"Reddit CEO Ellen Pao: \"The Vast Majority of Reddit Users are Uninterested in\" Victoria Taylor, Subreddits Going Private"},
-    {"url":"https://techcrunch.com/2018/05/23/representatives-rip-fcc-chairman-pais-lack-of-candor-and-double-down-on-net-neutrality-questions/","title":"13 Congress members tell Pai to stop giving evasive answers about net neutrality"},
-    {"url":"https://www.theguardian.com/technology/2019/jan/01/amazon-fulfillment-center-warehouse-employees-union-new-york-minnesota","title":"'We are not robots': Amazon warehouse employees push to unionize"},
-    {"url":"https://gizmodo.com/gop-data-firm-accidentally-leaks-personal-details-of-ne-1796211612","title":"GOP Data Firm Accidentally Leaks Personal Details of Nearly 200 Million American Voters"},
-    {"url":"https://thenextweb.com/opinion/2018/06/11/rip-net-neutrality-ajit-pais-fuck-you-to-the-american-people-becomes-official/","title":"RIP net neutrality: Ajit Pai's 'fuck you' to the American people becomes official."},
-    {"url":"https://arstechnica.com/tech-policy/2018/12/comcast-rejected-by-small-town-residents-vote-for-municipal-fiber-instead/","title":"Comcast rejected by small town—residents vote for municipal fiber instead"},
-    {"url":"https://www.techdirt.com/articles/20180605/07420739969/e-mails-show-fcc-made-up-ddos-attack-to-downplay-john-oliver-effect.shtml","title":"E-Mails Show FCC Made Up DDOS Attack To Downplay The 'John Oliver Effect'"},
-    {"url":"https://www.nbcnews.com/technology/exclusive-your-employer-may-share-your-salary-equifax-might-sell-1B8173066","title":"Equifax sells your salary history to debt collectors, financial service companies, and prospective employers"},
-    {"url":"https://motherboard.vice.com/en_us/article/43a5kg/80-percent-net-neutrality-comments-bots-astroturfing","title":"More Than 80% Of All Net Neutrality Comments Were Sent By Bots, Researchers Say - 95% of all organic comments favored net neutrality"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/03/17-house-representatives-introduced-bill-let-telecoms-sell-personal-internet-history/","title":"These are the 17 House Representatives that introduced a bill to let telecoms sell your personal internet history"},
-    {"url":"http://www.dslreports.com/shownews/the-fcc-is-preparing-to-weaken-the-definition-of-broadband-140987","title":"The FCC is preparing to weaken the definition of broadband - \"Under this new proposal, any area able to obtain wireless speeds of at least 10 Mbps down, 1 Mbps would be deemed good enough for American consumers.\""},
-    {"url":"https://www.bloomberg.com/news/articles/2017-11-15/killing-net-neutrality-rules-is-said-readied-for-december-vote","title":"FCC Plans December Vote to Kill Net Neutrality Rules"},
-    {"url":"https://medium.com/@fightfortheftr/documents-show-ajit-pai-met-with-at-t-execs-right-after-the-company-started-paying-michael-cohen-6d5f0eac0557","title":"Documents show Ajit Pai met with AT&T execs right after the company started paying Michael Cohen. Congress needs to overturn the FCC’s net neutrality repeal and investigate."},
-    {"url":"https://medium.com/@fightfortheftr/this-is-kind-of-a-big-deal-c23def03f0f8","title":"This is kind of a big deal. Two Senators, one Republican and one Democrat, who were impersonated during net neutrality repeal, call on FCC to investigate millions of fake comments"},
-    {"url":"http://www.businessinsider.com/intel-ceo-krzanich-sold-shares-after-company-was-informed-of-chip-flaw-2018-1","title":"Intel was aware of the chip vulnerability when its CEO sold off $24 million in company stock"},
-    {"url":"https://www.theregister.co.uk/2018/05/08/equifax_breach_may_2018/","title":"Equifax reveals full horror of its data breach - \"146.6 million names, 146.6 million dates of birth, 145.5 million social security numbers, 99 million address information and 209,000 payment cards (number and expiry date). There were also 38,000 US drivers' licenses and 3,200 passport details.\""},
-    {"url":"https://www.engadget.com/2017/12/15/fcc-harlem-shake-video-fair-use/","title":"The FCC's 'Harlem Shake' video may violate copyright law -- The agency apparently didn't get permission to use the song"},
-    {"url":"http://mashable.com/2017/11/02/facebook-phony-accounts-admission/?utm_campaign=Feed%3A+Mashable+%28Mashable%29&utm_cid=Mash-Prod-RSS-Feedburner-All-Partial&utm_source=feedburner&utm_medium=feed","title":"Facebook admits to nearly as many fake or clone accounts as the U.S. population"},
-    {"url":"https://www.theverge.com/2017/3/29/15100620/congress-fcc-isp-web-browsing-privacy-fire-sale?platform=hootsuite","title":"The 265 members of Congress who sold you out to ISPs"},
-    {"url":"https://www.theregister.co.uk/2018/12/20/facebook_disaster/","title":"Mark Zuckerberg did everything in his power to avoid Facebook becoming the next MySpace – but forgot one crucial detail… No one likes a lying asshole"},
-    {"url":"http://www.dslreports.com/shownews/Lawmaker-Disturbed-That-FCC-Made-up-DDOS-Lied-to-Press-141963","title":"Lawmaker 'Disturbed' That FCC Made up DDOS, Lied to Press"},
-    {"url":"https://medium.com/@fightfortheftr/reddit-its-friday-5d3811f1a6a8","title":"It’s Friday. The FCC just announced that the repeal of net neutrality will officially go into effect in one month unless Congress stops it. The Senate will vote on Wednesday. We have a job to do."},
-    {"url":"http://www.dslreports.com/shownews/GOP-Busted-Using-Cable-Lobbyist-Net-Neutrality-Talking-Points-139647","title":"GOP Busted Using Cable Lobbyist Net Neutrality Talking Points: email from GOP leadership... included a \"toolkit\" (pdf) of misleading or outright false talking points that, among other things, attempted to portray net neutrality as \"anti-consumer.\""},
-    {"url":"https://gizmodo.com/a-new-senate-bill-would-hit-robocallers-with-a-10-000-1830502632?rev=1542409291860&utm_campaign=socialflow_gizmodo_twitter&utm_source=gizmodo_twitter&utm_medium=socialflow","title":"A New Senate Bill Would Hit Robocallers With Up to a $10,000 Fine for Every Call"},
-    {"url":"https://www.theverge.com/2017/5/10/15610744/anti-net-neutrality-fake-comments-identities","title":"Fake anti-net neutrality comments were sent to the FCC using names and addresses of people without their consent"},
-    {"url":"https://www.commondreams.org/news/2017/12/12/warning-against-abdication-duty-senators-demand-fcc-abandon-net-neutrality-vote","title":"Warning Against Abdication of Duty, Senators Demand FCC Abandon Net Neutrality Vote: Ajit Pai's plan would leave the U.S. with a \"gaping consumer protection void,\" say 39 senators"},
-    {"url":"https://www.eff.org/deeplinks/2017/03/congress-debates-reversing-course-decades-consumer-privacy-protections?link_id=8&can_id=a6c53469a0fc060cebd5a72ffb651879&source=email-vote-is-tomorrow-6&email_referrer=vote-is-tomorrow-6&email_subject=vote-is-tomorrow","title":"Tomorrow the privacy of everyone in the United States will be on the floor of the House of Representatives. Call your rep right now. Tell them to vote NO on repealing the FCC broadband privacy rules."},
-    {"url":"https://www.theverge.com/2018/7/10/17556144/fcc-charge-225-review-complaints","title":"The FCC wants to charge you $225 to review your complaints"},
-    {"url":"https://arstechnica.com/tech-policy/2017/07/lawsuit-seeks-ajit-pais-net-neutrality-talks-with-internet-providers/#p3","title":"FCC getting sued for hiding from & ignoring multiple FoIA requests"},
-    {"url":"https://www.techdirt.com/articles/20180615/07410640047/ajit-pai-now-trying-to-pretend-that-everybody-supported-net-neutrality-repeal.shtml","title":"Ajit Pai Now Trying To Pretend That Everybody Supported Net Neutrality Repeal"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/03/minnesota-senate-votes-58-9-pass-internet-privacy-protections-response-repeal-fcc-privacy-rules/","title":"Minnesota Senate votes 58-9 to pass Internet privacy protections in response to repeal of FCC privacy rules"},
-    {"url":"http://www.bbc.co.uk/news/science-environment-42969020","title":"Elon Musk's Falcon Heavy rocket launches successfully"},
-    {"url":"https://medium.com/@fightfortheftr/remember-that-california-democrat-who-helped-at-t-eviscerate-a-net-neutrality-bill-there-e02636427958","title":"Remember that California Democrat who helped AT&T eviscerate a net neutrality bill? We’re gonna put up a billboard in his district"},
-    {"url":"http://thehill.com/policy/technology/376844-washington-becomes-first-state-to-pass-net-neutrality-law-after-fcc-repeal","title":"Washington becomes first state to pass net neutrality law after FCC repeal - “All Washingtonians should enjoy equal and unfettered access to the educational, social and economic power of the Internet. I’m proud that we're helping lead the way to preserve these rules, ensuring a level playing field.”"},
-    {"url":"https://www.forbes.com/sites/jaymcgregor/2017/02/20/reddit-is-being-manipulated-by-big-financial-services-companies/#4739b1054c92","title":"Reddit is being regularly manipulated by large financial services companies with fake accounts and fake upvotes via seemingly ordinary internet marketing agencies. -Forbes"},
-    {"url":"https://www.eff.org/deeplinks/2017/06/dont-be-fooled-comcast-pr-machine-it-has-always-opposed-open-internet","title":"Don't Be Fooled by the Comcast PR Machine: It Has Always Opposed Internet Freedom"},
-    {"url":"http://www.iicom.org/events/telecommunications-and-media-forum/item/tmf-washington-2017","title":"FCC Chair Pai who is carrying out Verizon's plan to end net neutrality is speaking at Verizon headquarters tomorrow."},
-    {"url":"http://www.bloomberg.com/news/articles/2015-07-10/ellen-pao-resigns-as-reddit-interim-ceo-after-user-revolt","title":"Ellen Pao Resigns as Reddit Interim CEO After User Revolt"},
-    {"url":"https://news.vice.com/en_us/article/xw9n3q/we-posed-as-100-senators-to-run-ads-on-facebook-facebook-approved-all-of-them","title":"We posed as 100 Senators to run ads on Facebook. Facebook approved all of them."},
-    {"url":"http://www.engadget.com/2015/02/26/fcc-net-neutrality/","title":"FCC approves net neutrality rules, reclassifies broadband as a utility"},
-    {"url":"http://forums.xfinity.com/t5/Customer-Service/Are-you-aware-Comcast-is-injecting-400-lines-of-JavaScript-into/td-p/3009551","title":"Are you aware? Comcast is injecting 400+ lines of JavaScript into web pages."},
-    {"url":"http://www.businessinsider.com/senate-democrats-are-forcing-a-vote-on-net-neutrality-2018-1?r=US&IR=T","title":"Senate Democrats have made a brilliant move to try and save an open internet. They only need a simple majority to win this vote. While that's a long shot, there's still a good reason for them to force a vote: It will force Republican senators to take a public stand on this hot-button issue."},
-    {"url":"http://www.bloomberg.com/news/articles/2015-07-04/reddit-restores-most-of-site-after-moderator-led-blackouts","title":"Reddit CEO Pao Under Fire as Users Protest Removal of Executive"},
-    {"url":"https://medium.com/@ainiesta/how-instagram-closed-my-account-and-gave-it-to-a-football-celebrity-625a6a770eb3","title":"How Instagram closed my account and gave it to a football celebrity"},
-    {"url":"http://www.pcgamer.com/verizon-vp-jokes-at-planting-a-brainwashed-fcc-chairman-ajit-pai-says-awesome/","title":"Verizon VP jokes at planting a 'brainwashed' FCC chairman, Ajit Pai says 'awesome'"},
-    {"url":"https://www.politico.com/story/2017/11/20/net-neutrality-repeal-fcc-251824","title":"FCC to seek total repeal of net neutrality rules, sources say"},
-    {"url":"https://news.cgtn.com/news/7a49444d34557a6333566d54/share_p.html","title":"Does the world really need a new iPhone every year?Apple and other tech firms have been criticized for deliberately making products with short life spans so consumers quickly find them obsolete and resort to buying the latest model."},
-    {"url":"https://www.dailykos.com/stories/2018/2/23/1744321/-Say-goodnight-to-net-neutrality-as-AT-T-just-rolled-out-internet-fast-lanes","title":"Say goodnight to net neutrality as AT&T just rolled out 'internet fast lanes'"},
-    {"url":"https://gizmodo.com/europes-gdpr-is-killing-email-marketing-to-the-disappo-1826880645","title":"Europe's GDPR is Killing Email Marketing, to the Disappointment of No One"},
-    {"url":"https://www.digitalmusicnews.com/2018/03/07/comcast-xfinity-paypal-net-neutrality/","title":"Comcast Found ‘Accidentally’ Blocking Legitimate Sites — Including PayPal and Steam"},
-    {"url":"http://www.androidauthority.com/fcc-pai-cherry-picking-data-repeal-net-neutrality-803801/","title":"FCC Chairman Ajit Pai accused of cherry-picking data to repeal net neutrality"},
-    {"url":"https://thenextweb.com/facebook/2018/02/01/i-salute-the-1-million-north-americans-who-ditched-facebook-last-quarter/","title":"I salute the 1 million North Americans who ditched Facebook last quarter"},
-    {"url":"https://thenextweb.com/gadgets/2017/08/31/stop-trying-to-kill-the-headphone-jack/#.tnw_gg3ed6Xc","title":"Stop trying to kill the headphone jack"},
-    {"url":"https://www.vox.com/2018/4/10/17220290/mark-zuckerberg-apologize-testimony","title":"Mark Zuckerberg has been apologizing for reckless privacy violations since he was a freshman - Enough is enough."},
-    {"url":"https://www.forbes.com/sites/thomasbrewster/2019/01/14/feds-cant-force-you-to-unlock-your-iphone-with-finger-or-face-judge-rules/","title":"Feds Can't Force You To Unlock Your iPhone With Finger Or Face, Judge Rules"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/05/9-senators-proposed-bill-kill-net-neutrality-called-restoring-internet-freedom-act/","title":"These 9 Senators proposed a bill to kill net neutrality called the \"Restoring Internet Freedom Act\""},
-    {"url":"http://www.foxbusiness.com/features/2017/07/24/amazon-jacked-up-prime-day-prices-misleading-consumers-says-vendor.html","title":"Amazon jacked up Prime Day prices, misleading consumers, says vendor. We had an agreement that the suggested price of the product would be $9.99. On Amazon Prime Day the product was listed at $15.42 and then exed it out to put '$9.99 for Amazon Prime Day.'"},
-    {"url":"https://www.techdirt.com/articles/20170620/10455137631/supreme-court-says-you-cant-ban-people-internet-no-matter-what-theyve-done.shtml","title":"Supreme Court Says You Can't Ban People From The Internet, No Matter What They've Done"},
-    {"url":"https://www.fightforthefuture.org/news/2017-11-24-breaking-first-republican-lawmaker-to-publicly/","title":"First Republican lawmaker to publicly oppose the FCC’s radical net neutrality repeal"},
-    {"url":"https://motherboard.vice.com/en_us/article/wjkmbn/verizon-firefighters-join-fight-restore-net-neutrality","title":"Pissed Off by Verizon, Firefighters Join the Fight to Restore Net Neutrality - First responders join a chorus of angry Americans tired of big telecom’s nonsense."},
-    {"url":"http://www.dailydot.com/politics/anti-net-neutrality-op-eds-time-wall-street-journal/","title":"Columnists in the Wall Street Journal and TIME are publishing anti-Net Neutrality op-eds without disclosing that they're taking money from ISP's"},
-    {"url":"https://torrentfreak.com/fox-stole-a-game-clip-used-it-in-family-guy-dmcad-the-original-160520/","title":"Fox dowloaded a game clip from YouTube, used it in Family Guy and DCMA'd the original."},
-    {"url":"https://www.wired.com/story/a-new-bill-wants-jail-time-for-execs-who-hide-data-breaches/","title":"A New Bill Wants Jail Time for Execs Who Hide Data Breaches"},
-    {"url":"https://motherboard.vice.com/en_us/article/it-begins-trumps-fcc-launches-attack-on-net-neutrality-transparency-rules","title":"It Begins: Trump’s FCC Launches Attack on Net Neutrality Transparency Rules"},
-    {"url":"https://gizmodo.com/last-minute-push-to-restore-net-neutrality-stymied-by-d-1831023390","title":"Last-Minute Push to Restore Net Neutrality Stymied by Democrats Flush With Telecom Cash."},
-    {"url":"https://arstechnica.com/gaming/2018/03/how-a-norwegian-comment-section-turned-chaos-into-order-with-a-simple-quiz/","title":"How a Norwegian comment section turned chaos into order—with a simple quiz: \"Readers had to prove they read a story before they were able to comment on it.\""},
-    {"url":"http://komonews.com/news/local/washington-state-to-sue-comcast-for-100m","title":"Washington state to sue Comcast for $100M. A news release says the lawsuit accuses Comcast of \"engaging in a pattern of deceptive practices.\""},
-    {"url":"http://wesa.fm/post/pai-pai-stop-lies-pittsburghers-protest-suppport-net-neutrality#stream/0","title":"“Pai, Pai, Stop the Lies,\" Pittsburghers Protest In Suppport Of Net Neutrality"},
-    {"url":"https://www.dslreports.com/shownews/80-Cut-the-Cord-Because-Cable-TV-is-Simply-Too-Expensive-139758","title":"80% Cut the Cord Because Cable TV is Simply Too Expensive"},
-    {"url":"https://marketingland.com/study-telecoms-have-been-throttling-youtube-and-netflix-since-demise-of-net-neutrality-247346","title":"Study: Telecoms have been throttling YouTube and Netflix since demise of net neutrality"},
-    {"url":"https://arstechnica.com/tech-policy/2018/01/gop-senator-says-shell-vote-to-restore-net-neutrality-rules/","title":"GOP senator says she’ll vote to restore net neutrality rules"},
-    {"url":"https://motherboard.vice.com/en_us/article/zmqmkw/comcast-net-neutrality-investment-tax-cut","title":"Comcast announced it's spending $10 billion annually on infrastructure upgrades, which is the same amount it spent before net neutrality repeal."},
-    {"url":"https://arstechnica.com/tech-policy/2017/11/voters-reject-cable-lobby-misinformation-campaign-against-muni-broadband/","title":"Sorry, Comcast: Voters say “yes” to city-run broadband in Colorado"},
-    {"url":"https://techcrunch.com/2016/10/03/amazon-bans-incentivized-reviews-tied-to-free-or-discounted-products/","title":"Amazon bans incentivized reviews tied to free or discounted products"},
-    {"url":"https://statescoop.com/dozens-of-mayors-sign-letter-supporting-resolution-to-restore-net-neutrality","title":"Dozens of mayors sign letter supporting resolution to restore net neutrality"},
-    {"url":"https://www.washingtonpost.com/politics/ivanka-trump-used-a-personal-email-account-to-send-hundreds-of-emails-about-government-business-last-year/2018/11/19/6515d1e0-e7a1-11e8-a939-9469f1166f9d_story.html","title":"Ivanka Trump used a personal email account to send hundreds of emails about government business last year"},
-    {"url":"https://motherboard.vice.com/en_us/article/7xwknx/republican-members-of-congress-fcc-letter","title":"Here's a List of the Members of Congress Who Just Told Ajit Pai to Repeal Net Neutrality - And how much money they've taken from the telecom industry."},
-    {"url":"https://www.usatoday.com/story/tech/2018/08/25/verizon-and-t-worst-offenders-throttling-but-we-have-some-solutions/1089132002/","title":"Verizon, instead of apologizing, we have a better idea --stop throttling"},
-    {"url":"https://www.dslreports.com/shownews/New-Bill-Would-Stop-States-From-Banning-Broadband-Competition-141088","title":"New Bill Would Stop States From Banning Broadband Competition"},
-    {"url":"https://timesofindia.indiatimes.com/business/india-business/internet-to-remain-free-and-fair-in-india-govt-approves-net-neutrality/articleshow/64948838.cms?from=mdr","title":"Internet to remain free and fair in India: Govt approves Net Neutrality"},
-    {"url":"http://www.telegraph.co.uk/technology/2016/03/24/microsofts-teen-girl-ai-turns-into-a-hitler-loving-sex-robot-wit/","title":"Microsoft's 'teen girl' AI, Tay, turns into a Hitler-loving sex robot within 24 hours"},
-    {"url":"http://exstreamist.com/netflix-has-almost-4x-as-many-streaming-subscribers-as-comcast-has-cable-subscribers/","title":"Netflix Has Almost 4x as Many Streaming Subscribers as Comcast has Cable Subscribers"},
-    {"url":"https://www.fightforthefuture.org/news/2018-09-28-facebook-caught-automatically-blocking-ap-and/","title":"Facebook caught automatically blocking AP and Guardian stories about the their massive data breach"},
-    {"url":"https://gizmodo.com/do-not-i-repeat-do-not-download-onavo-facebook-s-vam-1822937825","title":"Do Not, I Repeat, Do Not Download Onavo, Facebook’s Vampiric VPN Service"},
-    {"url":"https://www.fightforthefuture.org/news/2016-10-06-yahoo-let-the-nsa-read-your-email-before-you-even/","title":"Yahoo let the NSA read your email before you even opened it. Yahoo was just revealed to be the very first US internet company to build a program, at the request of US Intelligence Services, to search every single incoming message of every single user in real time."},
-    {"url":"https://www.inverse.com/article/39671-in-the-wake-of-net-neutrality-prepare-for-internet-fast-lanes","title":"With Net Neutrality Dead, Proposed Bill Promises Internet \"Fast Lanes\" - It’s pay to browse fast in the post-net neutrality age."},
-    {"url":"https://www.extremetech.com/internet/283522-att-plans-to-fire-7000-people-despite-tax-breaks-net-neutrality-repeal","title":"AT&T plans to fire 7000 people despite tax breaks/net neutrality repeal"},
-    {"url":"https://medium.com/@Laila/here-are-the-256-representatives-that-just-voted-to-reauthorize-and-expand-unconstitutional-nsa-b5b9cceedcb3","title":"Here are the 256 representatives that just voted to reauthorize and expand unconstitutional NSA spying"},
-    {"url":"https://www.wired.com/story/san-francisco-municipal-fiber/amp","title":"San Francisco just took a huge step towards internet utopia, becoming the first major city to pledge to connect all homes and businesses to a fiber optic network"},
-    {"url":"https://www.independent.co.uk/life-style/gadgets-and-tech/news/facebook-mark-zuckerberg-quit-investor-scott-stringer-a8286451.html","title":"Billion-Dollar Facebook Investor Tells Mark Zuckerberg To Quit As Chairman"},
-    {"url":"http://www.theverge.com/2014/11/10/7185933/fcc-should-reclassify-internet-as-utility-obama-says","title":"Obama says FCC should reclassify internet as a utility"},
-    {"url":"https://qz.com/1501696/facebook-owns-instagram-and-whatsapp-so-delete-them-too/","title":"You’re not quitting Facebook if you still use Instagram and WhatsApp"},
-    {"url":"https://www.commondreams.org/news/2018/11/02/real-teeth-senators-bill-would-punish-ceos-20-years-jail-violating-consumer-privacy","title":"'Real Teeth': Senator's Bill Would Punish CEOs With Up to 20 Years in Jail for Violating Consumer Privacy Rules"},
-    {"url":"https://www.nytimes.com/2017/04/17/business/dealbook/steve-ballmer-serves-up-a-fascinating-data-trove.html?referer=","title":"Steve Ballmer Serves Up a Fascinating Data Trove - \"On Tuesday, Mr. Ballmer plans to make public... a stealth start-up... called USAFacts. The database is perhaps the first nonpartisan effort to create a fully integrated look at revenue and spending across federal, state and local governments.\""},
-    {"url":"https://torrentfreak.com/ip-address-is-not-enough-to-identify-pirate-us-court-of-appeals-rules-180828/","title":"IP Address is Not Enough to Identify Pirate, US Court of Appeals Rules"},
-    {"url":"http://www.businessinsider.com/att-gigapower-tackles-google-fiber-in-kansas-city--but-its-charging-more-for-privacy-2015-2","title":"AT&T is charging customers an extra $29 a month if they want to opt out of the company’s “Internet Preferences” program, which tracks “the webpages you visit, the time you spend on each, the links or ads you see and follow, and the search terms you enter.”"},
-    {"url":"https://www.washingtonpost.com/news/the-switch/wp/2018/01/15/the-senates-push-to-overrule-the-fcc-on-net-neutrality-now-has-50-votes-democrats-say/?utm_term=.6f21047b421a","title":"The Senate’s push to overrule the FCC on net neutrality now has 50 votes"},
-    {"url":"http://www.bbc.com/news/technology-41760968","title":"Nazi forums closed as Reddit purges 'violent content' - Reddit has closed down several extremist forums after updating its policy regarding violent content."},
-    {"url":"http://www.dslreports.com/shownews/The-FCC-is-Lying-When-It-Claims-Net-Neutrality-Hurt-Investment-140782","title":"The FCC is Lying When It Claims Net Neutrality Hurt Investment"},
-    {"url":"https://www.reuters.com/article/us-usa-internet/twenty-two-states-ask-u-s-appeals-court-to-reinstate-net-neutrality-rules-idUSKCN1L605W","title":"Twenty-two states ask U.S. appeals court to reinstate 'net neutrality' rules"},
-    {"url":"https://gizmodo.com/senators-demand-fcc-answer-for-fake-comments-after-real-1826213294","title":"Senators demand FCC answer for fake comments after realizing their identities were stolen."},
-    {"url":"https://arstechnica.com/tech-policy/2018/11/comcast-forced-to-pay-refunds-after-its-hidden-fees-hurt-customers-credit/","title":"Comcast forced to pay refunds after its hidden fees hurt customers’ credit"},
-    {"url":"https://www.bloomberg.com/news/articles/2017-10-30/record-winds-in-germany-spur-free-electricity-at-weekend-chart","title":"There Was So Much Wind Power In Germany This Weekend, Consumers Got Free Energy - Power prices turned negative as wind output reached 39,409 megawatts on Saturday, equivalent to the output of about 40 nuclear reactors."},
-    {"url":"https://www.theverge.com/2018/7/26/17615634/amazon-rekognition-aclu-mug-shot-congress-facial-recognition","title":"Amazon’s facial recognition matched 28 members of Congress to criminal mugshots"},
-    {"url":"http://uk.businessinsider.com/amazon-warehouse-workers-have-to-pee-into-bottles-2018-4","title":"Amazon warehouse workers pee into bottles because they are scared of being punished for taking a comfort break"},
-    {"url":"https://gizmodo.com/fcc-commissioner-blasts-her-own-agency-for-withhold-evi-1821133018","title":"FCC Commissioner Blasts Her Own Agency for Withholding Evidence of Fraud"},
-    {"url":"https://arstechnica.com/information-technology/2018/03/facebook-scraped-call-text-message-data-for-years-from-android-phones/","title":"Facebook scraped call, text message data for years from Android phones."},
-    {"url":"http://arstechnica.com/gadgets/2015/07/google-officially-ends-forced-google-integration-first-up-youtube/","title":"Google officially ends forced Google+ integration on YouTube"},
-    {"url":"https://www.commondreams.org/views/2017/11/19/fake-news-only-beginning-fcc-votes-let-monopolies-decide-what-local-news-you-see","title":"Fake News Is Only the Beginning. The FCC Votes to Let Monopolies Decide What Local News You See"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/04/congresswoman-rosen-introduces-restoring-american-privacy-act-2017-reverse-s-j-res-34/","title":"Congresswoman Rosen introduces Restoring American Privacy Act of 2017 to reverse S.J. Res. 34"},
-    {"url":"https://www.washingtonpost.com/news/the-switch/wp/2017/11/16/the-fcc-just-repealed-decades-old-rules-blocking-broadcast-media-mergers/?utm_term=.0ed42f1a0d8e","title":"The FCC just repealed a 42-year-old rule blocking broadcast media mergers"},
-    {"url":"https://money.cnn.com/2018/08/04/news/companies/wells-fargo-mortgage-modification/index.html","title":"Wells Fargo says hundreds of customers lost homes after computer glitch; Hundreds of people had their homes foreclosed on after software used by Wells Fargo incorrectly denied them mortgage modifications"},
-    {"url":"https://arstechnica.com/tech-policy/2017/04/dont-like-privacy-violations-dont-use-the-internet-gop-lawmaker-says/","title":"Why one Republican voted to kill privacy rules: “Nobody has to use the Internet”"},
-    {"url":"https://gizmodo.com/amazon-workers-demand-jeff-bezos-cancel-face-recognitio-1827037509","title":"Amazon Workers Demand Jeff Bezos Cancel Face Recognition Contracts With Law Enforcement"},
-    {"url":"https://electrek.co/2017/02/12/tesla-crash-dead-drunk-driver/","title":"Tesla crash: father of dead driver blames Tesla’s ‘rocketship-like’ acceleration for his daughter’s death - \"the police revealed that both Speckman and McCarthy were intoxicated at the time of the accident.\""},
-    {"url":"https://arstechnica.com/tech-policy/2017/12/att-says-it-never-blocked-apps-fails-to-mention-how-it-blocked-facetime/","title":"AT&T says it never blocked apps, fails to mention how it blocked FaceTime."},
-    {"url":"http://mashable.com/2016/09/01/reliance-jio-launch-tariff-plans-india/","title":"India's richest man launches 4G LTE network in the country, offers unlimited free voice calls, cheapest data in the world"},
-    {"url":"https://theoutline.com/post/2558/death-of-the-internet-net-neutrality-donald-trump-alt-right-gamergate-facebook-twitter","title":"The death of the internet: If we lose this, we lose everything. | The Outline"},
-    {"url":"https://www.reddit.com/r/KeepOurNetFree/comments/7jdsev/ajit_pai_has_personal_financial_interests_in/","title":"Ajit Pai has personal financial interests in ending net neutrality"},
-    {"url":"http://www.dslreports.com/shownews/Big-ISPs-Spent-1-Million-Attacking-Colorado-Community-Broadband-140849","title":"Big ISPs Spent $1 Million Attacking Colorado Community Broadband - “ISPs like Comcast and CenturyLink spent nearly $1 million dollars trying to prevent one Colorado community from even discussing creative, community-driven solutions to the broadband competition problem.”"},
-    {"url":"https://techcrunch.com/2016/08/23/good-riddance/","title":"Google will soon start punishing mobile sites that show hard-to-dismiss popups"},
-    {"url":"https://arstechnica.com/?post_type=post&p=1429891","title":"Man sues feds after being detained for refusing to unlock his phone at airport"},
-    {"url":"https://tech.slashdot.org/story/17/11/23/149208/cloudflare-might-be-exploring-a-way-to-slow-down-fcc-chairman-ajit-pais-home-internet-speeds","title":"Cloudflare Might Be Exploring a Way To Slow Down FCC Chairman Ajit Pai's Home Internet Speeds"},
-    {"url":"http://www.theverge.com/ces/2017/1/3/14126382/new-hp-spectre-x360-laptop-2017-announced-price-release-date-ces","title":"HP made a laptop slightly thicker to add 3 hours of battery life"},
-    {"url":"http://www.ajc.com/business/former-gov-roy-barnes-others-file-equifax-data-breach-class-action/x1byRfcdw2ABAkxpFerrBL/","title":"Lawsuit filed in Atlanta U.S. District Court faults Equifax for “gargantuan failures to secure and safeguard consumers’ personally identifiable information … and for failing to provide timely, accurate and adequate notice”"},
-    {"url":"https://arstechnica.com/tech-policy/2018/04/france-seizes-france-com-from-man-whos-had-it-since-94-so-he-sues/?comments=1","title":"France seizes France.com from man who’s had it since ‘94, so he sues"},
-    {"url":"http://thehill.com/policy/technology/364937-netflix-rips-net-neutrality-repeal-this-is-the-beginning-of-a-longer-legal","title":"Netflix rips net neutrality repeal: ‘This is the beginning of a longer legal battle’"},
-    {"url":"https://www.cnbc.com/2018/01/31/google-facebook-data-privacy-concerns-out-of-control-commentary.html","title":"Google and Facebook are watching our every move online. It's time to make them stop"},
-    {"url":"https://www.theverge.com/2017/9/11/16290730/equifax-chatbots-ai-joshua-browder-security-breach","title":"Chatbot lets you sue Equifax for up to $25,000 without a lawyer."},
-    {"url":"http://www.billgeeks.com/comcast-broadcast-tv-fee/","title":"Comcast Subscribers Are Paying Up To $1.9 Billion a Year for Over-the-Air Channels They Can Get Free"},
-    {"url":"https://www.theverge.com/2019/1/30/18203413/robocalls-spam-text-calls-2018-analysis-hiya","title":"Robocallers blasted Americans with 26.3 billion spam calls last year - Robocalls are up 46 percent from 2017"},
-    {"url":"https://www.techdirt.com/articles/20171205/12420338750/fcc-tried-to-hide-net-neutrality-complaints-against-isps.shtml","title":"The FCC Tried To Hide Net Neutrality Complaints Against ISPs"},
-    {"url":"https://www.multichannel.com/news/netflix-could-lose-8-percent-of-subscribers","title":"Netflix Loses 8% of Consumers with $1 Price Increase: Study"},
-    {"url":"http://www.dslreports.com/shownews/ATT-Lays-Off-Up-to-1400-Employees-Just-Before-Christmas-140923","title":"AT&T Lays Off Up to 1400 Employees Just Before Christmas"},
-    {"url":"https://www.politico.com/story/2018/01/01/equifax-data-breach-congress-action-319631","title":"After Equifax breach, anger but no action in Congress. The aftermath of the data breach played out like a familiar script: White-hot bipartisan outrage, then hearings and proposals that went nowhere."},
-    {"url":"http://www.dslreports.com/shownews/Senators-Press-Ajit-Pai-on-DDOS-Attack-His-Agency-Made-Up-141999","title":"Senators Press Ajit Pai on DDOS Attack His Agency Made Up"},
-    {"url":"http://www.bbc.com/news/technology-40057855","title":"Net neutrality: 'Dead people' signing FCC consultation"},
-    {"url":"http://www.theverge.com/2017/4/26/15439622/fcc-net-neutrality-internet-freedom-isp-ajit-pai","title":"The fight for net neutrality is officially back on"},
-    {"url":"https://thepiratebay.se/","title":"After being down for 51 days, the original Pirate Bay is back online."},
-    {"url":"https://wikileaks.org/ciav7p1/","title":"Vault 7: CIA Hacking Tools Revealed"},
-    {"url":"https://www.wired.com/story/fcc-retracts-a-plan-to-discourage-consumer-complaints/","title":"FCC Retracts a Plan to Discourage Consumer Complaints"},
-    {"url":"https://www.wired.com/story/fcc-wants-to-kill-net-neutrality-congress-will-pay-the-price/","title":"FCC Wants to Kill Net Neutrality. Congress Will Pay the Price"},
-    {"url":"https://arstechnica.com/tech-policy/2018/02/rancher-finds-creepy-and-un-american-spy-cam-tied-to-his-tree-sues-feds/","title":"Man removes feds’ spy cam, they demand it back, he refuses and sues"},
-    {"url":"https://arstechnica.com/?post_type=post&p=1423479","title":"Ajit Pai buries 2-year-old speed test data in appendix of 762-page report"},
-    {"url":"http://www.businessinsider.com/shareholders-mulling-suit-against-intel-over-ceos-stock-sale-2018-1","title":"'These are bad facts for him': Intel CEO's $24 million stock sale before disclosing the chip flaw could trigger lawsuits, SEC inquiry"},
-    {"url":"http://www.theverge.com/2016/10/19/13330158/t-mobile-unlimited-data-settlement-fine-discount-free-data?utm_campaign=theverge&utm_content=chorus&utm_medium=social&utm_source=twitter","title":"T-Mobile will pay a $48 million fine for throttling ‘unlimited data’ plans"},
-    {"url":"https://www.cnet.com/news/almost-half-of-us-cell-phone-calls-will-be-scams-by-next-year-says-report/","title":"Almost half of US cellphone calls will be scams by next year, says report"},
-    {"url":"http://regated.com/2016/09/paul-combetta-asking-destroy-evidence/","title":"Hillary Clinton IT Paul Combetta Asked How To Destroy Evidence On Reddit"},
-    {"url":"http://www.dslreports.com/shownews/Senator-Doesnt-Buy-FCC-Justification-for-Killing-Net-Neutrality-139993","title":"Senator Doesn't Buy FCC Justification for Killing Net Neutrality"},
-    {"url":"https://arstechnica.com/tech-policy/2017/11/comcast-quietly-drops-promise-not-to-charge-tolls-for-internet-fast-lanes/","title":"Comcast quietly drops promise not to charge tolls for Internet fast lanes"},
-    {"url":"https://www.businessinsider.com/ios-12-shortcut-uses-iphone-to-record-police-during-traffic-stop-2018-10","title":"'Siri, I'm getting pulled over': a new shortcut for iPhones can automatically record the police"},
-    {"url":"https://www.theage.com.au/world/north-america/new-report-shows-russia-used-every-major-social-media-tool-to-help-trump-20181217-p50mn8.html","title":"New report shows Russia used every major social media tool to help Trump."},
-    {"url":"http://www.ndtv.com/world-news/bose-headphones-spy-on-listeners-lawsuit-1683707","title":"Bose headphones spy on listeners and sell personally identifiable information to third parties without permission: Lawsuit"},
-    {"url":"https://www.bloomberg.com/news/articles/2018-04-25/american-cities-are-fighting-big-business-over-wireless-internet-and-they-re-losing","title":"American Cities Are Fighting Big Business Over Wireless Internet, and They’re Losing: “It’s often lost on the public just how badly they’re being screwed”"},
-    {"url":"https://techcrunch.com/2018/10/11/pro-privacy-search-engine-duckduckgo-hits-30m-daily-searches-up-50-in-a-year/","title":"Pro-privacy search engine DuckDuckGo hits 30M daily searches, up 50% in a year"},
-    {"url":"https://www.phonearena.com/news/Apple-rejects-app-that-finds-net-neutrality-violations_id101750","title":"Apple has a change of heart and approves an app that finds net neutrality violations"},
-    {"url":"https://www.businessinsider.com/france-bans-children-using-phones-at-school-2018-9/","title":"France has banned all children under 15 from using their phones in school"},
-    {"url":"https://www.eff.org/deeplinks/2018/07/californias-net-neutrality-bill-strong-again-because-you-spoke-out","title":"California's Net Neutrality Bill Is Strong Again Because You Spoke Out"},
-    {"url":"http://arstechnica.com/tech-policy/2017/08/dont-kill-net-neutrality-before-making-complaints-public-groups-tell-fcc/","title":"Stop hiding 47,000 net neutrality complaints, advocates tell FCC chair"},
-    {"url":"https://deletefacebook.com/","title":"How To Permanently Delete A Facebook Account"},
-    {"url":"http://consumerist.com/2014/08/10/comcast-tells-customer-the-only-reason-hes-getting-bogus-charges-refunded-is-because-he-recorded-call/","title":"Comcast Tells Customer The Only Reason He’s Getting Bogus Charges Refunded Is Because He Recorded Call"},
-    {"url":"https://phys.org/news/2018-06-court-danger-posed-cannons.html","title":"US court confirms danger posed by 'sound cannons'. \"The problem posed by protesters in the street did not justify the use of force, much less force capable of causing serious injury, such as hearing loss,\" the court said in its ruling."},
-    {"url":"https://www.bloomberg.com/news/articles/2018-03-20/facebook-sees-tesla-sized-chunk-vanish-from-market-cap-in-2-days","title":"Facebook Just Lost More Than Tesla's Entire Market Cap in Two Days"},
-    {"url":"https://betanews.com/2018/12/04/duckduckgo-study-google-search-personalization/","title":"Privacy-focused DuckDuckGo finds Google personalizes search results even for logged out and incognito users"},
-    {"url":"https://www.gov.ca.gov/2018/09/30/governor-brown-issues-legislative-update-22/","title":"Gov. Brown signs California Net Neutrality Bill SB 822"},
-    {"url":"https://arstechnica.com/tech-policy/2018/08/georgia-defends-voting-system-despite-243-percent-turnout-in-one-precinct/","title":"Georgia defends voting system despite 243-percent turnout in one precinct"},
-    {"url":"https://www.theverge.com/2019/1/19/18189559/google-maps-speed-limits-android-and-ios-apps","title":"Google Maps will now display speed limits for its Android and iOS apps"},
-    {"url":"https://motherboard.vice.com/en_us/article/xwvg34/ajit-pai-net-neutrality-heist","title":"Yes, Net Neutrality Is Being Stolen From Us in a Fucked Up, Undemocratic Heist"},
-    {"url":"https://www.greentechmedia.com/articles/read/new-bipartisan-legislation-would-repeal-trump-admin-solar-tariffs","title":"New Bipartisan Legislation Would Repeal Trump’s Solar Tariffs: “I don’t know what good can possibly come as a consequence of stifling the growth of solar power.”"},
-    {"url":"https://motherboard.vice.com/en_us/article/kznxde/hawaii-ballistic-missile-warning-no-testing-system","title":"Hey, Hawaii: The Telecom Industry Lobbied Against Testing for Emergency Alert System - Everyone in Hawaii received a ballistic missile threat today under a system that currently has no good testing protocols."},
-    {"url":"https://arstechnica.com/tech-policy/2018/05/jails-are-replacing-in-person-visits-with-video-calling-services-theyre-awful/","title":"Jails are replacing visits with video calls—inmates and families hate it"},
-    {"url":"https://www.theregister.co.uk/2019/01/25/fcc_accused_of_colluding/","title":"FCC accused of colluding with Big Cable to game 5G legal challenge"},
-    {"url":"https://venturebeat.com/2018/04/17/chrome-66-arrives-with-autoplaying-content-blocked-by-default/","title":"Chrome 66 arrives with autoplaying content blocked by default."},
-    {"url":"https://customer.comcast.com/help-and-support/internet/data-usage-what-are-the-different-plans-launching?ref=1","title":"Comcast to begin charging for data usage on home internet the same way cell phone companies are charging for data"},
-    {"url":"https://www.theverge.com/2018/8/31/17805892/california-sb822-net-neutrality-law-vote","title":"California passes strongest net neutrality law in the country"},
-    {"url":"https://www.techdirt.com/articles/20181018/08242940864/streaming-exclusives-will-drive-users-back-to-piracy-industry-is-largely-oblivious.shtml","title":"Streaming Exclusives Will Drive Users Back To Piracy And The Industry Is Largely Oblivious"},
-    {"url":"https://consumerist.com/2016/06/22/comcast-admits-it-incorrectly-debited-1775-from-account-tells-me-to-sort-it-out-with-bank/","title":"Comcast Admits It Incorrectly Debited $1,775 From Account, Tells Me To Sort It Out With Bank"},
-    {"url":"https://www.xda-developers.com/android-dns-over-tls-website-privacy/","title":"Android getting \"DNS over TLS\" support to stop ISPs from knowing what websites you visit"},
-    {"url":"https://www.theregister.co.uk/2018/04/30/net_neutrality_senate_democrats/","title":"Democrats need just one more senator (and then a miracle) to reverse US net neutrality death"},
-    {"url":"http://fortune.com/2018/01/06/google-microsoft-amazon-internet-association-net-neutrality/","title":"Google, Microsoft, and Amazon’s Trade Group Joining Net Neutrality Court Challenge"},
-    {"url":"http://gizmodo.com/fcc-chair-ajit-pai-cant-come-up-with-a-single-plausible-1797286906?IR=T","title":"FCC Chair Ajit Pai Can't Come Up With a Single Plausible Reason Not to Screw Up the Entire US Internet"},
-    {"url":"https://www.newscientist.com/article/mg24032052-900-time-to-break-academic-publishings-stranglehold-on-research/","title":"Time to break academic publishing’s stranglehold on research - Science journals are laughing all the way to the bank, locking the results of publicly funded research behind exorbitant paywalls. A campaign to make content free must succeed"},
-    {"url":"https://www.buzzfeednews.com/article/ryanhatesthis/reddits-largest-pro-trump-subreddit-appears-to-have-been","title":"Reddit's Largest Pro-Trump Subreddit Appears To Have Been Targeted By Russian Propaganda For Years"},
-    {"url":"https://techcrunch.com/2017/08/06/10-members-of-congress-rake-fcc-over-the-coals-in-official-net-neutrality-comment/","title":"10 Members of Congress rake FCC over the coals in official net neutrality comment"},
-    {"url":"https://www.techdirt.com/articles/20170123/07582236547/google-ting-netflix-dare-to-suggest-that-maybe-giant-anti-competitive-isps-shouldnt-be-writing-state-telecom-laws.shtml","title":"Google, Ting, Netflix Dare To Suggest That Maybe Giant, Anti-Competitive ISPs Shouldn't Be Writing State Telecom Laws"},
-    {"url":"https://gizmodo.com/ajit-pai-is-suddenly-very-concerned-about-whether-tech-1828819118?IR=T","title":"Ajit Pai Is Suddenly Very Concerned About Whether Tech Companies Are Censoring Conservatives"},
-    {"url":"https://arstechnica.com/?post_type=post&p=1357875","title":"Ajit Pai loses in court—FCC can’t kill broadband subsidy in Tribal areas"},
-    {"url":"https://www.eff.org/deeplinks/2017/06/isps-across-country-tell-chairman-pai-not-repeal-network-neutrality","title":"More than 40 ISPs Across the Country Tell Chairman Pai to Not Repeal Network Neutrality and Maintain Title II Enforcement"},
-    {"url":"https://supporters.eff.org/donate","title":"If the FCC succeeds in dismantling net neutrality, it’ll be up to organisations like the EFF to mount a legal challenge. Now more than ever, it’s time to donate to the EFF!"},
-    {"url":"http://housely.com/complaints-against-police-officers-with-body-cameras-drop-93-percent/","title":"Complaints Against Police Officers With Body Cameras Drop 93 Percent"},
-    {"url":"http://www.businessinsider.com/nsa-hack-apple-fbi-2016-8","title":"The NSA hack proves Apple was right to fight the FBI"},
-    {"url":"https://www.vanityfair.com/news/2018/03/zuckerberg-hits-users-with-the-hard-truth-you-agreed-to-this?utm_source=quora","title":"Zuckerberg Hits Users with the Hard Truth: You Agreed to This"},
-    {"url":"https://www.theverge.com/2017/5/24/15682240/fcc-net-neutrality-proposal-sees-few-changes","title":"2.6 million comments in, the FCC has changed almost nothing about its net neutrality proposal"},
-    {"url":"http://motherboard.vice.com/read/lawmakers-have-snuck-cisa-into-a-bill-that-is-guaranteed-to-become-a-law","title":"Lawmakers Have Snuck CISA Into a Bill That Is Guaranteed to Become a Law"},
-    {"url":"http://www.salon.com/2017/07/30/fight-for-your-right-to-fix-your-own-iphone/","title":"Fight for your right to fix your own iPhone: The \"Right-to-Repair\" movement fights corporate rules that keep you from fixing your own broken stuff"},
-    {"url":"http://www.dslreports.com/shownews/ISPs-Gave-8X-More-Cash-to-Politicians-That-Axed-FCC-Privacy-Rule-139377","title":"ISPs Gave 8X More Cash to Politicians That Axed FCC Privacy Rule"},
-    {"url":"https://www.commondreams.org/news/2018/03/12/11-mayors-applauded-refusing-do-business-companies-dont-support-net-neutrality","title":"11 Mayors Applauded for Refusing to Do Business With Companies That Don't Support Net Neutrality: \"Town by town, city by city, local leaders are taking back everyone's right to connect and communicate.\""},
-    {"url":"http://hosted.ap.org/dynamic/stories/U/US_NET_NEUTRALITY_STAY_DENIED?SITE=AP&SECTION=HOME&TEMPLATE=DEFAULT&CTIME=2015-06-11-18-51-15","title":"Court says net neutrality rules will go into effect today: Rules that treat the Internet like a public utility and prevent companies from blocking or slowing down some online traffic will go into effect today after a federal appeals court refused to delay them"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/03/24-senators-introduced-bill-let-telecoms-sell-private-internet-history/","title":"These are the 24 Senators that introduced a bill to let telecoms sell your private internet history"},
-    {"url":"http://www.businessinsider.com/china-social-credit-system-punishments-and-rewards-explained-2018-4","title":"China has started ranking citizens with a creepy 'social credit' system - here's what you can do wrong, and the embarrassing, demeaning ways they can punish you"},
-    {"url":"https://www.vanityfair.com/news/2018/11/mark-zuckerberg-has-never-cared-about-your-privacy","title":"“He doesn’t believe in it”: Mark Zuckerberg has never cared about your privacy, and he’s not going to change."},
-    {"url":"https://arstechnica.com/tech-policy/2017/12/fcc-still-withholding-isps-responses-to-net-neutrality-complaints/","title":"Democrat asks why FCC is hiding ISPs’ answers to net neutrality complaints: 'FCC apparently still hasn't released thousands of documents containing the responses ISPs made to net neutrality complaints.'"},
-    {"url":"https://www.upi.com/Top_News/US/2018/03/06/Rhode-Island-bill-would-charge-20-fee-to-unblock-Internet-porn/8441520319464/","title":"Rhode Island bill would charge $20 fee to unblock Internet porn"},
-    {"url":"http://www.bbc.com/news/technology-33379571","title":"Reddit in uproar after staff sacking"},
-    {"url":"https://motherboard.vice.com/en_us/article/kzvndz/trumps-cybersecurity-advisor-rudy-giuliani-thinks-his-twitter-was-hacked-because-someone-took-advantage-of-his-typo","title":"Trump’s Cybersecurity Advisor Rudy Giuliani Thinks His Twitter Was Hacked Because Someone Took Advantage of His Typo"},
-    {"url":"https://www.privateinternetaccess.com/blog/2016/07/fourth-amendment-caucus-defeats-patriot-act-expansion-in-congress/","title":"Fourth Amendment Caucus defeats Patriot Act expansion in Congress"},
-    {"url":"https://motherboard.vice.com/en_us/article/ev5b3k/net-neutrality-fcc-zero-consumer-comments-cited","title":"The FCC Cited Zero of the 22 Million Consumer Comments in its 218-Page Net Neutrality Repeal: \"Despite the millions of comments, letters, and calls received, this Order cites, not even one consumer comment.\""},
-    {"url":"http://www.cnbc.com/id/102808806","title":"Calling for Reddit’s CEO to step down reaches 14,000 (now 18,000 plus)"},
-    {"url":"https://slate.com/news-and-politics/2018/07/facebook-says-infowars-valid-opinion-and-analysis-but-what-about-the-martian-slave-colony.html?via=recirc_recent","title":"Facebook Says InfoWars, Which Reported That NASA Has a Slave Colony on Mars, Is a Valid Source of “Opinion and Analysis”"},
-    {"url":"https://www.privateinternetaccess.com/blog/2016/09/police-routinely-misuse-state-federal-databases-stalk-romantic-interests-business-partners-family-even/","title":"Police routinely misuse state and federal databases to stalk romantic interests, business partners, family, and even each other"},
-    {"url":"https://www.scribblrs.com/google-now-penalizing-mobile-ads/","title":"Google Has Finally Started Penalizing Mobile Websites With Intrusive Pop-Up Ads"},
-    {"url":"https://arstechnica.com/tech-policy/2018/03/att-and-verizon-data-cap-exemptions-would-be-banned-by-california-bill/","title":"Calif. weighs toughest net neutrality law in US—with ban on paid zero-rating. Bill would recreate core FCC net neutrality rules and be tougher on zero-rating."},
-    {"url":"https://arstechnica.com/tech-policy/2017/12/obama-didnt-force-fcc-to-impose-net-neutrality-investigation-found/","title":"Obama didn't force FCC to impose net neutrality, investigation found"},
-    {"url":"http://www.independent.co.uk/environment/france-petrol-diesel-ban-vehicles-cars-2040-a7826831.html","title":"France will 'ban all petrol and diesel vehicles by 2040'"},
-    {"url":"http://www.truth-out.org/opinion/item/25563-should-the-internet-be-like-the-public-library","title":"Every American town should do what Rockport, Maine and Chattanooga, Tennessee have done and build a publically-owned fiber-optic network. If they can't afford to do that, the state or federal government should step in and help them finish the job, just like we did with electric power in the 1930s"},
-    {"url":"https://thenextweb.com/insider/2017/05/11/hp-is-shipping-audio-drivers-with-a-built-in-keylogger/","title":"HP is shipping audio drivers with a built-in keylogger"},
-    {"url":"https://motherboard.vice.com/en_us/article/gyab5m/its-now-clear-none-of-the-supposed-benefits-of-killing-net-neutrality-are-real","title":"It's Now Clear None of the Supposed Benefits of Killing Net Neutrality Are Real - Network investment is down, layoffs abound, and networks are falling apart. This isn’t the glorious future Ajit Pai promised."},
-    {"url":"https://www.theverge.com/2019/1/23/18193539/hulu-price-change-subscription-ads-live-tv-2019","title":"Hulu drops to just $5.99 per month after Netflix’s price hikes"},
-    {"url":"http://gu.com/p/4g8ab?CMP=Share_AndroidApp_reddit_is_fun","title":"Uninstalling Facebook app saves up to 20% of Android battery life"},
-    {"url":"http://www.washingtonpost.com/blogs/the-switch/wp/2015/06/17/att-just-got-hit-with-a-100-million-fine-after-slowing-down-its-unlimited-data/","title":"AT&T just got hit with a $100 million fine after slowing down its ‘unlimited’ data"},
-    {"url":"http://www.networkworld.com/article/3195466/security/fcc-should-produce-logs-to-prove-multiple-ddos-attacks-stopped-net-neutrality-comments.html","title":"FCC should produce logs to prove ‘multiple DDoS attacks’ stopped net neutrality comments"},
-    {"url":"http://www.extremetech.com/computing/230794-woman-wins-10000-judgment-against-microsoft-for-forced-windows-10-upgrade","title":"Woman wins $10,000 judgment against Microsoft for forced Windows 10 upgrade"},
-    {"url":"http://www.dslreports.com/shownews/FCC-Boss-Ajit-Pai-Annoyed-As-Neutrality-Fight-Heads-to-the-House-141860","title":"FCC Boss Ajit Pai Annoyed As Neutrality Fight Heads to the House"},
-    {"url":"https://unfairplay.ca/","title":"Bell and other companys are working together to try and censor the internet in Canada, here's a link to were you can find more info on what's happening and how you can help stop them"},
-    {"url":"http://www.dslreports.com/shownews/Verizon-Apple-Continue-to-Lobby-Against-Your-Right-to-Repair-141134","title":"Verizon, Apple Continue to Lobby Against Your 'Right to Repair'"},
-    {"url":"https://www.inverse.com/article/39507-mesh-networks-net-neutrality-fcc","title":"Without Net Neutrality, Is It Time To Build Your Own Internet? Here's what you need to know about mesh networking."},
-    {"url":"http://fortune.com/2018/02/28/google-right-to-be-forgotten-europe-reasons-eu/","title":"Google says European politicians and government officials have used the \"right to be forgotten\" to delete 34000 articles about themselves from search results in Europe"},
-    {"url":"http://www.gospelherald.com/articles/68478/20161202/elon-musk-beats-out-mark-zuckerburg-steve-jobs-as-the-most-admired-tech-leader.htm","title":"Elon Musk Beats Out Mark Zuckerburg, Steve Jobs As The Most Admired Tech Leader"},
-    {"url":"http://arstechnica.com/gaming/2016/08/pokemon-go-sheds-more-than-10m-users/","title":"Pokémon Go loses its luster, sheds more than 10 million users. Engagement, downloads, and time spent in the app are fading fast."},
-    {"url":"http://www.alexa.com/topsites/countries/US","title":"Reddit Is Now The 4th Most Popular Site In The US"},
-    {"url":"https://www.techdirt.com/blog/netneutrality/articles/20170213/14460536703/comcast-att-are-paying-minority-groups-to-support-killing-net-neutrality.shtml","title":"Comcast, AT&T Are Paying Minority Groups To Support Killing Net Neutrality"},
-    {"url":"http://theantimedia.org/trump-mass-surveillance-privacy/amp/","title":"Trump Quietly Nominates Mass Surveillance Advocate To \"Protect\" Your Privacy Rights"},
-    {"url":"http://www.bbc.com/news/world-us-canada-38721056","title":"Trump pulls out of TPP trade deal"},
-    {"url":"http://www.timescall.com/opinion/letterstotheeditor/ci_31916956/stan-gelb-encourage-congress-restore-net-neutrality","title":"“Polls show that over 80 percent of Republicans support net neutrality, while Democrat support is even higher, because almost everyone now knows that the internet is a prime part of our constitutional right to free speech.”"},
-    {"url":"https://www.commondreams.org/news/2018/01/15/will-ajit-pais-fcc-probe-hawaii-false-alarm-expose-role-telecom-giants-played","title":"Will Ajit Pai's FCC Probe into Hawaii False Alarm Expose Role Telecom Giants Played in Blocking Emergency System Upgrades? '...it was telecom giants, including his former employer Verizon, that played a specific and outsized role in preventing the implementation of several key safeguards.'"},
-    {"url":"http://fortune.com/2017/08/26/trump-cybersecurity-advisors-resign/","title":"Seven cybersecurity members resign from Trump's advisory panel citing \"insufficient attention to the growing threats\""},
-    {"url":"http://bgr.com/2015/11/02/comcast-vs-google-fiber-facebook-post/","title":"Comcast's attempt to bash Google Fiber on Facebook backfires hilariously as its own customers respond by hammering it with complaints"},
-    {"url":"http://exstreamist.com/people-arent-cancelling-netflix-because-of-price-increases-theyre-cancelling-because-the-library-is-shrinking/","title":"People Aren’t Cancelling Netflix Because of Price Increases, They’re Cancelling Because the Library is Shrinking"},
-    {"url":"https://www.technologyreview.com/s/607908/the-worlds-largest-wind-turbines-have-started-generating-power-in-england/","title":"The World’s Largest Wind Turbines Have Started Generating Power in England - A single revolution of a turbine’s blades can power a home for 29 hours."},
-    {"url":"http://www.boredpanda.com/microsoft-paint-ebook-illustrations-camp-redblood-pat-hines/","title":"Guy Sucks At Photoshop, Spends 10 Years Mastering Microsoft Paint To Illustrate His Book"},
-    {"url":"https://motherboard.vice.com/en_us/article/ne9qdq/warranty-void-if-removed-stickers-illegal-ftc","title":"FTC Says 'Warranty Void If Removed' Stickers Are Bullshit, Warns Manufacturers - Federal law says you can repair your own things, and manufacturers cannot force you to use their own repair services."},
-    {"url":"https://futurism.com/its-official-humans-are-going-to-mars-nasa-has-unveiled-their-mission/","title":"It's official. Humans are going to Mars. NASA has unveiled their plan."},
-    {"url":"http://consumerist.com/2014/10/06/unhappy-customer-comcast-told-my-employer-about-complaint-got-me-fired/","title":"Unhappy Customer: Comcast told my employer about my complaint, got me fired"},
-    {"url":"http://www.defenseone.com/politics/2017/08/trump-cybersecurity-advisers-resign-moral-protest/140535/","title":"Trump Cybersecurity Advisers Resign In ‘Moral’ Protest"},
-    {"url":"https://www.revealnews.org/blog/a-judge-unsealed-a-trove-of-internal-facebook-documents-following-our-legal-action/","title":"Federal judge unseals trove of internal Facebook documents about how it made money off children"},
-    {"url":"https://www.theverge.com/2018/9/7/17833748/apple-just-permanently-banned-infowars-from-the-app-store","title":"Apple just permanently banned Infowars from the App Store"},
-    {"url":"https://motherboard.vice.com/en_us/article/vbympa/net-neutrality-fcc-inspector-general-report","title":"Internal FCC Report Shows Republican Net Neutrality Narrative Is False"},
-    {"url":"https://arstechnica.com/video/2017/06/the-u-s-government-is-removing-scientific-data-from-the-internet/","title":"The US government is removing scientific data from the Internet"},
-    {"url":"https://www.bloomberg.com/news/articles/2017-09-07/three-equifax-executives-sold-stock-before-revealing-cyber-hack","title":"Three Equifax Managers Sold Stock Before Cyber Hack Was Revealed"},
-    {"url":"http://gizmodo.com/at-t-launches-fake-5g-network-in-desperate-attempt-to-s-1794645881","title":"AT&T Launches Fake 5G Network in Desperate Attempt to Seem Innovative"},
-    {"url":"https://thenextweb.com/apps/2017/03/10/windows-10-is-bringing-shitty-ads-to-file-explorer-heres-how-to-turn-them-off/","title":"Windows 10 is bringing shitty ads to File Explorer, here's how to turn them off"},
-    {"url":"https://www.reuters.com/article/us-usa-equifax-cfpb/exclusive-u-s-consumer-protection-official-puts-equifax-probe-on-ice-sources-idUSKBN1FP0IZ","title":"U.S. consumer protection official puts Equifax probe on ice"},
-    {"url":"http://www.vox.com/energy-and-environment/2017/2/7/14533618/solar-jobs-coal","title":"There are now twice as many solar jobs as coal jobs in the US"},
-    {"url":"http://arstechnica.com/staff/2016/11/its-time-to-get-rid-of-the-facebook-news-feed-because-its-not-news/","title":"It’s time to get rid of the Facebook “news feed,” because it’s not news"},
-    {"url":"http://www.theverge.com/2015/8/24/9196969/twitter-shuts-down-politwoops-diplotwoops","title":"Twitter shuts down 30 sites dedicated to saving politicians' deleted tweets"},
-    {"url":"https://www.thesun.co.uk/news/3672676/british-airways-boss-tries-gag-staff-it-failure/","title":"British Airways boss 'tries to gag staff' on IT meltdown which has hit 300,000 passengers after 'inexperienced staff outsourced to India didn't know to launch back up system'"},
-    {"url":"http://cordcutt.in/76-of-netflix-subscribers-think-netflix-can-replace-traditional-tv/","title":"76% of Netflix Subscribers Think Netflix Can Replace Traditional TV"},
-    {"url":"https://arstechnica.com/tech-policy/2018/09/did-russia-meddle-with-net-neutrality-comments-nyt-sues-fcc-to-find-out/","title":"NYT sues FCC, says it hid evidence of Russia meddling in net neutrality repeal"},
-    {"url":"https://www.commondreams.org/news/2018/08/16/complete-joke-democrats-ripped-totally-failing-grill-fcc-chair-ajit-pai-over-net","title":"'Complete Joke': Democrats Ripped for Totally Failing to Grill FCC Chair Ajit Pai Over Net Neutrality Cyberattack Lies"},
-    {"url":"https://www.businessinsider.com/can-hackers-take-entire-countries-offline-2018-12","title":"Someone is trying to take entire countries offline and cybersecurity experts say 'it's a matter of time because it's really easy"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/08/11-representatives-21-senators-stood-fcc-regarding-net-neutrality/","title":"These are the 11 Representatives and 21 Senators that have stood up to the FCC regarding net neutrality"},
-    {"url":"https://www.axios.com/sean-parker-facebook-exploits-a-vulnerability-in-humans-2507917325.html","title":"Sean Parker: Facebook was designed to exploit human \"vulnerability\""},
-    {"url":"https://www.cnet.com/news/ticketmaster-partners-with-scalpers-to-rip-you-off-two-undercover-reporters-say","title":"Ticketmaster partners with scalpers to rip you off, two undercover reporters say. The company is reportedly helping ticket resellers violate its own terms of use."},
-    {"url":"https://www.theverge.com/2018/6/13/17461464/apple-update-graykey-ios-police-hacking","title":"Apple will update iOS to block police hacking tool"},
-    {"url":"https://www.theverge.com/2018/3/2/17071586/trump-video-game-violence-summit-esa-gun-control","title":"Video game companies unaware of Trump’s summit on video game violence - The meeting is supposed to take place next week"},
-    {"url":"http://money.cnn.com/2015/11/05/technology/facebook-tsu/index.html","title":"Facebook is blocking any link to Tsu.co on every platform it owns, including Messenger and Instagram. It even…deleted more than 1 million Facebook posts that ever mentioned Tsu.co…Tsu is a new social network that claims to share its advertising revenue with its users."},
-    {"url":"https://motherboard.vice.com/en_us/article/ywb83y/justin-trudeau-is-very-concerned-with-fcc-plan-to-roll-back-net-neutrality-donald-trump","title":"Justin Trudeau Is ‘Very Concerned’ With FCC’s Plan to Roll Back Net Neutrality"},
-    {"url":"https://www.purdue.edu/newsroom/releases/2018/Q4/unlimited-data-draining-your-wallet-your-plan-costs-more-in-u.s.-than-those-in-most-developed-countries.html","title":"Americans pay more for wireless data than consumers in most other developed countries"},
-    {"url":"https://motherboard.vice.com/en_us/article/kzg8yy/ajit-pai-net-neutrality-speech","title":"FCC Chair Ajit Pai Falsely Claims Killing Net Neutrality Will Help Sick and Disabled People"},
-    {"url":"http://gadgets.ndtv.com/internet/news/reddit-country-local-home-pages-1723573","title":"Reddit Is Testing Country-Specific Home Pages; People Across the World See Different Stories. If You Are Not a Fan of the Idea, Speak Now"},
-    {"url":"https://www.cbc.ca/news/thenational/complete-control-apple-accused-of-overpricing-restricting-device-repairs-1.4859099","title":"'Complete control': Apple accused of overpricing, restricting device repairs"},
-    {"url":"https://www.theguardian.com/technology/2017/jul/12/ajit-pai-fcc-net-neutrality-open-internet","title":"Ajit Pai: the man who could destroy the open internet - The FCC chairman leading net neutrality rollback is a former Verizon employee and whose views on regulation echo those of broadband companies"},
-    {"url":"https://www.eff.org/deeplinks/2018/09/you-gave-facebook-your-number-security-they-used-it-ads","title":"You Gave Facebook Your Number For Security. They Used It For Ads."},
-    {"url":"https://hothardware.com/news/nvidia-tells-retailers-to-sell-to-gamers-not-cryptominers","title":"NVIDIA Tells Retailers To Sell To Gamers, Not Cryptominers As GPU Shortage Causes Extreme Price Gouging"},
-    {"url":"http://www.thedailybeast.com/almost-all-of-fccs-new-advisory-panel-works-for-telecoms","title":"Almost All of FCC’s New Advisory Panel Works for Telecoms"},
-    {"url":"https://www.commondreams.org/news/2018/08/14/denouncing-wanton-disregard-congress-and-american-people-dems-call-ajit-pai-come","title":"Denouncing 'Wanton Disregard for Congress and the American People,' Dems Call on Ajit Pai to Come Clean About False FCC Cyberattack"},
-    {"url":"http://www.washingtontimes.com/news/2016/jul/23/twitter-users-erupt-dncleaks-disappears-from-trend/","title":"Twitter users erupt: #DNCLeaks disappears from trending news as WikiLeaks emails released"},
-    {"url":"https://www.usatoday.com/story/tech/nation-now/2018/07/26/facebook-mark-zuckerberg-net-worth-drops/843178002/","title":"Facebook CEO Mark Zuckerberg loses more than $15 billion in wealth in a single day"},
-    {"url":"https://motherboard.vice.com/en_us/article/zmd9a5/tim-cook-to-investors-people-bought-fewer-new-iphones-because-they-repaired-their-old-ones","title":"Tim Cook to Investors: People Bought Fewer New iPhones Because They Repaired Their Old Ones - Apple finally says that repair hurts its bottom line."},
-    {"url":"https://arstechnica.com/tech-policy/2017/08/comcast-sues-vermont-to-avoid-building-550-miles-of-new-cable-lines/","title":"Comcast sues Vermont to avoid building 550 miles of new cable lines - Vermont is trying to make Comcast bring TV and Internet to unserved areas."},
-    {"url":"https://arstechnica.com/tech-policy/2018/05/california-net-neutrality-bill-that-att-hates-is-coming-to-new-york-too/","title":"California net neutrality bill that AT&T hates is coming to New York, too | Ars Technica"},
-    {"url":"https://www.theregister.co.uk/2017/11/17/big_cable_fcc_net_neutrality/","title":"Big Cable's pillow talk with FCC to forbid US states from writing own net neutrality rules"},
-    {"url":"http://www.wired.co.uk/article/uk-broadband-speeds-fibre-to-the-home","title":"Your ISP now has to stop lying to you about broadband speeds - New rules around broadband advertising will usher in a depressing new era of honesty about the UK's cripplingly out-dated internet infrastructure"},
-    {"url":"https://www.fastcompany.com/40537222/washington-just-passed-the-countrys-toughest-net-neutrality-legislation","title":"Washington just passed the country’s toughest net neutrality legislation"},
-    {"url":"https://www.retaildetail.eu/en/news/elektronica/eu-aims-abolish-planned-obsolescence","title":"EU aims to abolish planned obsolescence"},
-    {"url":"https://www.engadget.com/amp/2017/09/08/uber-federal-investigation-hell-program/","title":"Uber is under federal investigation for spying on Lyft drivers."},
-    {"url":"https://www.commondreams.org/newswire/2018/08/14/ajit-pais-fcc-lied-congress-about-net-neutrality-they-should-act-now-reverse","title":"Ajit Pai’s FCC Lied to Congress About Net Neutrality. They Should Act Now to Reverse the Repeal"},
-    {"url":"https://www.bleepingcomputer.com/news/microsoft/man-sues-microsoft-seeking-new-copy-of-windows-7-after-forced-windows-10-upgrade/","title":"Man sues Microsoft seeking new copy of Windows 7 after forced Windows 10 upgrade"},
-    {"url":"https://www.techdirt.com/articles/20151118/08474732854/after-endless-demonization-encryption-police-find-paris-attackers-coordinated-via-unencrypted-sms.shtml","title":"After Endless Demonization Of Encryption, Police Find Paris Attackers Coordinated Via Unencrypted SMS"},
-    {"url":"https://gizmodo.com/mark-zuckerberg-thinks-you-dont-trust-facebook-because-1832040327","title":"Mark Zuckerberg Thinks You Don't Trust Facebook Because You Don't 'Understand' It"},
-    {"url":"https://www.engadget.com/2018/05/31/fulfilled-by-amazon-counterfeit-fake/","title":"Amazon needs to get a handle on its counterfeit problem. Fulfilled by Amazon should be a badge of trust, not a legal loophole."},
-    {"url":"https://www.theverge.com/2018/3/22/17150870/google-chrome-autoplay-videos-sound-mute-update","title":"Google Chrome’s next update will finally block autoplay videos that have sound"},
-    {"url":"https://www.kommersant.ru/doc/3386016","title":"Russia revoked .ru domain of racist Daily Stormer"},
-    {"url":"http://thehill.com/opinion/technology/357774-federal-move-to-undo-internet-freedom-would-make-us-more-like-russia-not","title":"Federal move to undo internet freedom would make US more like Russia, not less"},
-    {"url":"https://www.digitalmusicnews.com/2018/03/29/los-angeles-broadband-net-neutrality/","title":"Los Angeles Wants to Build Its Own Citywide Broadband Network - It would be one of the largest municipal broadband networks in the world. Now, Los Angeles is studying an aggressive plan to protect net neutrality."},
-    {"url":"https://arstechnica.com/tech-policy/2018/12/fcc-still-hiding-possible-evidence-of-russia-meddling-in-net-neutrality-comments/","title":"“What is the FCC hiding?” Pai still won’t release net neutrality server logs - FCC denies NYT appeal, says producing requested records is too hard."},
-    {"url":"http://www.ibtimes.co.uk/opdomesticterrorism-anonymous-hackers-take-down-over-dozen-neo-nazi-sites-new-wave-attacks-1647385","title":"Anonymous hackers take down over a dozen neo-Nazi sites in new wave of attacks."},
-    {"url":"https://www.washingtonpost.com/news/energy-environment/wp/2017/02/07/trumps-energy-plan-doesnt-mention-solar-an-industry-that-just-added-51000-jobs/?utm_term=.a633afab6945","title":"Trump’s energy plan doesn’t mention solar, an industry that just added 51,000 jobs"},
-    {"url":"https://arstechnica.com/tech-policy/2018/09/judge-fcc-cant-hide-records-that-may-explain-net-neutrality-comment-fraud/","title":"Judge: FCC can’t hide records that may explain net neutrality comment fraud"},
-    {"url":"https://www.multichannel.com/news/rep-khanna-releases-internet-bill-of-rights","title":"Rep. Khanna Releases Internet Bill of Rights - Would restore net neutrality rules, require opt in for personal info use"},
-    {"url":"https://qz.com/1509095/hospital-to-post-the-costs-of-medical-services/","title":"Finally, U.S. hospitals will have to post their prices online."},
-    {"url":"http://time.com/money/5205630/mark-zuckerberg-net-worth-facebook-stock/","title":"Mark Zuckerberg Has Lost $5 Billion So Far Today Amid Facebook Data Controversy"},
-    {"url":"http://search.slashdot.org/story/15/06/11/1223236/ask-toolbar-now-considered-malware-by-microsoft","title":"Ask Toolbar Now Considered Malware By Microsoft"},
-    {"url":"http://mashable.com/2016/09/07/iphone-headphone-jack-courage/?utm_cid=hp-hh-sec#CSiVtmuEXiqZ","title":"No, Apple, killing your headphone jack is not \"courage\""},
-    {"url":"http://trai.gov.in/notifications/press-release/trai-releases-recommendations-net-neutrality","title":"India just got strongest regulations on Net Neutrality in the world"},
-    {"url":"http://www.thedailybeast.com/articles/2016/04/21/hillary-pac-spends-1-million-to-correct-commenters-on-reddit-and-facebook.html","title":"Hillary PAC Spends $1 Million to ‘Correct’ Commenters on Reddit and Facebook: FEC loopholes mean Correct the Record can openly coordinate with Clinton’s campaign."},
-    {"url":"http://www.dslreports.com/shownews/Ajit-Pais-FCC-Cant-Stop-Lying-About-Net-Neutrality-141221","title":"Ajit Pai's FCC Can't Stop Lying About Net Neutrality"},
-    {"url":"https://arstechnica.com/tech-policy/2018/09/ajit-pai-helped-charter-kill-consumer-protection-rules-in-minnesota/","title":"Ajit Pai helped Charter kill consumer-protection rules in Minnesota"},
-    {"url":"http://www.theverge.com/2016/11/14/13630722/google-fake-news-advertising-ban-2016-us-election","title":"Google will soon ban fake news sites from using its ad network"},
-    {"url":"https://futurism.com/germany-just-smashed-an-energy-record-generating-85-electricity-from-renewables/","title":"Germany Just Smashed an Energy Record, Generating 85% Electricity From Renewables"},
-    {"url":"https://www.engadget.com/2018/11/06/fcc-caller-id-authentication-2019/","title":"FCC pushes carriers to implement caller ID authentication by 2019 to block spam and scam robocalls from going through."},
-    {"url":"http://apps.fcc.gov/ecfs/proceeding/view?name=14-28","title":"I'm calling shenanigans - FCC Comments for Net Neutrality drop from 700,000 to 200,000"},
-    {"url":"http://arstechnica.com/business/2015/02/fcc-overturns-state-laws-that-protect-isps-from-local-competition/","title":"FCC overturns state laws that protect ISPs from local competition"},
-    {"url":"https://www.theguardian.com/games/2018/dec/17/fresh-prince-actor-sues-fortnite-for-use-carlton-dance","title":"Fresh Prince actor sues Fortnite for use of 'iconic' Carlton dance - Alfonso Ribeiro wants to stop the makers of Fortnite and NBA 2K from using the dance he first performed on the 1990s sitcom"},
-    {"url":"http://thenextweb.com/apps/2016/01/15/uh-oh-controversial/","title":"F.lux creators call Apple out for releasing Night Shift after banning their app"},
-    {"url":"https://www.independent.co.uk/life-style/gadgets-and-tech/news/trump-news-google-search-results-twitter-rigged-us-president-a8510736.html","title":"President Trump claims Google is rigging search results to make him look bad."},
-    {"url":"https://www.cnbc.com/2019/01/03/apples-losses-since-peak-exceed-the-value-of-496-of-sp-500.html","title":"Apple's value has lost $446 billion since peaking in October, which is greater than the total market value of Facebook (or nearly any other US company)"},
-    {"url":"http://thehill.com/policy/technology/380691-aclu-urges-cities-to-build-public-broadband-networks-to-protect-net","title":"ACLU urges cities to build public broadband to protect net neutrality"},
-    {"url":"http://www.theverge.com/2016/5/11/11656088/payday-loan-ads-banned-from-google","title":"Google bans ads for payday loans"},
-    {"url":"https://www.privateinternetaccess.com/blog/2016/08/court-rules-isps-not-need-give-information-alleged-pirates-copyright-infringers/","title":"Court rules that ISPs do not need to give up information on alleged pirates, copyright infringers"},
-    {"url":"http://www.theverge.com/2017/4/27/15447394/fcc-net-neutrality-roll-back-startups-letter-y-combinator","title":"Kill net neutrality and you’ll kill us, say 800 US startups"},
-    {"url":"http://gizmodo.com/the-new-cispa-bill-is-literally-exactly-the-same-as-the-1679496808","title":"The New CISPA Bill Is Literally Exactly the Same as the Last One"},
-    {"url":"https://arstechnica.com/science/2017/09/solar-now-costs-6-per-kilowatt-hour-beating-government-goal-by-3-years/","title":"Solar now costs 6¢ per kilowatt-hour, beating government goal by 3 years"},
-    {"url":"https://motherboard.vice.com/en_us/article/gymdbq/sinclair-broadcasting-media-consolidation-regulations","title":"The Sinclair Horrorshow Is the Result of Decades of Failing to Take Media Consolidation Worries Seriously - An FCC commissioner says the agency has become a rubber stamp for Sinclair Broadcasting."},
-    {"url":"http://www.theverge.com/2017/2/17/14649018/youtube-ending-unskippable-30-second-ads-2018","title":"YouTube will kill unskippable 30-second ads next year"},
-    {"url":"https://www.cnbc.com/2018/04/11/goldman-asks-is-curing-patients-a-sustainable-business-model.html","title":"Goldman Sachs asks in biotech research report: 'Is curing patients a sustainable business model?'"},
-    {"url":"https://www.cnbc.com/2018/11/27/read-google-employees-open-letter-protesting-project-dragonfly.html","title":"Google employees: We no longer believe the company places values over profits"},
-    {"url":"https://www.techdirt.com/articles/20180620/12174040079/att-successfully-derails-californias-tough-new-net-neutrality-law.shtml","title":"AT&T Successfully Derails California's Tough New Net Neutrality Law"},
-    {"url":"https://consumerist.com/2017/06/15/netflix-changes-its-mind-decides-maybe-it-does-care-about-net-neutrality-again/","title":"Netflix Changes Its Mind, Decides Maybe It Does Care About Net Neutrality Again"},
-    {"url":"https://cei.org/blog/uber-wants-make-it-illegal-operate-your-own-self-driving-car-cities","title":"Uber Wants to Make It Illegal to Operate Your Own Self-Driving Car in Cities"},
-    {"url":"http://www.businessinsider.com/netflix-catalog-size-shrinks-2016-9","title":"Netflix's catalog has shrunk by a whopping 50% in the past few years"},
-    {"url":"http://www.dslreports.com/shownews/FCC-Refuses-to-Release-47000-Net-Neutrality-Complaints-139977","title":"FCC Refuses to Release 47,000 Net Neutrality Complaints"},
-    {"url":"https://wikileaks.org/tpp-ip3/WikiLeaks-TPP-IP-Chapter/WikiLeaks-TPP-IP-Chapter-051015.pdf","title":"TPP leaked: final draft of the intellectual property chapter, which some claim will destroy the internet as we know it, made available by Wikileaks"},
-    {"url":"http://www.theregister.co.uk/2017/10/11/trump_protest_website_privacy_latest/","title":"Judge says US govt has 'no right to rummage' through anti-Trump protest website logs"},
-    {"url":"https://www.yahoo.com/news/house-democrats-call-investigation-fcc-190101716.html","title":"House Democrats Call for Investigation of FCC Chairman Over Sinclair Merger"},
-    {"url":"http://www.ibtimes.co.uk/sci-hub-russian-neuroscientist-running-pirate-bay-scientists-48-million-free-academic-papers-1543926?","title":"Sci-Hub: Russian neuroscientist running 'Pirate Bay for scientists' with 48 million free academic papers"},
-    {"url":"http://www.huffingtonpost.com/entry/57e43749e4b05d3737be5784?timestamp=1474574566927","title":"77% of Ad Blocking Users Feel Guilty about Blocking Ads; \"The majority of ad blocking users are not downloading ad blockers to remove online advertising completely, but rather to fix user-experience problems\""},
-    {"url":"https://www.recode.net/2018/3/27/17170552/snapchat-api-data-sharing-facebook","title":"Snapchat is building the same kind of data-sharing API that just got Facebook into trouble."},
-    {"url":"https://www.wired.com/story/ajit-pais-plan-will-take-broadband-away-from-poor-people/","title":"Ajit Pai’s Plan Will Take Broadband Away From Poor People"},
-    {"url":"https://duckduckgo.com/traffic","title":"DuckDuckGo Traffic is Exploding"},
-    {"url":"https://www.theverge.com/2018/4/30/17303086/bill-gates-trump-white-house-science-advisor","title":"Bill Gates told Trump that being his science adviser is ‘not a good use of my time.’"},
-    {"url":"https://www.theroot.com/netneutrality-us-supreme-court-hands-over-a-major-vic-1830269778","title":"#NetNeutrality: Supreme Court Hands Over a Major Victory for Open Internet Advocates"},
-    {"url":"https://www.theguardian.com/money/2016/dec/31/french-workers-win-legal-right-to-avoid-checking-work-email-out-of-hours","title":"French workers win legal right to avoid checking work email out-of-hours"},
-    {"url":"http://jeffreyfossett.com/2017/05/13/fcc-filings.html","title":"FCC Filings Overwhelmingly Support Net Neutrality Once Spam is Removed [Data Analysis]"},
-    {"url":"https://techcrunch.com/2017/11/21/the-fccs-craven-net-neutrality-vote-announcement-makes-no-mention-of-the-22-million-comments-filed/","title":"The FCC’s craven net neutrality vote announcement makes no mention of the 22 million comments filed"},
-    {"url":"https://www.fightforthefuture.org/news/2017-10-26-the-fcc-will-soon-vote-to-kill-net-neutrality-but/","title":"The FCC will soon vote to kill net neutrality. But Congress can stop them if they hear from constituents now."},
-    {"url":"https://www.masslive.com/politics/index.ssf/2018/11/us_sen_ed_markey_says_mobile_c.html","title":"US Sen. Ed Markey says mobile carriers' alleged throttling practices highlight need for 'net neutrality'"},
-    {"url":"https://www.washingtonpost.com/news/the-watch/wp/2016/03/10/surprise-nsa-data-will-soon-routinely-be-used-for-domestic-policing-that-has-nothing-to-do-with-terrorism","title":"Surprise! NSA data will soon routinely be used for domestic policing that has nothing to do with terrorism"},
-    {"url":"http://www.cnet.com/news/amazons-next-noise-canceling-headphones-could-turn-off-when-someone-yells-your-name/","title":"Amazon patents a noise-canceling headphone that automatically turns off when it detects certain sound patterns, frequencies or key words like a name."},
-    {"url":"http://english.alarabiya.net/en/News/middle-east/2017/12/31/Iran-cuts-off-Internet-service-in-several-cities-as-mass-protests-erupt.html","title":"Iran cuts off internet access in several cities as mass protests continue."},
-    {"url":"http://www.csmonitor.com/World/Passcode/Passcode-Voices/2016/0419/Opinion-Burr-Feinstein-antiencryption-bill-a-firing-offense","title":"Sens. Richard Burr (R) of North Carolina and Dianne Feinstein (D) of California should be stripped of their positions for introducing a bill that would endanger American digital security and privacy."},
-    {"url":"https://www.recode.net/2017/7/25/16026184/mark-zuckerberg-artificial-intelligence-elon-musk-ai-argument-twitter","title":"Mark Zuckerberg thinks AI fearmongering is bad. Elon Musk thinks Zuckerberg doesn’t know what he’s talking about."},
-    {"url":"https://www.techdirt.com/articles/20170919/10061338239/fcc-sued-ignoring-foia-request-investigating-fraudulent-net-neutrality-comments.shtml","title":"FCC Sued For Ignoring FOIA Request Investigating Fraudulent Net Neutrality Comments"},
-    {"url":"http://www.thelocal.se/20151127/swedish-court-we-cannot-ban-pirate-bay","title":"Swedish court: \"We cannot ban Pirate Bay.\" In a landmark decision, a Swedish court on Friday ruled that the country's internet service providers cannot be forced to block controversial Swedish file-sharing site Pirate Bay."},
-    {"url":"http://www.dslreports.com/shownews/Porn-Companies-Join-The-Fight-For-Net-Neutrality-139831","title":"Porn Companies Join The Fight For Net Neutrality: \"Without [net neutrality], the cable and wireless companies that control internet access will have unfair power to pick winners and losers in the market,\" Corey Price, VP of Pornhub,"},
-    {"url":"https://www.engadget.com/2016/08/11/adblock-plus-bypasses-facebooks-attempt-to-restrict-ad-blockers/","title":"Adblock Plus bypasses Facebook's attempt to restrict ad blockers. \"It took only two days to find a workaround.\""},
-    {"url":"https://motherboard.vice.com/en_us/article/tennessee-could-give-taxpayers-americas-fastest-internet-for-free-but-it-will-give-comcast-and-atandt-dollar45-million-instead","title":"Tennessee Could Give Taxpayers America's Fastest Internet For Free, But It Will Give Comcast and AT&T $45 Million Instead"},
-    {"url":"https://arstechnica.com/gaming/2018/08/netflix-begins-testing-ads-for-its-own-series-between-binge-season-episodes/","title":"Netflix will now interrupt series binges with video ads for its other series"},
-    {"url":"https://www.theguardian.com/technology/2017/mar/10/elon-musk-i-can-fix-south-australia-power-network-in-100-days-or-its-free","title":"Elon Musk: I can fix South Australia power network in 100 days or it's free"},
-    {"url":"https://www.theguardian.com/technology/2017/aug/20/elon-musk-killer-robots-experts-outright-ban-lethal-autonomous-weapons-war","title":"Elon Musk leads 116 experts calling for outright ban on killer robots - Open letter signed by Tesla chief and Google’s Mustafa Suleyman urges UN to block use of lethal autonomous weapons to prevent third age of war"},
-    {"url":"https://www.recode.net/2017/8/26/16205010/hurricane-harvey-texas-att-verizon-wireless-telecom-emergency-alert-system","title":"Before Hurricane Harvey, wireless carriers lobbied against upgrades to a national emergency alert system - A wonky debate at the FCC has real-life consequences, and public-safety officials aren’t happy"},
-    {"url":"http://gizmodo.com/the-fbi-says-its-malware-isn-t-malware-because-the-fbi-1783537208","title":"The FBI Says Its Malware Isn’t Malware Because the FBI Is Good"},
-    {"url":"http://torrentfreak.com/pirate-bay-founder-will-wear-handcuffs-to-carry-fathers-coffin-140917/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+Torrentfreak+%28Torrentfreak%29","title":"Pirate Bay Founder \"Will Wear Handcuffs\" to Carry Father's Coffin \"While the Pirate Bay founder will be allowed to attend the funeral, prison staff have told him he can expect to carry the coffin while wearing handcuffs. For someone convicted of copyright offenses with just 50 days sentence left ..\""},
-    {"url":"https://www.businessinsider.com/facebook-approved-political-ads-paid-for-by-cambridge-analytica-2018-10","title":"We ran 2 fake ads pretending to be Cambridge Analytica — and Facebook failed to catch that they were frauds"},
-    {"url":"https://arstechnica.com/information-technology/2018/07/att-promised-lower-prices-after-time-warner-merger-its-raising-them-instead/","title":"AT&T promised lower prices after Time Warner merger—it’s raising them instead."},
-    {"url":"https://techcrunch.com/2017/05/16/fcc-commissioner-net-neutrality-is-doomed-if-were-silent/","title":"FCC commissioner: ‘Net neutrality is doomed if we’re silent’"},
-    {"url":"http://arstechnica.com/business/2014/12/data-caps-limited-competition-a-recipe-for-trouble-in-home-internet-service/","title":"The FCC is not addressing home data caps because \"the number of consumer complaints regarding Usage Based Pricing by fixed providers appears to be small\". Go increase the number! Link in comments."},
-    {"url":"https://www.techspot.com/news/75754-spectrum-allegedly-throttled-content-providers-netflix-riot-games.html","title":"Spectrum allegedly throttled content providers Netflix and Riot Games for money. So much for that Net Neutrality rollback"},
-    {"url":"https://gizmodo.com/ajit-pai-refuses-to-brief-lawmakers-over-phone-tracking-1831750774","title":"Ajit Pai Refuses to Brief Lawmakers Over Phone-Tracking Scandal, Dubiously Blames Shutdown"},
-    {"url":"http://www.theregister.co.uk/2017/01/07/tv_anchor_says_alexa_buy_me_a_dollhouse_and_she_does/?mt=1483795705927","title":"TV anchor says live on-air 'Alexa, order me a dollhouse' – story on accidental Alexa order sets off Alexa-powered Echo boxes around San Diego on their own shopping sprees"},
-    {"url":"http://www.theverge.com/2016/7/11/12147600/nintendos-stock-pokemon-go","title":"Pokémon Go's success adds $7.5 billion to Nintendo's market value"},
-    {"url":"http://bgr.com/2014/07/28/twc-vs-google-netflix/","title":"Time Warner Cable hilariously claims that Google and Netflix are the real threats to net neutrality"},
-    {"url":"https://arstechnica.com/tech-policy/2018/06/ajit-pais-fcc-lied-about-ddos-attack-ex-chairs-statement-indicates/","title":"Ajit Pai’s FCC lied about “DDoS” attack, ex-chair’s statement indicates - Wheeler: There was no \"coverup\" of 2014 DDoS attack, because there was no DDoS."},
-    {"url":"https://arstechnica.com/tech-policy/2018/11/cops-pull-over-tesla-cruising-on-a-freeway-with-apparently-asleep-driver/","title":"It took seven miles to pull over a Tesla with a seemingly asleep driver - The driver was arrested for drunk driving."},
-    {"url":"https://gizmodo.com/least-transparent-fcc-ever-goes-dark-as-former-it-chief-1826631088","title":"A former FCC senior official who issued false statements to reporters, claiming a cyberattack hobbled the agency’s comment system in 2014 and that the ex-chairman ordered it kept quiet, is now backpedaling amid renewed scrutiny by U.S. lawmakers and a wholesale denial by the former chairman himself."},
-    {"url":"https://motherboard.vice.com/read/five-states-are-considering-bills-to-legalize-the-right-to-repair-electronics","title":"Five States Are Considering Bills to Legalize the 'Right to Repair' Electronics"},
-    {"url":"http://www.bbc.co.uk/news/world-us-canada-47036515","title":"US charges China's Huawei with fraud"},
-    {"url":"https://www.pbs.org/newshour/politics/texans-say-voting-machines-are-flipping-selections-to-the-other-party","title":"Texans say voting machines are flipping selections to the other party"},
-    {"url":"https://motherboard.vice.com/en_us/article/wjmddq/study-finds-that-leaving-facebook-makes-you-happier-and-less-informed","title":"Leaving Facebook Makes You Happier, less politically informed, more active in IRL activities, and less likely to go back to Facebook."},
-    {"url":"https://www.latimes.com/world/europe/la-fg-germany-coal-power-20190126-story.html","title":"Germany to close all 84 of its coal-fired power plants, will rely primarily on renewable energy"},
-    {"url":"http://www.dslreports.com/shownews/Comcast-Accused-Again-of-Billing-Fraud-140942","title":"Comcast Accused (Again) of Billing Fraud: \"Comcast may have signed up more than half of all SPP subscribers without their consent,\" and in numerous instances charged customers for the SPP plan after telling them it was \"free.\""},
-    {"url":"https://techcrunch.com/2017/12/28/trump-500-internal-server-error-obama-joke/","title":"Trump’s website is coded with a broken server error message that blames Obama"},
-    {"url":"https://www.businessinsider.com/googles-top-executives-stopped-posting-on-google-at-least-a-year-ago-2018-10","title":"The biggest clue that Google+ was long dead - Google's top executives stopped using it up to 3 years ago"},
-    {"url":"https://www.usatoday.com/story/tech/2018/04/08/apple-co-founder-steve-wozniak-says-hes-leaving-facebook/497392002/","title":"Apple co-founder Steve Wozniak says he's leaving Facebook"},
-    {"url":"https://www.wired.com/story/warrantless-us-spying-is-set-to-expire-soon-let-it-die","title":"Warrantless US Spying Is Set to Expire Soon. Let It Die"},
-    {"url":"http://www.nationalreview.com/article/421516/stop-internet-streaming-tax","title":"As of July 1, 2015, citizens of Chicago who enjoy their Netflix, Spotify, Pandora, Amazon Prime, Xbox Live, and/or PlayStation Network subscriptions are now subject to the city’s 9 percent “Amusement Tax” for the privilege."},
-    {"url":"https://www.politico.com/story/2018/06/18/senate-rejects-trumps-rescue-of-chinese-firm-zte-652459","title":"Senate rejects Trump’s rescue of Chinese firm ZTE"},
-    {"url":"https://www.cnet.com/news/net-neutrality-is-officially-dead-fcc-ajit-pai-now-what","title":"Net neutrality is officially dead. Now what? - The FCC has taken the final step in erasing the 2015 rules protecting the internet."},
-    {"url":"https://www.usatoday.com/story/tech/news/2018/04/22/google-amazon-push-power-companies-solar-and-wind-blow-coal/438020002/","title":"Tech firms like Google, Amazon push power companies toward solar and wind, a blow to coal"},
-    {"url":"https://www.theverge.com/2018/5/1/17308418/fcc-commissioner-orielly-trump-law","title":"FCC commissioner broke the law by advocating for Trump, officials find"},
-    {"url":"https://motherboard.vice.com/en_us/article/qvajpv/michigan-teen-right-to-repair","title":"This 17-Year-Old Has Become Michigan's Leading Right to Repair Advocate - When Surya Raghavendran dropped his iPhone, he learned to repair it himself. Now he wants to protect that right for everyone in his home state of Michigan."},
-    {"url":"http://newnetworks.com/ShortSCANDALSummary.htm","title":"Just a reminder You already paid for High Speed Fiber Optic Infrastructure in the USA."},
-    {"url":"http://informitv.com/2014/11/12/president-obama-calls-for-net-neutrality/","title":"President Obama calls for net neutrality, demanding no blocking, no throttling, increased transparency, and no paid prioritization"},
-    {"url":"https://www.theverge.com/2017/8/9/16114530/net-neutrality-crusade-against-verizon-alex-nguyen-fcc","title":"As net neutrality dies, one man wants to make Verizon pay for its sins"},
-    {"url":"https://blog.mozilla.org/blog/2018/08/20/mozilla-files-arguments-against-the-fcc-latest-step-in-fight-to-save-net-neutrality/","title":"Mozilla files arguments against the FCC – latest step in fight to save net neutrality"},
-    {"url":"https://www.nature.com/articles/d41586-018-05357-w","title":"Sucking carbon dioxide from air is cheaper than scientists thought"},
-    {"url":"https://gizmodo.com/facebook-fined-just-645-000-in-uk-over-cambridge-analy-1829989116","title":"Facebook Fined Just $645,000 in UK Over Cambridge Analytica Scandal, Money It Makes in Less Than 10 Minutes"},
-    {"url":"https://www.techdirt.com/articles/20181009/11353140804/new-verizon-ad-hopes-to-make-you-forget-it-throttled-firefighters-no-reason.shtml","title":"New Verizon Ad Hopes To Make You Forget It Throttled Firefighters For No Reason"},
-    {"url":"https://www.mercurynews.com/2018/08/23/california-state-assembly-plans-hearing-on-verizon-throttling-of-firefighters-data/","title":"California State Assembly plans hearing on Verizon throttling of firefighters’ data"},
-    {"url":"http://theantimedia.org/google-to-begin-alerting-users-if-gmail-account-is-targeted-by-government/","title":"Google To Begin Alerting Users if Gmail Account is Targeted by Government"},
-    {"url":"http://www.zdnet.com/article/snoopers-charter-expansive-new-spying-powers-becomes-law/","title":"Britain just passed the \"most extreme surveillance law ever passed in a democracy\""},
-    {"url":"https://nakedsecurity.sophos.com/2018/11/01/passcodes-are-protected-by-fifth-amendment-says-court/","title":"Passcodes are protected by Fifth Amendment, says court"},
-    {"url":"https://www.techdirt.com/articles/20160603/06530234613/broadband-ceos-admit-usage-caps-are-nothing-more-than-toll-uncompetitive-markets.shtml","title":"Broadband CEOs Admit Usage Caps Are Nothing More Than A Toll On Uncompetitive Markets"},
-    {"url":"https://www.techdirt.com/articles/20171023/11391838461/michigan-lawmaker-flees-twitter-after-reports-highlight-she-helped-att-push-anti-competition-broadband-law.shtml","title":"Michigan Lawmaker Flees Twitter After Reports Highlight She Helped AT&T Push Anti-Competition Broadband Law"},
-    {"url":"https://qz.com/930512/the-most-striking-thing-about-the-wikileaks-cia-data-dump-is-how-little-most-people-cared/","title":"The most striking thing about the WikiLeaks CIA data dump is how little most people cared"},
-    {"url":"https://www.wired.com/story/fcc-pledges-openness-just-dont-ask-to-see-complaints/","title":"FCC Pledges Openness – Just Don't Ask To See Complaints: \"The FCC seems more concerned with helping Big Cable than living up to his promise.\""},
-    {"url":"https://www.techdirt.com/articles/20171129/23412638704/after-attacking-random-hollywood-supporters-net-neutrality-ajit-pai-attacks-internet-companies.shtml","title":"After Attacking Random Hollywood Supporters Of Net Neutrality, Ajit Pai Attacks Internet Companies"},
-    {"url":"https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/","title":"Introducing the New Firefox: Firefox Quantum"},
-    {"url":"https://www.commondreams.org/news/2018/06/13/shallow-best-and-ridiculous-worst-analysis-eviscerates-fcc-chairs-arguments-killing","title":"'Shallow at Best and Ridiculous at Worst': Analysis Eviscerates FCC Chair's Arguments for Killing Net Neutrality"},
-    {"url":"https://www.usatoday.com/story/tech/2017/09/12/internet-companies-too-big-ftc-chair-says-more-than-market-share-counts/656394001/","title":"Internet companies too big? FTC chair says more than market share counts: “we are spiraling towards a dystopian future where a few giant technology companies will ultimately gain sustained control over our economic lives.”"},
-    {"url":"https://gizmodo.com/the-nra-quadrupled-its-digital-ad-budget-after-parkland-1824050808","title":"The NRA Quadrupled Its Digital Ad Budget After Parkland Killings, Flooding Facebook and YouTube"},
-    {"url":"http://www.ibtimes.com/fbi-forced-twitter-share-user-data-without-legal-warrant-company-reveals-gag-orders-2482632","title":"FBI Forced Twitter To Share User Data Without Legal Warrant, Company Reveals As Gag Orders Lifted"},
-    {"url":"https://techcrunch.com/2017/10/24/congress-votes-to-disallow-consumers-from-suing-equifax-and-other-companies-with-arbitration-agreements/","title":"Congress votes to disallow consumers from suing Equifax and other companies with arbitration agreements."},
-    {"url":"http://motherboard.vice.com/read/jailbreaking-iphone-rooting-android-does-not-void-warranty","title":"Companies Can’t Legally Void the Warranty for Jailbreaking or Rooting Your Phone"},
-    {"url":"https://www.fastcompany.com/40445949/ex-chair-tom-wheeler-dismantles-fccs-argument-to-abandon-net-neutrality","title":"Ex-FCC Chair Tom Wheeler Dismantles The Case For Abandoning Net Neutrality - The Trump FCC is simply doing the bidding of Comcast, AT&T, Verizon, and Charter in its quest to abandon rules against blocking, slowing, or speeding internet traffic, Wheeler says."},
-    {"url":"https://arstechnica.com/tech-policy/2017/08/att-absurdly-claims-that-most-legitimate-net-neutrality-comments-favor-repeal/?comments=1","title":"AT&T absurdly claims that most “legitimate” net neutrality comments favor repeal"},
-    {"url":"http://www.washingtonpost.com/opinions/kickstarter-ceo-fccs-fast-lane-internet-plan-threatens-free-exchange-of-ideas/2014/07/04/a52ffd2a-fcbc-11e3-932c-0a55b81f48ce_story.html?tid=rssfeed","title":"FCC’s ‘fast lane’ Internet plan threatens free exchange of ideas \"Once a fast lane exists, it will become the de facto standard on the Web. Sites unwilling or unable to pay up will be buffered to death: unloadable, unwatchable and left out in the cold.\""},
-    {"url":"http://thehill.com/blogs/congress-blog/judicial/360895-senate-chooses-wall-street-over-consumers-seniors-and-service","title":"Senate chooses Wall Street over consumers, seniors, and service members - “senators decided that consumers should lose the right to hold massive financial institutions like Wells Fargo and Equifax accountable.”"},
-    {"url":"http://qz.com/859860/bill-gates-is-leading-a-new-1-billion-fund-focused-on-combatting-climate-change-through-innovation/","title":"Bill Gates and investors worth $170 billion are launching a fund to fight climate change through energy innovation"},
-    {"url":"http://www.freeingenergy.com/the-market-has-spoken-clean-energy-just-became-the-cheapest-source-of-electricity/","title":"The market has spoken – clean energy just became the cheapest source of electricity"},
-    {"url":"https://rietta.com/blog/2016/04/08/feinstein-burr-encryption-bill/","title":"U.S. Senate Bill Seeks to Ban Effective Encryption, Making Security Illegal"},
-    {"url":"http://www.zdnet.com/article/fcc-will-not-publish-evidence-of-alleged-ddos-attack/","title":"FCC says it was hit by a DDoS attack, but refuses to show any evidence"},
-    {"url":"https://mashable.com/2018/07/23/net-neutrality-cra-campaign-donations-scorecard/#BGAUEdVuCqqT","title":"Here's how much money anti-net neutrality members of Congress have received from the telecom industry"},
-    {"url":"http://gawker.com/former-reddit-ceo-youre-all-screwed-1717901652","title":"Former Reddit CEO Yishan Wong's latest big reveal: Reddit’s board has been itching to purge hate-based subreddits since the beginning. And recently, the only thing stopping them had been... Ellen Pao. Whoops."},
-    {"url":"https://www.techdirt.com/articles/20161220/12411836320/company-bricks-users-software-after-he-posts-negative-review.shtml","title":"Company Bricks User's Software After He Posts A Negative Review"},
-    {"url":"https://motherboard.vice.com/en_us/article/d3dz7z/comcast-and-centurylink-spent-dollar50k-in-seattle-to-support-a-mayoral-candidate-who-opposes-community-owned-internet","title":"Comcast and CenturyLink Spent $50K in Seattle to Support a Mayoral Candidate Who Opposes Community-Owned Internet"},
-    {"url":"https://www.tremr.com/movements/facebook-facing-heavy-criticism-after-removing-major-atheist-pages","title":"Facebook Facing Heavy Criticism After Removing Major Atheist Pages"},
-    {"url":"https://www.theverge.com/2018/5/9/17334602/apple-targeting-apps-location-data-sharing-third-parties","title":"Apple is reportedly removing apps that share your location data with third parties"},
-    {"url":"http://www.theguardian.com/commentisfree/2015/jun/01/guardian-view-on-surveillance-after-edward-snowden-outlaw-rewrites-law","title":"Edward Snowden deserves a pardon at home, or else asylum in western Europe, for revealing truths that US lawmakers have recognised required a response."},
-    {"url":"https://motherboard.vice.com/en_us/article/bj49j8/fcc-falsely-claims-community-broadband-an-ominous-threat-to-the-first-amendment","title":"FCC falsely claims community broadband an 'ominous threat to the first amendment.'"},
-    {"url":"https://www.businessinsider.com/facebook-employees-react-nyt-report-leadership-scandals-2018-11","title":"Facebook employees react to the latest scandals: “Why does our company suck at having a moral compass?”"},
-    {"url":"https://www.theguardian.com/commentisfree/2017/aug/30/24-hours-left-to-protect-net-neutrality","title":"We've got less than 24 hours left to protect net neutrality - There are few government regulations that are more popular than net neutrality rules. Now, they might be scrapped"},
-    {"url":"http://www.gamerevolution.com/features/free-speech-under-attack-youtuber--repair-specialist-louis-rossmann-alludes-to-apple-lawsuit","title":"Apple is suing a man that teaches people to repair their Macbooks [ORIGINAL WORKING LINK]"},
-    {"url":"https://www.theregister.co.uk/2019/01/28/apple_iphone_batteries/","title":"Apple: You can't sue us for slowing down your iPhones because you, er, invited us into, uh, your home... we can explain"},
-    {"url":"https://www.businessinsider.com/mit-grad-made-a-robot-to-detect-water-pipe-leaks-2018-9","title":"A 28-year-old MIT graduate has created a leak-detecting robot that could eliminate some of the 2 trillion gallons of wasted drinking water annually"},
-    {"url":"https://www.pri.org/stories/2017-12-31/big-money-backing-out-fossil-fuel-industry-moving-greener-alternatives","title":"Big money is backing out of fossil fuel industry, moving into greener alternatives - “follow the dollar to see where the future of energy is headed, globally.”"},
-    {"url":"http://www.independent.co.uk/news/world/americas/fbi-director-james-comey-no-absolute-privacy-a7619621.html","title":"FBI Director James Comey says 'absolute privacy' does not exist in the US"},
-    {"url":"https://np.reddit.com/r/privacy/comments/3l4apg/avg_anti_virus_just_updated_there_privacy_policy/","title":"AVG anti virus just updated there privacy policy. it says that they can and will sell your browsing history to 3rd parties."},
-    {"url":"https://motherboard.vice.com/en_us/article/bj4ez3/motorola-becomes-first-smartphone-company-to-sell-diy-repair-kits-to-its-customers","title":"Motorola Becomes First Smartphone Company to Sell DIY Repair Kits to Its Customers"},
-    {"url":"https://www.hcn.org/issues/50.21/nuclear-energy-a-new-generation-of-environmentalists-is-learning-to-stop-worrying-and-love-nuclear-power","title":"Is nuclear energy the key to saving the planet? A new generation of environmentalists is learning to stop worrying and love atomic power."},
-    {"url":"https://www.recode.net/2019/1/6/18171035/apple-samsung-tv-service-strategy","title":"Apple is going to sell its Apple TV service on Samsung TVs, because Apple wants to be a service company: Tim Cook can’t just rely on Apple customers anymore — he needs to sell things to people who don’t buy Apple products."},
-    {"url":"https://www.theverge.com/circuitbreaker/2018/2/20/17031256/worlds-largest-ssd-drive-samsung-30-terabyte-pm1643","title":"Samsung unveils world’s largest SSD with whopping 30TB of storage. It’s the most memory ever crammed into a 2.5-inch form factor — enough to store 5,700 full HD movies"},
-    {"url":"https://www.ft.com/content/57c9f432-de6d-11e7-a0d4-0944c5f49e46","title":"Nanobots kill off cancerous tumours as fiction becomes reality - Researchers inject tiny devices into the bloodstream to deliver drugs with precision"},
-    {"url":"https://www.fightforthefuture.org/news/2018-09-15-ajit-pai-seems-really-upset-about-the-california/","title":"Ajit Pai seems really upset about the California net neutrality bill that passed with bipartisan support"},
-    {"url":"https://news.bitcoin.com/update-bitcoiners-use-tor-warned/","title":"Unless congress stops it, the FBI wants to mass-hack computers, especially targeting Tor and Bitcoin users"},
-    {"url":"https://www.theguardian.com/science/2017/jul/19/give-robots-an-ethical-black-box-to-track-and-explain-decisions-say-scientists?CMP=twt_a-science_b-gdnscience","title":"Robots should be fitted with an “ethical black box” to keep track of their decisions and enable them to explain their actions when accidents happen, researchers say."},
-    {"url":"https://arstechnica.com/tech-policy/2018/08/isps-want-to-be-utilities-but-only-to-get-more-money-from-the-government/","title":"ISPs say they can’t expand broadband unless gov’t gives them more money: Industry asks for handouts, arguing that broadband is essential—like a utility."},
-    {"url":"https://www.techdirt.com/blog/netneutrality/articles/20150123/05191129787/hey-just-silly-thought-maybe-its-time-we-stop-letting-comcast-att-write-state-telecom-law.shtml","title":"Hey, Just A Silly Thought: Maybe It's Time We Stop Letting Comcast And AT&T Write State Telecom Law?"},
-    {"url":"https://www.techdirt.com/blog/netneutrality/articles/20170722/03252237838/verizon-throttles-netflix-subscribers-test-it-doesnt-inform-customers-about.shtml","title":"Verizon Throttles Netflix Subscribers In 'Test' It Doesn't Inform Customers About"},
-    {"url":"https://medium.com/@jtabish/five-republicans-have-opposed-the-fccs-plan-we-need-to-tweet-the-rest-of-them-d7ade9df19bf","title":"Five Republicans have opposed the FCC’s plan. We need to convince the rest of them."},
-    {"url":"https://motherboard.vice.com/en_us/article/qvx3ep/whats-happening-with-lifeline-fcc-program","title":"Congress Is Trying to Stop Ajit Pai from Taking Broadband Assistance Away from the Poor: \"The Lifeline program provides subsidized communications services to low-income Americans, many of whom rely on it as their only way to access the internet.\""},
-    {"url":"http://www.businessinsider.com/why-political-ads-should-be-regulated-online-2017-9?","title":"When it comes to political ads, it's time for Facebook and Google to be held to the same standards as ABC and CBS"},
-    {"url":"https://dailym.ai/2DstYb2","title":"China 'launches an app that tells you if you are within 500 yards of someone in debt - and encourages you to report them if they seem capable of paying up'"},
-    {"url":"https://mybroadband.co.za/news/software/269659-google-has-slowed-down-youtube-on-firefox-and-edge-mozilla-exec.html","title":"Google has slowed down YouTube on Firefox and Edge according to Mozilla exec"},
-    {"url":"https://torrentfreak.com/kickasstorrents-brought-back-to-life-by-original-staffers-161216/","title":"KickassTorrents Brought Back to Life by Original Staffers"},
-    {"url":"https://edition.cnn.com/2018/12/14/tech/facebook-billion-dollar-fine/index.html","title":"Facebook could face billion dollar fine for data breaches"},
-    {"url":"http://www.usatoday.com/story/money/2017/01/29/gates-warns-against-denying-climate-change/97214936/","title":"Bill Gates warned against denying climate change and pushed for more innovation in clean energy, during an event Friday at Columbia University"},
-    {"url":"http://www.commondreams.org/news/2016/12/15/nsa-inspector-who-criticized-snowden-not-using-official-channels-found-guilty","title":"NSA Inspector Who Criticized Snowden for Not Using 'Official' Channels Found Guilty of Retaliating Against Whistleblower Who Did Just That"},
-    {"url":"http://www.businessinsider.com/people-increased-facebook-usage-after-cambridge-analytica-scandal-2018-5","title":"The backlash that never happened: New data shows people actually increased their Facebook usage after the Cambridge Analytica scandal."},
-    {"url":"https://www.cnet.com/news/wpa3-wi-fi-is-here-and-its-harder-to-hack/","title":"WPA3 Wi-Fi is here, and it's harder to hack - That's good, because the last update was during the George W. Bush administration."},
-    {"url":"http://reneweconomy.com.au/teslas-price-shock-solar-battery-as-cheap-as-grid-power-22265/","title":"Tesla's price shock: Solar + battery as cheap as grid power -... \"The price per kWh stored and re-used has halved in less than a yea\""},
-    {"url":"https://qz.com/1103874/the-us-government-underestimated-solar-energy-installation-in-the-us-by-4813-along-with-renewable-wind-and-solar-generation/","title":"The US government underestimated solar energy installation in the US by 4,813%"},
-    {"url":"https://www.salon.com/2018/08/19/gop-leader-accuses-twitter-of-censoring-conservatives-finds-out-his-user-settings-was-hiding-tweets/","title":"GOP leader accuses Twitter of censoring conservatives, finds out his user settings was hiding tweets"},
-    {"url":"https://theintercept.com/2017/09/23/police-schedule-7-uk-rabbani-gchq-passwords/","title":"Airport police demanded activist’s passwords. He refused. Now faces prison in UK"},
-    {"url":"https://torrentfreak.com/pirate-bay-founders-acquitted-in-criminal-copyright-case-150710/","title":"Pirate bay founders acquitted in criminal copyright case"},
-    {"url":"http://bgr.com/2015/01/06/google-vs-verizon-att-wireless/","title":"Google wants to make wireless networks that will free you from AT&T and Verizon’s data caps"},
-    {"url":"https://nypost.com/2018/09/01/stop-treating-tech-jerks-like-gods/","title":"Stop treating tech jerks like gods"},
-    {"url":"https://arstechnica.com/?post_type=post&p=1198755","title":"Republican tax plan kills electric vehicle credit"},
-    {"url":"https://github.com/mandatoryprogrammer/NorthKoreaDNSLeak","title":"North Korea accidentally leaks DNS for .kp: only 28 domains"},
-    {"url":"http://motherboard.vice.com/read/reddit-admits-its-front-page-is-broken-is-working-on-an-entirely-new-algorithm","title":"Reddit Admits Its Front Page Is Broken, Is Working on an Entirely New Algorithm"},
-    {"url":"https://www.bostonglobe.com/business/2018/12/30/here-why-this-western-mass-town-rejected-comcast-and-built-its-own-broadband-network/w8RdFWzwGLiRqWviYIBL2M/story.html","title":"This Western Mass. town rejected Comcast and built its own broadband network - The Boston Globe"},
-    {"url":"https://www.bloomberg.com/news/articles/2019-01-08/samsung-phone-users-get-a-shock-they-can-t-delete-facebook","title":"Samsung Phone Users Perturbed to Find They Can't Delete Facebook"},
-    {"url":"http://qz.com/263950/hbo-is-now-seriously-considering-whether-to-offer-hbo-go-without-cable-tv/","title":"HBO is now “seriously considering” whether to offer HBO Go without cable TV"},
-    {"url":"https://shanghai.ist/2018/08/16/chinas-first-fully-homegrown-web-browser-found-to-be-google-chrome-clone/","title":"China’s first ‘fully homegrown’ web browser found to be Google Chrome clone"},
-    {"url":"https://www.androidcentral.com/all-major-us-carriers-give-your-real-time-location-info-third-parties","title":"All major U.S. carriers give your real-time location info to third parties"},
-    {"url":"https://www.theverge.com/2018/6/27/17511500/att-admin-fee-increase-wireless-bill-cover-costs","title":"AT&T more than doubles ‘admin fee’ for every wireless customer | Increase will net telecom giant $800 million a year"},
-    {"url":"https://www.telegraph.co.uk/news/2017/05/19/instagram-ranked-worst-social-network-young-peoples-mental-health/","title":"Instagram ranked worst social network for young people's mental health"},
-    {"url":"https://www.theverge.com/2019/1/29/18202602/san-francisco-facial-recognition-ban-proposal","title":"San Francisco proposal would ban government facial recognition use in the city"},
-    {"url":"http://www.streamingobserver.com/netflix-now-allows-download-programming/","title":"Netflix Now Allows You to Download Content for Offline Viewing"},
-    {"url":"https://www.techdirt.com/articles/20180426/11195739727/cord-cutting-is-obvious-result-70-spike-cable-tv-prices-since-2000.shtml","title":"Cord Cutting Is The Obvious Result Of A 70% Spike In Cable TV Prices Since 2000"},
-    {"url":"https://thehill.com/policy/technology/425926-court-rejects-fcc-request-to-delay-net-neutrality-case","title":"Court rejects FCC request to delay net neutrality case"},
-    {"url":"https://www.bloomberg.com/view/articles/2018-10-08/google-privacy-glitch-no-we-did-not-consent-to-this","title":"No, Google, We Did Not Consent to This - The company knew about a privacy glitch and kept quiet. That has to stop."},
-    {"url":"http://venturebeat.com/2015/06/10/pornhub-is-crowdfunding-3-4m-to-explore-the-final-frontier/","title":"PornHub is crowdfunding $3.4M to shoot a sex tape in space"},
-    {"url":"http://customwire.ap.org/dynamic/stories/U/US_COMMUNITY_SOLAR_POWER?SITE=AP&SECTION=HOME&TEMPLATE=DEFAULT","title":"US utilities seek sun as Trump sides with coal, fossil fuels | Solar growth is so extensive and has so much momentum behind it that we're at the point where you can't put the genie back in the bottle,\" said Jeffrey R.S. Brownson, a Pennsylvania State University professor who studies solar adoption"},
-    {"url":"http://www.alternet.org/economy/chris-hedges-tpp-most-brazen-corporate-power-grab-american-history","title":"The TPP is the Most Brazen Corporate Power Grab in American History: It's worst than any of us feared"},
-    {"url":"http://heatst.com/tech/germany-considers-fining-facebook-522000-per-fake-news-item/","title":"Germany Considers Fining Facebook $522,000 Per Fake News Item"},
-    {"url":"http://www.mirror.co.uk/tech/reddit-brings-down-north-koreas-8881736","title":"Reddit brings down North Korea's entire internet after links to country's 28 websites are posted online"},
-    {"url":"https://arstechnica.com/tech-policy/2018/03/please-dont-take-broadband-away-from-poor-people-democrats-tell-fcc-chair/","title":"Please don’t take broadband away from poor people, Democrats tell FCC chair"},
-    {"url":"https://www.engadget.com/2018/09/28/zuckerberg-facebook-page-hacker-livestream/","title":"Hacker says he'll livestream deletion of Zuckerberg's Facebook page"},
-    {"url":"https://hothardware.com/news/google-fiber-scales-back-tv-service-to-focus-solely-on-gigabit-internet","title":"Google Fiber Scales Back TV Service To Focus Solely On High-Speed Internet"},
-    {"url":"http://money.cnn.com/2017/12/07/technology/anheuser-busch-tesla/index.html","title":"Anheuser-Busch orders 40 Tesla trucks"},
-    {"url":"https://gizmodo.com/british-police-identify-two-russian-suspects-in-novicho-1827710334","title":"British Police Identify Two Russian Suspects in Novichok Poisonings Using Facial Recognition Tech"},
-    {"url":"http://www.dailydot.com/politics/trump-closing-the-internet-up-in-some-way/?tw=dd","title":"Donald Trump wants to close up the Internet, saying \"We have to go see Bill Gates,” to better understand the Internet and then possibly “close it up.”“We’re losing a lot of people because of the Internet.”"},
-    {"url":"https://www.cbsnews.com/news/80-percent-of-mass-shooters-showed-no-interest-in-video-games-researcher-says/","title":"80 percent of mass shooters showed no interest in video games, researcher says"},
-    {"url":"http://thehill.com/policy/technology/367929-senate-bill-to-reverse-net-neutrality-repeal-wins-30th-co-sponsor-ensuring","title":"Senate bill to reverse net neutrality repeal gains 30th co-sponsor, ensuring floor vote"},
-    {"url":"https://www.theguardian.com/uk-news/2018/oct/06/police-drone-finds-girl-16-who-called-999-to-report","title":"UK Police drone finds girl, 16, who called 999 to report rape - The force said the thermal drone was used to find the girl and guide officers to her within minutes."},
-    {"url":"https://motherboard.vice.com/en_us/article/yw5bpv/fcc-caf-auction-final-census-blocks","title":"The FCC Disqualified a Bunch of Rural Communities from Receiving Internet Funding After Big Telecom Said They Already Have Internet"},
-    {"url":"http://www.commondreams.org/news/2017/03/23/here-are-50-gop-senators-who-just-sacrificed-your-broadbandprivacy-corporate-profits","title":"Here Are the 50 GOP Senators Who Just Sacrificed Your #BroadbandPrivacy to Corporate Profits: 'Extremely disappointing that the Senate voted today to sacrifice the privacy rights of Americans in the interest of protecting the profits of major internet companies'"},
-    {"url":"https://www.techdirt.com/articles/20170213/14460536703/comcast-att-are-paying-minority-groups-to-support-killing-net-neutrality.shtml","title":"Comcast, AT&T Are Paying Minority Groups To Support Killing Net Neutrality"},
-    {"url":"https://www.commondreams.org/news/2018/12/19/zuckerberg-must-resign-now-outrage-after-report-shows-facebook-let-corporate","title":"'Zuckerberg Must Resign Now': Outrage After Report Shows Facebook Let Corporate Partners Read Users' Private Messages"},
-    {"url":"https://arstechnica.com/tech-policy/2017/08/shunned-by-godaddy-and-google-racist-daily-stormer-moves-to-russian-domain/","title":"Racist Daily Stormer moves to Russian domain after losing .com address"},
-    {"url":"https://arstechnica.com/tech-policy/2018/12/centurylink-blocks-internet-access-falsely-claims-state-law-required-it/","title":"CenturyLink blocked its customers’ Internet access in order to show an ad - Utah customers were booted offline until they acknowledged security software ad."},
-    {"url":"https://www.bloomberg.com/view/articles/2018-01-03/americans-should-have-more-control-over-their-data","title":"Americans Should Have More Control Over Their Data - In Europe, internet users will soon get to decide how their online activity is tracked. The U.S. should follow suit."},
-    {"url":"http://www.popularmechanics.com/technology/gadgets/a19607/apple-ceo-we-will-take-this-iphone-case-to-the-supreme-court/","title":"Apple CEO: We Will Take This iPhone Case to the Supreme Court"},
-    {"url":"http://undergroundreporter.org/fbi-quiet-biometrics-database/","title":"The Federal Bureau of Investigation (FBI) is attempting to suppress information about a massive database which contains fingerprints, palm prints, iris, voice, and face scans, as well as other biometric data, of millions of Americans."},
-    {"url":"http://fortune.com/2018/11/08/mark-zuckerberg-facebook-reputation/","title":"Facebook Is the Least Trusted Major Tech Company When it Comes to Safeguarding Personal Data, Poll Finds"},
-    {"url":"http://www.marketwatch.com/story/400-college-professors-say-consumers-should-be-able-to-sue-equifax-and-other-financial-institutions-2017-09-25","title":"400 college professors say consumers should be able to sue Equifax and other financial institutions - The professors sent a letter to senators protesting mandatory arbitration clauses"},
-    {"url":"https://www.bloombergquint.com/business/2018/09/22/draft-order-for-trump-would-crack-down-on-google-facebook#gs.BHhDros","title":"The White House has drafted an executive order for President Donald Trump’s signature that would instruct federal antitrust and law enforcement agencies to open investigations into the business practices of Alphabet Inc.’s Google, Facebook Inc. and other social media companies."},
-    {"url":"https://www.techdirt.com/articles/20160329/15041234047/71-want-dark-net-shut-down-showing-most-have-no-idea-what-dark-net-is.shtml","title":"71% Want The Dark Net Shut Down, Showing Most Have No Idea What The Dark Net Is"},
-    {"url":"http://arstechnica.com/tech-policy/2015/03/nypd-caught-red-handed-sanitizing-police-brutality-wikipedia-entries/","title":"NYPD caught red-handed sanitizing police brutality Wikipedia entries"},
-    {"url":"https://medium.com/@fightfortheftr/yes-the-fcc-repeal-entered-the-federal-register-today-but-that-does-not-mean-net-neutrality-is-dd149af408e9","title":"Yes, the FCC repeal entered the Federal Register today, but that does NOT mean net neutrality is dead. We now have 60 legislative days to overrule the FCC using the Congressional Review Act, and there’s a massive online protest planned this Tuesday."},
-    {"url":"https://www.theverge.com/2018/7/5/17535814/uk-face-recognition-police-london-accuracy-completely-comfortable","title":"London police chief ‘completely comfortable’ using facial recognition with 98 percent false positive rate"},
-    {"url":"https://www.businessinsider.com/ibm-is-reportedly-nearing-a-deal-to-acquire-redhat-the-software-company-valued-at-20-billion-2018-10","title":"IT'S OFFICIAL: IBM is acquiring software company Red Hat for $34 billion"},
-    {"url":"http://gizmodo.com/the-sony-pictures-hack-exposed-budgets-layoffs-and-3-1665739357/1666122168/+ace","title":"Sony hack is potentially the worst in history. 100 TB stolen, including unreleased movies & scripts, medical records, 3800 SSNs, etc."},
-    {"url":"http://www.bbc.co.uk/news/world-europe-36423250","title":"Longest Tunnel in the World Opened Today: 57 km from Switzerland to Italy underneath Alps; Took 17 Years to Build."},
-    {"url":"https://mashable.com/2018/01/24/nsa-core-values-honesty-deleted.amp","title":"The NSA literally deleted 'trust' and 'honesty' from its core values"},
-    {"url":"http://www.networkworld.com/article/3077932/windows/credibility-and-trust-microsoft-blows-it.html","title":"Credibility and trust: Microsoft blows it by forcing Windows 10 on users"},
-    {"url":"http://electrek.co/2015/05/28/ford-follow-teslas-lead-and-open-all-their-electric-vehicles-patents/","title":"Ford follows Tesla’s lead and opens all their electric vehicle patents"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/04/dear-fcc-destroying-net-neutrality-not-restoring-internet-freedom/","title":"Dear FCC: Destroying net neutrality is not \"Restoring Internet Freedom\""},
-    {"url":"https://www.eff.org/takedowns/sony-finally-admits-it-doesnt-own-bach-and-it-only-took-public-pressure","title":"Sony Finally Admits It Doesn’t Own Bach and It Only Took Public Pressure"},
-    {"url":"https://finance.yahoo.com/news/apple-fans-returning-macbook-pros-154205304.html","title":"Apple fans are returning their new MacBook Pros that cost a minimum of $2,800 because they can't reach the advertised speeds"},
-    {"url":"https://www.pcworld.com/article/3284186/mobile/bring-back-the-headphone-jack-why-usb-c-audio-still-doesnt-work.html","title":"Bring back the headphone jack: Why USB-C audio still doesn't work"},
-    {"url":"https://www.theregister.co.uk/2018/08/08/us_broadband_competition/","title":"Surprise, surprise. Here comes Big Cable to slay another rule that helps small ISPs compete"},
-    {"url":"http://uk.businessinsider.com/adblock-plus-facebook-blocking-ad-blockers-is-anti-user-2016-8?r=US&IR=T","title":"Adblock Plus says Facebook's decision to block ad blockers is 'anti-user'"},
-    {"url":"http://thehill.com/blogs/pundits-blog/technology/318788-fcc-should-retain-net-neutrality-for-sake-of-consumers","title":"FCC should retain net neutrality for sake of consumers"},
-    {"url":"http://www.businessinsider.com.au/reddit-unbanned-russia-magic-mushrooms-germany-watchpeopledie-localised-censorship-2015-8","title":"Reddit is now censoring posts and communities on a country-by-country basis"},
-    {"url":"http://www.pcworld.com/article/3101396/windows/microsoft-faces-two-new-lawsuits-over-aggressive-windows-10-upgrade-tactics.html","title":"Microsoft faces two new lawsuits over aggressive Windows 10 upgrade tactics"},
-    {"url":"https://arstechnica.com/tech-policy/2017/10/ajit-pai-gets-new-term-on-fcc-despite-protest-of-anti-net-neutrality-plan/","title":"Ajit Pai gets new term on FCC despite protest of anti-net neutrality plan"},
-    {"url":"https://arstechnica.com/apple/2017/05/apple-has-a-record-250-billion-in-the-bank/","title":"Apple is about to report $250 billion in the bank, keeps 93 percent offshore"},
-    {"url":"http://bgr.com/2014/12/03/comcast-time-warner-cable-merger-opposition/","title":"Huge coalition forms to kill the Comcast-TWC merger for good"},
-    {"url":"https://www.washingtonpost.com/news/the-switch/wp/2017/11/22/official-says-hes-been-stymied-by-the-fcc-in-investigation-of-fake-net-neutrality-foes/?noredirect=on&utm_term=.172775121c1b","title":"Investigation of fake net neutrality foes has been stymied by the FCC, New York attorney general says"},
-    {"url":"https://techcrunch.com/2018/09/08/equifax-one-year-later-unscathed/","title":"A year later, Equifax lost your data but faced little fallout"},
-    {"url":"https://www.bleepingcomputer.com/news/security/ccleaner-compromised-to-distribute-malware-for-almost-a-month/","title":"CCleaner Compromised to Distribute Malware for Almost a Month"},
-    {"url":"https://www.usatoday.com/story/tech/2018/02/23/amazon-google-and-apple-under-pressure-remove-nratv-their-streaming-services/368894002/","title":"Amazon, Google, Apple under pressure to remove NRA streaming channel"},
-    {"url":"https://www.theverge.com/2018/1/25/16932524/broadband-fcc-committee-san-jose-mayor","title":"San Jose mayor says he’s quitting FCC broadband committee because Big Telecom is running it."},
-    {"url":"http://www.govtech.com/security/A-Year-After-Data-Breach-Atlanta-Based-Equifax-Unbowed.html","title":"After a Year, Equifax Remains Largely Unfazed by Historic Breach -- Despite a breach that exposed the personal data of more than 147 million Americans, the company has yet to face a government-imposed financial punishment"},
-    {"url":"http://www.dslreports.com/shownews/Trump-Could-Spell-Big-Trouble-for-Broadband-Net-Neutrality-138298","title":"Trump Could Spell Big Trouble for Broadband, Net Neutrality: 'Trump has made it clear he vehemently opposes net neutrality, despite repeatedly making it clear he's not entirely certain what net neutrality even is.'"},
-    {"url":"https://www.engadget.com/2017/03/15/chrome-57-throttle-background-tabs/","title":"Chrome 57 will throttle background tabs to save energy (Finally...)"},
-    {"url":"https://arstechnica.com/tech-policy/2018/08/fire-dept-rejects-verizons-customer-support-mistake-excuse-for-throttling/","title":"Fire dep’t rejects Verizon’s “customer support mistake” excuse for throttling"},
-    {"url":"http://www.businessinsider.com/google-engineer-benson-leung-reviewing-bad-usb-cables-on-amazon-until-he-forced-the-site-to-ban-them-2016-3?r=UK&IR=T","title":"A Google engineer spent months reviewing bad USB cables on Amazon until he forced the site to ban them"},
-    {"url":"https://electrek.co/2017/06/09/tesla-superchargers-solar-battery-grid-elon-musk/","title":"Tesla plans to disconnect ‘almost all’ Superchargers from the grid and go solar+battery"},
-    {"url":"http://www.nbcnews.com/meet-the-press/lindsey-graham-ive-never-sent-email-n319571","title":"U.S. Senator Lindsey Graham, who is currently on the Subcommittee on Privacy, Technology and the Law admits on Meet the Press that he has never sent an email in his life."},
-    {"url":"https://www.theverge.com/2018/8/15/17693834/uber-revenue-loss-earnings-q2-2018","title":"Uber loses $900 million in second quarter; urged by investors to sell off self-driving division"},
-    {"url":"https://techcrunch.com/2017/02/06/fbi-foia-fax-march-2017/","title":"FBI will stop taking FOIA (Freedom Of Information Act) Requests by email. Recommends Faxing or sending a letter."},
-    {"url":"http://bgr.com/2015/06/17/net-neutrality-lawsuit-twc-cns/","title":"Time Warner Cable is About to be Sued for Violating Net Neutrality Rules and Holding Traffic for Ransom"},
-    {"url":"https://www.techdirt.com/articles/20180919/07473240669/court-orders-fcc-to-hand-over-data-bogus-net-neutrality-comments.shtml","title":"Court Orders FCC To Hand Over Data On Bogus Net Neutrality Comments"},
-    {"url":"http://exstreamist.com/the-most-common-reason-users-cancel-a-streaming-service-advertisements/?t=t","title":"Study: Netflix is the least-cancelled of all the major streaming services (Because it doesn't have advertisements)"},
-    {"url":"http://fortune.com/2017/04/01/trump-net-neutrality/","title":"Trump Sets Sights on Net Neutrality Rules Next, Spicer Says"},
-    {"url":"https://www.usatoday.com/story/tech/talkingtech/2018/12/29/did-apple-retail-prices-get-too-high-2018-consumers-say-way-yes/2432445002/","title":"Did Apple retail prices get too high in 2018? Consumers say way yes."},
-    {"url":"https://www.theverge.com/2018/11/12/18088846/comcast-nbcuniversal-american-cable-doj-antitrust-investigation-letter-trump-tweet","title":"Comcast should be investigated for antitrust violations, say small cable companies"},
-    {"url":"https://www.bbc.com/news/uk-46497526","title":"NHS told to ditch 'absurd' fax machines - The NHS will be banned from buying fax machines from next month - and has been told by the government to phase out the machines entirely by 31 March 2020."},
-    {"url":"http://www.bbc.com/news/technology-36619223","title":"Google says there was a large spike in searches for Irish passport applications as news broke"},
-    {"url":"http://www.businessinsider.com/google-maps-is-now-wheelchair-friendly-accessible-20-percent-time-employee-project-2016-12?op=1","title":"A group of Google employees spent their '20% time' making Google Maps wheelchair-friendly"},
-    {"url":"http://gadgets.ndtv.com/laptops/news/lenovo-in-the-news-again-for-installing-spyware-on-its-machines-743952","title":"Lenovo caught pre-installing spyware on its laptops yet again"},
-    {"url":"http://www.wired.com/2014/09/exercism/","title":"The Site That Teaches You to Code Well Enough to Get a Job"},
-    {"url":"http://www.theguardian.com/commentisfree/2015/apr/18/congress-cannot-be-taken-seriously-on-cybersecurity","title":"\"Members of Congress—most of whom can’t secure their own websites, and some of whom don’t even use email—are trying to force a dangerous 'cybersecurity' bill down the public’s throat. Everyone’s privacy is in the hands of people who, by all indications, have no idea what they’re talking about.\""},
-    {"url":"https://www.battleforthenet.com/sept10th/#infographic","title":"The Internet Slowdown was a huge success! Over 300,000 calls and 2,000,000 e-mails were sent to Congress. Here's an infographic on what happened."},
-    {"url":"http://www.theverge.com/2016/10/25/13410020/apple-annual-revenue-decline-first-2001","title":"Apple just had its first annual revenue decline since 2001"},
-    {"url":"https://www.androidheadlines.com/2018/07/republican-intros-bill-that-would-turn-net-neutrality-into-law.html","title":"Republican Intros Bill That Would Turn Net Neutrality Into Law"},
-    {"url":"https://arstechnica.com/tech-policy/2018/01/new-bill-could-finally-get-rid-of-paperless-voting-machines/","title":"New bill could finally get rid of paperless voting machines - The bill reads like a computer security expert’s wish list."},
-    {"url":"https://www.fastcompany.com/40551457/heres-how-to-plug-one-of-the-biggest-privacy-holes-in-the-internet","title":"Here’s How To Plug One Of The Biggest Privacy Holes In The Internet - An upgrade to DNS, the internet’s address book, would make it harder for ISPs to know where you surf, and for hackers to hijack your traffic."},
-    {"url":"https://www.ctvnews.ca/sci-tech/tech-writer-suggests-10-year-challenge-may-be-collecting-data-for-facial-recognition-algorithm-1.4259579","title":"Tech writer suggests '10 Year Challenge' may be collecting data for facial recognition algorithm"},
-    {"url":"https://arstechnica.com/staff/2017/02/op-ed-mark-zuckerbergs-manifesto-is-a-political-trainwreck/","title":"Mark Zuckerberg’s manifesto is a political trainwreck: Zuckerberg hopes to create what he calls a \"global community\" by essentially gerrymandering the Internet."},
-    {"url":"https://nakedsecurity.sophos.com/2017/07/05/illinois-poised-to-ban-geolocation-tracking-without-consent/","title":"Illinois poised to ban geolocation tracking without consent"},
-    {"url":"http://www.theverge.com/2016/9/13/12890050/adblock-plus-now-sells-ads","title":"Adblock Plus now sells ads"},
-    {"url":"http://uk.businessinsider.com/apple-paying-ireland-16-billion-dollars-back-taxes-2018-4","title":"Apple will start paying $16 billion in back taxes to Ireland"},
-    {"url":"http://www.nytimes.com/2015/08/16/technology/inside-amazon-wrestling-big-ideas-in-a-bruising-workplace.html","title":"Amazon employee on relentless working conditions - “Nearly every person I worked with, I saw cry at their desk.”"},
-    {"url":"http://www.wired.co.uk/article/bullshit-jobs-david-graeber-review","title":"Forget fears of automation, your job is probably bullshit anyway - A subversive new book argues that many of us are working in meaningless “bullshit jobs”. Let automation continue and liberate people through universal basic income"},
-    {"url":"http://motherboard.vice.com/read/court-cops-need-a-warrant-to-open-your-phone-even-just-to-look-at-the-screen","title":"Court: Cops Need a Warrant to Open Your Phone, Even Just to Look at the Screen"},
-    {"url":"http://thenextweb.com/insider/2016/08/22/comcast-hopes-you-dont-notice-its-twice-as-expensive-in-non-google-fiber-markets/","title":"Comcast hopes you don’t notice it’s twice as expensive in non-Google Fiber markets"},
-    {"url":"https://electrek.co/2016/11/10/tesla-made-more-money-last-quarter-than-the-entire-us-oil-industry-made-last-year/","title":"Tesla made more money last quarter than the entire US oil industry made last year"},
-    {"url":"http://www.theverge.com/2016/6/13/11920072/microsoft-linkedin-acquisition-2016","title":"Microsoft to acquire LinkedIn for $26.2 billion"},
-    {"url":"http://www.redditblog.com/2014/11/time-to-call-fcc-we-are-nearing-home.html?m=1","title":"If the Reddit admins don't want this on /r/blog, then let's embrace it here. Let's give calling the FCC another go. We are nearing the home stretch for net neutrality at the FCC."},
-    {"url":"https://arstechnica.com/tech-policy/2018/07/24-people-have-now-been-sentenced-in-india-based-phone-scam-case/","title":"24 people have now been sentenced in India-based phone-scam case"},
-    {"url":"https://medium.com/@chris_urmson/the-view-from-the-front-seat-of-the-google-self-driving-car-chapter-2-8d5e2990101b","title":"Google: \"Our self-driving cars are being hit surprisingly often by other drivers who are distracted and not paying attention to the road.\""},
-    {"url":"https://www.eff.org/deeplinks/2017/06/attack-net-neutrality-attack-free-speech","title":"An Attack on Net Neutrality Is an Attack on Free Speech"},
-    {"url":"http://www.overclock3d.net/articles/misc_hardware/netflix_wants_to_make_neflix_global/1","title":"Netflix plans to create Netflix global, removing geo-blocking and allowing all customers access to all content. \"The key thing about piracy is that some fraction of it is because [users] couldn’t get the content. That part we can fix\""},
-    {"url":"http://arstechnica.com/tech-policy/2016/12/fcc-republicans-vow-to-gut-net-neutrality-rules-as-soon-as-possible/","title":"FCC Republicans vow to gut net neutrality rules “as soon as possible”"},
-    {"url":"https://arstechnica.com/tech-policy/2017/01/sen-franken-asks-att-to-prove-time-warner-merger-is-good-for-customers/","title":"Sen. Franken asks AT&T to prove Time Warner merger is good for customers"},
-    {"url":"https://www.digitaltrends.com/cool-tech/space-elon-musk-fcc-approval/","title":"Elon Musk receives FCC approval to launch over 7,500 satellites into space"},
-    {"url":"http://www.dailydot.com/technology/hola-vpn-security/?tw=dd","title":"Stop using the Hola VPN right now. The company behind Hola is turning your computer into a node on a botnet, and selling your network to anyone who is willing to pay."},
-    {"url":"https://www.thenation.com/article/net-neutrality-is-in-danger-tell-the-fcc-why-we-need-it/","title":"Net Neutrality Is in Danger. Tell the FCC Why We Need It"},
-    {"url":"https://arstechnica.com/?post_type=post&p=1126243","title":"Tom Wheeler defends Title II rules, accuses Pai of helping monopolists"},
-    {"url":"https://techcrunch.com/2017/04/04/apple-pushes-the-reset-button-on-the-mac-pro/","title":"In an extremely rare move, Apple admits its current mac pro design was a mistake. Reveals they are working on a fully modular Mac Pro, to be released next year."},
-    {"url":"https://www.theguardian.com/technology/2018/jun/09/human-cost-kindle-amazon-china-foxconn-jeff-bezos","title":"Underpaid and exhausted: the human cost of your Kindle - In the Chinese city of Hengyang, we find a fatigued, disposable workforce assembling gadgets for Amazon, owned by the world’s richest man."},
-    {"url":"https://gizmodo.com/at-ts-estimated-payment-to-trumps-lawyer-rises-to-600-1825901783?IR=T","title":"AT&T's Estimated Payment to Trump's Lawyer Rises to $600,000 as Investigations Ramp Up"},
-    {"url":"https://www.androidpolice.com/2018/02/12/verizon-stop-honoring-fcc-restriction-not-sim-locking-phones-nothing-matters-anymore/","title":"Verizon to stop honoring FCC restriction on not SIM-locking phones because nothing matters anymore"},
-    {"url":"http://recode.net/2015/01/28/ftc-says-unlimited-data-with-throttling-doesnt-count-as-unlimited/","title":"FTC Says Unlimited Data With Throttling Doesn’t Count as Unlimited"},
-    {"url":"http://www.zdnet.com/article/amazon-the-least-transparent-tech-company/","title":"Amazon won't say if it hands your Echo data to the government - The retail, cloud, and device giant stands as the least transparent of transparent tech companies."},
-    {"url":"http://qz.com/628761/the-irs-is-using-a-system-that-was-hacked-to-protect-victims-of-a-hack-and-it-was-just-hacked/","title":"The IRS is using the same authentication system that was hacked last year to protect the victims of that hack--and it's just been hacked"},
-    {"url":"https://arstechnica.com/tech-policy/2017/05/senators-ask-fcc-why-reporter-was-manhandled-after-net-neutrality-vote/","title":"Senators ask FCC why reporter was “manhandled” after net neutrality vote"},
-    {"url":"https://www.eff.org/deeplinks/2018/08/after-patent-office-rejection-it-time-google-abandon-its-attempt-patent-use-public","title":"Google is trying to patent use of a data compression algorithm that the real inventor had already dedicated to the public domain. This week, the U.S. Patent Office issued a non-final rejection of all claims in Google’s application."},
-    {"url":"https://techcrunch.com/2018/03/19/deletefacebook/","title":"#deletefacebook"},
-    {"url":"https://www.hongkongfp.com/2017/06/08/china-uncovers-massive-underground-network-apple-employees-selling-customers-personal-data/","title":"China uncovers massive underground network of Apple employees selling customers' personal data"},
-    {"url":"https://cleantechnica.com/2018/08/06/analysis-reveals-that-worlds-largest-battery-saves-south-australia-8-9-million-in-6-months/","title":"Analysis Reveals That World’s Largest Battery Saved South Australia $8.9 Million In 6 Months"},
-    {"url":"http://www.miaminewtimes.com/news/fcc-fines-miami-man-120-million-for-making-96-million-robocalls-in-three-months-9440277","title":"Miami Man Fined $120 Million for Making 96 Million Robocalls in Three Months"},
-    {"url":"https://thewire.in/90591/governments-shut-down-internet-50-times-2016/","title":"Governments around the world shut down the internet more than 50 times in 2016 – suppressing elections, slowing economies and limiting free speech"},
-    {"url":"https://www.forbes.com/sites/trevornace/2018/09/10/the-worlds-largest-ocean-cleanup-has-officially-begun/#4a34ac582738","title":"The World's Largest Ocean Cleanup Has Officially Begun"},
-    {"url":"http://www.businessinsider.com/google-sued-discriminating-white-asian-men-2018-3?r=UK&IR=T","title":"An ex-YouTube recruiter claims Google discriminated against white and Asian men, then deleted the evidence"},
-    {"url":"https://www.businessinsider.com/video-games-may-increase-your-brains-gray-matter-2018-12/?r=AU&IR=T","title":"Playing video games may increase your brain's gray matter and improve how it communicates"},
-    {"url":"https://www.seattletimes.com/business/bitcoin-backlash-as-miners-suck-up-electricity-stress-power-grids-in-central-washington/","title":"Bitcoin backlash as ‘miners’ suck up electricity, stress power grids in Central Washington"},
-    {"url":"https://gizmodo.com/report-equifax-lost-even-more-information-on-consumers-1822898461","title":"Report: Equifax lost even more information on consumers than it told the public."},
-    {"url":"http://www.independent.co.uk/news/people/elon-musk-universal-income-robots-ai-tesla-spacex-a7402556.html","title":"Elon Musk says people should receive a universal income once robots take their jobs: 'People will have time to do other things, more complex things, more interesting things'"},
-    {"url":"http://arstechnica.com/business/2016/03/isps-should-be-required-to-let-customers-cancel-online-lawmaker-says","title":"Proposed legislation in California would require Internet service providers to let customers cancel online, potentially ending the scourge of long, awkward cancellation phone calls."},
-    {"url":"http://www.wsj.com/articles/paris-attacks-plot-was-hatched-in-plain-sight-1448587309","title":"Paris attackers used real names, real IDs, and unencrypted, simple messaging to make plans."},
-    {"url":"http://www.broadcastingcable.com/news/fates-and-fortunes/wyden-slams-pai-senate-floor/168973","title":"Sen. Wyden Slams Pai on Senate Floor - Says FCC chair is on side of 'big cable'"},
-    {"url":"https://www.commondreams.org/news/2018/04/03/fcc-commissioner-slams-her-own-agency-policies-custom-built-favor-sinclair-tribune","title":"FCC Commissioner Slams Her Own Agency for Policies 'Custom-Built' to Favor Sinclair-Tribune Merger"},
-    {"url":"https://www.newstatesman.com/science-tech/social-media/2018/05/facebook-s-answer-privacy-concerns-dating-site","title":"\"Facebook decided that the best thing to do after the Cambridge Analytica scandal was to ask its users to hand over access to their humiliating pick-up lines, their sexual fetishes, and, inevitably, their nudes.\""},
-    {"url":"http://www.statepress.com/article/2017/03/spopinion-why-ending-net-neutrality-would-be-disastrous","title":"Ending net neutrality would be disastrous for everyone"},
-    {"url":"https://www.androidheadlines.com/2018/07/fftf-calls-for-net-neutrality-reversal-due-to-fake-comments.html","title":"FFTF Calls For Net Neutrality Reversal Due To Fake Comments"},
-    {"url":"http://wgntv.com/2016/10/11/comcast-hit-with-fccs-biggest-cable-fine-ever/","title":"Comcast fined $2.3 million for mischarging customers"},
-    {"url":"https://gizmodo.com/new-york-attorney-general-subpoenas-industry-groups-lo-1829800862","title":"New York Attorney General Subpoenas Industry Groups, Lobbyists Over Fake Net Neutrality Comments"},
-    {"url":"https://arstechnica.com/apple/2017/01/apple-international-business-ireland-luxembourg/","title":"Apple will move its entire international iTunes business to Ireland. International HQ will move from one tax haven to another."},
-    {"url":"https://www.techdirt.com/articles/20160114/06532833339/56-would-drop-espn-heartbeat-if-it-meant-saving-8-month-cable.shtml","title":"56% Would Drop ESPN In A Heartbeat If It Meant Saving $8 A Month On Cable"},
-    {"url":"https://www.theguardian.com/technology/shortcuts/2017/sep/19/apple-crumbles-cookies-but-there-is-more-to-come-in-the-online-advertising-arms-race","title":"Apple cuts cookies – but there is more to come in the online advertising arms race: Apple’s latest software update has enraged companies who have been using cookies to track users across the web"},
-    {"url":"https://www.techdirt.com/articles/20170614/07270337586/wall-street-still-annoyed-that-competition-forced-wireless-carriers-to-bring-back-unlimited-data-plans.shtml","title":"Wall Street Still Annoyed That Competition Forced Wireless Carriers To Bring Back Unlimited Data Plans"},
-    {"url":"https://www.reddit.com/r/Vive/comments/4nxpnq/fuck_facebook_and_fuck_oculus/d480x6v?context=3","title":"Facebook finally caught buying out developers for Oculus Exclusivity, despite claims to the contrary"},
-    {"url":"https://www.androidauthority.com/verizon-att-selling-information-807684/","title":"Verizon and AT&T accused of selling your phone number and location to almost anyone"},
-    {"url":"https://www.polygon.com/2017/2/9/14548880/time-warner-lawsuit-new-york-league-of-legends-netflix","title":"Time Warner Cable sued by New York on behalf of League of Legends, Netflix customers"},
-    {"url":"http://www.bbc.com/future/story/20161207-the-first-pirate-politician-in-power","title":"The first pirate politician in power - many Icelandic voters have rallied around a radical, technology-focused left-wing party that champions political transparency, free health care and new measures to protect digital privacy."},
-    {"url":"http://www.redmondpie.com/firm-that-helped-fbi-break-into-san-bernardino-iphone-gets-hacked-tools-leaked-online/","title":"Firm That Helped FBI Break Into San Bernardino iPhone Gets Hacked, Tools Leaked Online"},
-    {"url":"http://www.businessinsider.com/tesla-lawsuit-oil-executive-impersonated-elon-musk-2016-9","title":"Tesla sues oil executive who impersonated Elon Musk to get info from the company."},
-    {"url":"https://www.extremetech.com/computing/245553-microsoft-now-puts-ads-windows-file-explorer","title":"Microsoft now puts ads in Windows 10 File Explorer, because of course"},
-    {"url":"http://motherboard.vice.com/read/orlando-shooting-response-shows-reddit-cant-be-the-front-page-of-the-internet?utm_source=vicefbus","title":"Orlando Shooting Response Shows Reddit Can't Be the ‘Front Page of the Internet'"},
-    {"url":"http://mashable.com/2015/03/02/google-confirms-wireless-carrier-service/","title":"Google confirms it wants to be a wireless carrier."},
-    {"url":"https://fossbytes.com/tenn-hacked-apple-servers-australia/","title":"A 16-Year-Old Hacked Apple Servers And Stored Data In Folder Named 'hacky hack hack'"},
-    {"url":"https://www.techtimes.com/articles/236834/20181227/fake-alexa-setup-app-ios-climbs-apples-store-charts.htm","title":"Fake Amazon Alexa Setup App Climbs Its Way To Apple's App Store Charts"},
-    {"url":"http://news.abs-cbn.com/overseas/08/05/18/bangladesh-shuts-down-mobile-internet-to-tackle-teen-protests","title":"Bangladesh shuts down mobile internet to tackle teen protests"},
-    {"url":"https://www.recode.net/2017/11/11/16619956/president-donald-trump-science-technology-open-jobs-federal-goverment-nominees","title":"One year after President Trump’s election, these 11 science and tech posts in government are still lacking leaders. Some of the jobs — like overseeing self-driving cars — have no nominees at all."},
-    {"url":"http://fortune.com/2018/01/19/uk-france-net-neutrality-us/","title":"The U.K. and France Are Thumbing Their Noses at the U.S. Over Net Neutrality Repeal - ‘the U.K. and France said Friday: “... we wish to restate our commitment and support for the principle of net neutrality, which promotes a free and open internet.”’"},
-    {"url":"http://www.theguardian.com/media/2014/sep/03/netflix-petitions-fcc-high-speed-internet-services","title":"Netflix pushes FCC to scrap rules blocking cities from building their own high-speed internet services"},
-    {"url":"http://electrek.co/2016/06/06/tesla-model-x-crash-not-at-fault/","title":"Tesla logs show that Model X driver hit the accelerator, Autopilot didn’t crash into building on its own"},
-    {"url":"https://motherboard.vice.com/en_us/article/a33j5a/a-redditor-archived-nearly-2-million-gigabytes-of-porn-to-test-amazons-unlimited-cloud-storage","title":"A Redditor Archived Nearly 2 Million Gigabytes of Porn to Test Amazon’s ‘Unlimited’ Cloud Storage"},
-    {"url":"http://www.theguardian.com/commentisfree/2014/dec/24/sony-threat-free-speech-north-korea-the-interview","title":"Before praising Sony for \"free speech\" remember for the past two weeks they've attempted to censor Twitter, threatened journalists reporting on public info, and secretly planned to use state governments to block all sorts of websites."},
-    {"url":"http://nymag.com/selectall/2018/04/richard-stallman-rms-on-privacy-data-and-free-software.html","title":"‘No Company Is So Important Its Existence Justifies Setting Up a Police State’"},
-    {"url":"https://www.theguardian.com/commentisfree/2017/jul/07/elon-musks-big-battery-brings-reality-crashing-into-a-post-truth-world","title":"Elon Musk's big battery brings reality crashing into a post-truth world. For months, politicians and fossil fuel industry have lied about the viability of renewables. Now Tesla’s big battery in South Australia will prove them wrong."},
-    {"url":"https://www.theguardian.com/technology/2018/may/11/facebook-class-action-lawsuit-collection-texts-call-logs","title":"Facebook hit with class action lawsuit over collection of texts and call logs - Plaintiffs claim social network’s ‘scraping’ of information including call recipients and duration violates privacy and competition law"},
-    {"url":"https://slate.com/technology/2018/06/ajit-pais-argument-for-repealing-net-neutrality-is-orwellian-and-wrong.html","title":"Ajit Pai Is Twisting the Meaning of the “Open Internet” - Don’t be fooled by the FCC chairman’s Orwellian argument justifying the repeal of net neutrality."},
-    {"url":"http://www.theguardian.com/commentisfree/2015/nov/17/intelligence-agencies-pounce-paris-attacks-pursue-spy-agenda","title":"\"Officials are wasting no time in attempting to exploit the tragedy in Paris to pass invasive anti-privacy laws and acquire extraordinary new powers that they have wanted for years. In the process, they are making incredibly dishonest arguments & are receiving virtually no pushback from the media.\""},
-    {"url":"https://qz.com/945261/how-to-get-a-personal-vpn-and-why-you-need-one-now/","title":"Set up a VPN in 10 minutes for free—and yes, Americans urgently need one, thanks to Congress"},
-    {"url":"https://www.recode.net/2018/2/12/16998750/facebooks-teen-users-decline-instagram-snap-emarketer","title":"Facebook lost around 2.8 million U.S. users under 25 last year. 2018 won’t be much better."},
-    {"url":"http://www.bbc.com/news/world-africa-38922819#share-tools","title":"The first African winner in Google's annual coding competition is a Cameroonian kid who had to travel 370km from home, because the government has cut off his hometown from the internet"},
-    {"url":"https://torrentfreak.com/pirate-bay-founder-finally-free-after-three-years-150928/","title":"Pirate Bay Founder Finally Free After Three Years"},
-    {"url":"https://www.recode.net/2019/1/10/18175869/susan-crawford-fiber-book-internet-access-comcast-verizon-google-peter-kafka-media-podcast","title":"America desperately needs fiber internet, and the tech giants won’t save us - Harvard’s Susan Crawford explains why we shouldn’t expect Google to fix slow internet speeds in the US."},
-    {"url":"https://www.theverge.com/2018/10/24/18020746/president-donald-trump-iphone-personal-calls-china-russia-spies-eavesdropping","title":"Trump reportedly still uses an unsecured iPhone, and China and Russia are listening in"},
-    {"url":"https://www.scribblrs.com/facebook-users-becoming-less-satisfied-new-research-shows/","title":"Facebook Users Becoming Less Satisfied and Using the Service Less; \"People are tired of being bombarded with political posts from their friends and the pages they follow\""},
-    {"url":"http://motherboard.vice.com/read/the-fcc-says-your-city-can-build-a-public-internet-even-if-your-state-says-no","title":"The FCC Says Your City Can Build a Public Internet, Even If Your State Says No"},
-    {"url":"https://motherboard.vice.com/en_us/article/a3yadk/apple-sued-an-independent-iphone-repair-shop-owner-and-lost","title":"Apple Sued an Independent iPhone Repair Shop Owner from Norway and Lost"},
-    {"url":"http://www.spacex.com/webcast/","title":"SpaceX successfully lands Falcon 9 booster for the first time, paving the road for reusable rockets"},
-    {"url":"http://www.livetrucking.com/self-driving-semi-truck-just-made-first-cross-country-trip/","title":"A self-driving semi truck just made its first cross-country trip"},
-    {"url":"http://www.washingtonpost.com/blogs/the-switch/wp/2014/09/19/world-wide-web-inventor-lashes-out-at-internet-fast-lanes-its-bribery/?tid=rssfeed","title":"World Wide Web inventor lashes out at Internet fast lanes: ‘It’s bribery.’ \"Berners-Lee said that system is now in danger from ISPs who stand to amass too much power over what was intentionally built as a decentralized network — one where no single actor could dictate outcomes to everyone else.\""},
-    {"url":"http://www.washingtonpost.com/blogs/the-switch/wp/2014/11/18/john-hodgman-the-government-should-be-laying-down-broadband-like-eisenhower-laid-down-interstates/?tid=rssfeed","title":"John Hodgman: ‘The government should be laying down broadband like Eisenhower laid down interstates. And I believe preferential fast-laning for big companies will decrease competition and quality ...\""},
-    {"url":"https://www.thedailybeast.com/exclusive-lone-dnc-hacker-guccifer-20-slipped-up-and-revealed-he-was-a-russian-intelligence-officer","title":"‘Lone DNC Hacker’ Guccifer 2.0 Slipped Up and Revealed He Was a Russian Intelligence Officer"},
-    {"url":"https://www.theguardian.com/world/2016/nov/14/china-threatens-to-cut-sales-of-iphones-and-us-cars-if-naive-trump-pursues-trade-war?utm_source=dlvr.it&utm_medium=twitter","title":"China threatens to cut sales of iPhones and US cars if 'naive' Trump pursues trade war"},
-    {"url":"https://www.theverge.com/2018/3/28/17171470/playboy-leaves-facebook","title":"Playboy deletes its Facebook accounts"},
-    {"url":"https://motherboard.vice.com/en_us/article/yw9qk7/macbook-pro-software-locks-prevent-independent-repair","title":"Apple's New Proprietary Software Locks Kill Independent Repair on New MacBook Pros - Failure to run Apple's proprietary diagnostic software after a repair \"will result in an inoperative system and an incomplete repair.\""},
-    {"url":"https://www.techdirt.com/articles/20170523/13491237437/if-net-neutrality-dies-comcast-can-just-block-protest-site-instead-sending-bogus-cease-and-desist.shtml","title":"f Net Neutrality Dies, Comcast Can Just Block A Protest Site Instead Of Sending A Bogus Cease-And-Desist"},
-    {"url":"https://www.zdnet.com/article/after-microsoft-complaints-indian-police-arrest-tech-support-scammers-at-26-call-centers/","title":"After Microsoft complaints, Indian police arrest tech support scammers at 26 call centers"},
-    {"url":"https://www.cnbc.com/2018/06/18/apple-will-automatically-share-emergency-location-with-911-in-ios-12.html","title":"Apple will automatically share a user's location with emergency services when they call 911"},
-    {"url":"http://motherboard.vice.com/read/the-gop-is-trying-to-nuke-net-neutrality-with-a-budget-bill-sneak-attack","title":"The GOP Is Trying to Nuke Net Neutrality With a Budget Bill Sneak Attack"},
-    {"url":"http://news.sky.com/story/1412846/googles-record-spend-to-keep-net-neutral","title":"Google has spent a record amount on Washington lobbyists as it pushes to maintain net neutrality."},
-    {"url":"https://www.theguardian.com/commentisfree/2017/nov/13/sending-in-our-nude-photos-to-fight-revenge-porn-no-thanks-facebook","title":"Sending in our nude photos to fight revenge porn? No thanks, Facebook. Rather than trusting a private corporation, let’s just enforce existing laws supposed to protect us from harassment and abuse – in person or online"},
-    {"url":"https://techcrunch.com/2019/01/09/us-cell-carriers-still-selling-your-location-data/","title":"Despite promises to stop, US cell carriers are still selling your real-time phone location data"},
-    {"url":"https://www.cnbc.com/2018/07/02/over-800-cryptocurrencies-are-now-dead-as-bitcoin-feels-pressure.html","title":"Over 800 cryptocurrencies are now dead as bitcoin is 70 percent off its record high"},
-    {"url":"https://www.courthousenews.com/democrats-close-to-forcing-vote-on-net-neutrality/","title":"Democrats Close to Forcing Vote on Net Neutrality"},
-    {"url":"http://www.vox.com/2016/6/9/11898512/multiple-sclerosis-stem-cell-chemo","title":"This isn’t hype: Canadian doctors just reversed severe MS using stem cells"},
-    {"url":"https://www.techdirt.com/articles/20150424/14443230784/president-obama-demands-critics-tell-him-whats-wrong-with-tpp-course-we-cant-do-that-because-he-wont-show-us-agreement.shtml","title":"President Obama Demands Critics Tell Him What's Wrong With TPP; Of Course We Can't Do That Because He Won't Show Us The Agreement"},
-    {"url":"https://www.nbcnews.com/think/opinion/mark-zuckerberg-wanted-facebook-change-world-it-has-not-better-ncna897701","title":"Mark Zuckerberg wanted Facebook to change the world. And it has — but not for the better: Facebook, Twitter and Google’s YouTube have become the digital arms dealers of the modern age."},
-    {"url":"https://medium.com/@fightfortheftr/at-t-funded-democrats-in-california-just-eviscerated-the-best-net-neutrality-bill-in-the-country-1e90defb5086","title":"AT&T funded democrats in California just “eviscerated” the best net neutrality bill in the country"},
-    {"url":"http://motorcitymuckraker.com/2015/10/09/more-than-10000-problems-fixed-through-improve-detroit-cell-phone-app/","title":"More than 10,000 problems fixed through ‘Improve Detroit’ cell phone app -- \"allows users to easily alert city hall to potholes, illegal dumping sites, abandoned cars, water main breaks, busted traffic signals and broken hydrants\""},
-    {"url":"https://techcrunch.com/2018/10/31/united-states-drops-internet-freedoms-fake-news-net-neutrality/","title":"U.S. declines in internet freedom rankings, thanks to net neutrality repeal and fake news"},
-    {"url":"http://www.dslreports.com/shownews/Comcast-Sued-For-Misleading-Hidden-Fees-138136","title":"Comcast Sued For Misleading, Hidden Fees"},
-    {"url":"https://www.privateinternetaccess.com/blog/2017/05/today-fcc-votes-fate-net-neutrality/","title":"Today, the FCC votes on the fate of net neutrality"},
-    {"url":"http://torrentfreak.com/bittorrent-anonymous-and-impossible-to-shut-down-141218/","title":"Researchers Make BitTorrent Anonymous and Impossible to Shut Down"},
-    {"url":"https://www.businessinsider.com/apple-iphone-xs-and-xr-mainstream-consumers-2018-9","title":"Apple's $1,000 iPhones are turning it into a luxury brand — and it could lose a whole generation of customers"},
-    {"url":"http://www.businessinsider.com/google-merrill-lynch-and-the-right-to-be-forgotten-2014-7","title":"Google was required to delete a link to a factually accurate BBC article about Stan O'Neal, the former CEO of Merrill Lynch."},
-    {"url":"http://news.softpedia.com/news/Youtube-Says-Goodbye-to-Flash-HTML5-Is-Now-Default-471426.shtml","title":"YouTube Says Goodbye to Flash, HTML5 Is Now Default"},
-    {"url":"https://www.eff.org/deeplinks/2014/07/act-immediately-stop-congresss-sneaky-move-shut-down-broadband-competition","title":"Act Immediately to Stop Congress’s Sneaky Move to Shut Down Broadband Competition (X-Post /r/news)"},
-    {"url":"https://medium.com/@fightfortheftr/no-net-neutrality-is-not-officially-dead-today-b6f133075c13","title":"No, net neutrality is not “officially dead,” today. The FCC repeal has not yet gone into effect. The senate will vote soon on whether to block the repeal. Now’s the time to pay attention!"},
-    {"url":"http://finance.yahoo.com/news/more-software-engineers-over-age-195308179.html","title":"Google sued over refusing to employ engineers over 40 years of age"},
-    {"url":"http://www.dslreports.com/shownews/GOP-Pushing-Bill-That-Guts-FCC-Authority-Kills-Net-Neutrality-137060","title":"GOP Pushing Bill That Guts FCC Authority, Kills Net Neutrality"},
-    {"url":"https://www.techdirt.com/articles/20180104/09234138930/colorado-cities-keep-voting-to-build-their-own-broadband-networks.shtml","title":"Colorado Cities Keep Voting To Build Their Own Broadband Networks"},
-    {"url":"https://motherboard.vice.com/en_us/article/wj793y/ajit-pai-net-neutrality-repeal-not-official-yet","title":"Ajit Pai Is Intentionally Delaying His Net Neutrality Repeal and No One Knows Why"},
-    {"url":"http://www.theverge.com/2016/3/10/11196548/apple-accuses-department-of-justice-fbi-smearing-desperation","title":"Apple attorney: \"I can only conclude that the DoJ is so desperate at this point that it has thrown all decorum to the winds... Everyone should beware, because it seems like disagreeing with the Department of Justice means you must be evil and anti-American. Nothing could be further from the truth.\""},
-    {"url":"http://www.slate.com/articles/technology/bitwise/2015/02/lenovo_superfish_scandal_why_it_s_one_of_the_worst_consumer_computing_screw.html","title":"Lenovo committed one of the worst consumer betrayals ever made"},
-    {"url":"http://gizmodo.com/fcc-now-says-there-is-no-documented-analysis-of-the-cyb-1797073113","title":"FCC Now Says There Is No Documented 'Analysis' of the Cyberattack It Claims Crippled Its Website in May"},
-    {"url":"https://consumerist.com/2016/03/16/comcast-att-lobbyists-help-kill-community-broadband-expansion-in-tennessee/","title":"Comcast, AT&T Lobbyists Help Kill Community Broadband Expansion In Tennessee"},
-    {"url":"https://theintercept.com/2017/12/15/fcc-net-neutrality-public-broadband-seattle/","title":"Killing Net Neutrality Has Brought On a New Call For Public Broadband"},
-    {"url":"https://theintercept.com/2017/05/02/nypd-refuses-to-disclose-information-about-its-face-recognition-program-so-privacy-researchers-are-suing/","title":"NYPD Refuses to Disclose Information About Its Face Recognition Program, So Privacy Researchers Are Suing"},
-    {"url":"https://www.washingtonpost.com/news/grade-point/wp/2016/06/15/college-courses-without-textbooks-these-schools-are-giving-it-a-shot/","title":"open-source materials in place of textbooks, an initiative that could save students as much as $1,300 a year. Such open educational resources—created using open licenses that let students download or print materials for free—have gained popularity as the price of print textbooks have skyrocketed"},
-    {"url":"https://www.theguardian.com/technology/2017/sep/27/pirate-bay-showtime-ads-websites-electricity-pay-bills-cryptocurrency-bitcoin?CMP=twt_gu","title":"Ads don't work so websites are using your electricity to pay the bills: Pirate Bay and Showtime turned to forcing unknowing visitors to mine cryptocurrency, using computers rather than eyeballs on ads to generate money"},
-    {"url":"https://arstechnica.com/tech-policy/2017/11/sorry-poor-people-the-fcc-is-coming-after-your-broadband-plans/","title":"Sorry, poor people: The FCC is coming after your broadband plans -- 70% of low-income wireless subscribers in Lifeline could have to find new ISPs"},
-    {"url":"https://fair.org/home/the-fcc-chair-is-outright-lying-to-reporters-and-congress/","title":"‘The FCC Chair Is Outright Lying to Reporters and Congress’"},
-    {"url":"https://www.commondreams.org/news/2018/06/04/sure-looks-zuckerberg-lied-congress-about-user-privacy-new-facebook-data-sharing","title":"'Sure Looks Like Zuckerberg Lied' to Congress About User Privacy, As New Facebook Data-Sharing Deals Come to Light"},
-    {"url":"https://www.theguardian.com/uk-news/2018/mar/23/leaked-cambridge-analyticas-blueprint-for-trump-victory?CMP=Share_iOSApp_Other","title":"Leaked: Cambridge Analytica's blueprint for Trump victory | UK news | The Guardian"},
-    {"url":"http://www.slate.com/blogs/future_tense/2015/04/10/florida_middle_schooler_arrested_charged_with_hacking_cybercrimes.html","title":"Eighth-Grader Arrested, Charged With Cybercrimes For Changing Teacher's Desktop Wallpaper"},
-    {"url":"http://hothardware.com/News/Enraged-Verizon-FiOS-Customer-Posts-Video-Seemingly-Proving-ISP-Throttles-Netflix/","title":"Enraged Verizon FiOS customer posts video seemingly proving ISP throttles Netflix; video streams 10x faster through a VPN than directly."},
-    {"url":"http://www.cbc.ca/news/business/tvaddons-piracy-rogers-bell-videotron-court-1.4231340","title":"Cable giants step up piracy battle by interrogating Montreal software developer and searching his home"},
-    {"url":"https://www.fastcompany.com/40510095/snubbing-fcc-states-are-writing-their-own-net-neutrality-laws","title":"Snubbing FCC, States Are Writing Their Own Net Neutrality Laws - California, New York, Washington, and likely more states are challenging both internet providers and the reach of the federal government."},
-    {"url":"https://www.techdirt.com/articles/20180903/09561940575/after-nabbing-billions-tax-breaks-ats-promised-job-growth-magically-evaporates.shtml","title":"After Nabbing Billions In Tax Breaks, AT&T's Promised Job Growth Magically Evaporates"},
-    {"url":"http://nymag.com/intelligencer/2018/04/dan-mccomas-reddit-product-svp-and-imzy-founder-interview.html","title":"Former Reddit product head Dan McComas: 'I Fundamentally Believe That My Time at Reddit Made the World a Worse Place'"},
-    {"url":"http://arstechnica.com/tech-policy/2016/11/adblock-plus-wins-its-6th-court-case-brought-by-der-spiegel/?comments=1","title":"Adblock Plus wins its 6th court case trying to shut them down"},
-    {"url":"http://bgr.com/2014/10/15/hbo-online-streaming-service-launch/","title":"HBO will fulfill cord cutters’ dreams and launch a standalone streaming service next year"},
-    {"url":"http://www.nbcnews.com/tech/tech-news/fbi-can-t-force-apple-new-york-iphone-case-judge-n528446?cid=sm_tw&hootPostID=62e8ba65b2509e6191a213c775f8f628","title":"Apple Doesn't Have to Help FBI in New York iPhone Case, Judge Says"},
-    {"url":"https://www.inverse.com/article/34239-how-many-solar-panels-to-power-the-usa","title":"Here's Elon Musk's Plan to Power the USA on Solar Energy: \"you only need about 100 miles by 100 miles of solar panels to power the entire United States\""},
-    {"url":"https://www.cultofmac.com/585868/apple-bars-bloomberg-from-ipad-event-as-payback-for-spy-chip-story/","title":"Apple bars Bloomberg from iPad event as payback for spy chip story"},
-    {"url":"https://www.techdirt.com/articles/20170413/11293537144/new-survey-most-millennials-both-pay-streaming-services-use-pirate-streams-when-content-isnt-legally-available.shtml","title":"New Survey: Most Millennials Both Pay For Streaming Services And Use Pirate Streams When Content Isn't Legally Available"},
-    {"url":"http://www.theverge.com/2016/2/23/11098592/bill-gates-fbi-apple-comments","title":"Bill Gates says he was 'disappointed' by reports he backs FBI in Apple fight"},
-    {"url":"https://www.pcmag.com/news/364132/california-law-bans-bots-from-pretending-to-be-human","title":"California Law Bans Bots From Pretending to Be Human - Effective July 1, it will be illegal for bots interacting with California consumers to pretend they're human if they're trying to sell goods, services, or to 'influence a vote in an election.'"},
-    {"url":"http://www.techradar.com/us/news/software/operating-systems/windows-xp-still-the-third-most-popular-os-two-years-after-end-of-life-1318572","title":"Windows XP is still the third most popular OS 2 years after end-of-life and 15 1/2 years after it was introduced."},
-    {"url":"http://www.ibtimes.co.uk/netflix-once-loved-talking-about-net-neutrality-so-why-has-it-suddenly-gone-quiet-1656260","title":"Netflix once loved talking about net neutrality - so why has it suddenly gone quiet?"},
-    {"url":"https://www.engadget.com/2017/01/09/report-fbi-arrests-volkswagen-executive-over-dieselgate/?sr_source=Twitter","title":"FBI arrests Volkswagen executive over Dieselgate"},
-    {"url":"https://www.techdirt.com/articles/20170217/15584936738/federal-bill-introduced-to-add-warrant-requirement-to-stingray-deployment.shtml","title":"Federal Bill Introduced To Add A Warrant Requirement To Stingray Deployment"},
-    {"url":"http://www.dslreports.com/shownews/Claims-That-Net-Neutrality-Hurt-Broadband-Investment-Are-Crap-140454","title":"Claims That Net Neutrality Hurt Broadband Investment Are Crap"},
-    {"url":"https://www.theverge.com/2017/6/12/15768920/police-body-camera-state-secret","title":"Police body camera footage is becoming a state secret - North Carolina, Louisiana, Kansas, and other states are writing laws to keep police videos out of public hands"},
-    {"url":"https://fight215.org/","title":"Fight 215: Call Congress now and urge them to end mass surveillance under the Patriot Act"},
-    {"url":"https://www.extremetech.com/computing/241587-microsoft-finally-admits-malware-style-get-windows-10-upgrade-campaign-went-far","title":"Microsoft finally admits that its malware-style Get Windows 10 upgrade campaign went too far"},
-    {"url":"https://www.engadget.com/2016/06/20/new-york-scalper-law-ticket-bots/","title":"New York criminalizes the use of ticket buying bots"},
-    {"url":"https://www.upi.com/Top_News/US/2018/09/16/New-Mexico-sues-Google-Twitter-for-illegally-collecting-data-on-children/9931537151359/","title":"New Mexico sues Google, Twitter for illegally collecting data on children"},
-    {"url":"https://electrek.co/2018/02/04/tesla-powerwall-solar-virtual-power-plant/","title":"Tesla is installing Powerwalls and solar power on 50,000 homes to create biggest virtual power plant in the world"},
-    {"url":"https://www.theguardian.com/commentisfree/2018/sep/13/scientific-publishing-rip-off-taxpayers-fund-research","title":"Scientific publishing is a rip-off. We fund the research – it should be free"},
-    {"url":"http://www.bit-tech.net/news/bits/2016/12/21/curia-rules-ip-act-illegal/1","title":"The Court of Justice of the European Union has ruled blanket communications data collection, as in the UK's IP Act, illegal"},
-    {"url":"https://techcrunch.com/2018/12/05/australia-rushes-its-dangerous-anti-encryption-bill-into-parliament/","title":"Australia rushes its ‘dangerous’ anti-encryption bill into parliament, despite massive opposition"},
-    {"url":"http://www.businessinsider.com/design-trumps-border-wall-hyperloop-2017-4","title":"A group of engineers just submitted this incredible proposal for Trump's border 'wall' that's actually a $15 billion hyperloop"},
-    {"url":"http://www.npr.org/blogs/alltechconsidered/2015/01/10/376166180/forget-wearable-tech-people-really-want-better-batteries","title":"Forget Wearable Tech. People Really Want Better Batteries."},
-    {"url":"https://www.wired.com/story/equifax-deserves-the-corporate-death-penalty/","title":"Equifax Deserves the Corporate Death Penalty"},
-    {"url":"https://qz.com/962487/states-are-moving-to-cut-college-costs-by-introducing-open-source-textbooks/","title":"States are moving to cut college costs by adopting open-source e-textbooks"},
-    {"url":"https://au.finance.yahoo.com/news/netflix-cofounder-apos-moviepass-now-035414536.html","title":"Netflix cofounder's MoviePass will now let you see one movie per day in theatres for just $10 a month"},
-    {"url":"https://www.techdirt.com/articles/20151209/06231533028/att-has-fooled-press-public-into-believing-building-massive-fiber-network-that-barely-exists.shtml","title":"AT&T Has Fooled The Press And Public Into Believing It's Building A Massive Fiber Network That Barely Exists"},
-    {"url":"https://gizmodo.com/at-t-employees-reportedly-encouraged-to-use-unethical-s-1827088406","title":"AT&T Employees Reportedly Encouraged to Use Unethical Sales Tactics to Drive Up DirecTV Now Subscriptions"},
-    {"url":"http://inthesetimes.com/article/20784/fcc-net-neutrality-open-internet-public-good-nationalize/","title":"It’s Time to Nationalize the Internet. To counter the FCC’s attack on net neutrality, we need to start treating the Internet like the public good it is."},
-    {"url":"http://www.engadget.com/2014/10/10/obama-net-neutrality","title":"President Obama wants the FCC to abandon plans for tiered 'net neutrality'"},
-    {"url":"https://www.theverge.com/2018/3/25/17162158/netflix-banned-from-competing-cannes-film-festival","title":"Netflix banned from competing at Cannes Film Festival - “because Netflix refuses to release its films in theaters, choosing instead to debut them on its streaming service”"},
-    {"url":"http://www.independent.co.uk/news/uk/politics/theresa-may-internet-regulated-london-bridge-terror-attack-google-facebook-whatsapp-borough-security-a7771896.html","title":"Theresa May says the internet must now be regulated following London Bridge terror attack"},
-    {"url":"http://www.latimes.com/opinion/op-ed/la-oe-rosenworcel-fcc-net-neutrality-repeal-20171122-story.html","title":"I'm on the FCC. Please stop us from killing net neutrality"},
-    {"url":"https://www.theverge.com/2018/3/20/17145200/brian-acton-delete-facebook-whatsapp","title":"The co-founder of WhatsApp just told everyone to delete Facebook"},
-    {"url":"https://www.reuters.com/article/us-shell-m-a/shell-buying-spree-cranks-up-race-for-clean-energy-idUSKBN1FF1A8","title":"Shell buying spree cranks up race for clean energy - “spent over $400 million on a range of acquisitions in recent weeks, from solar power to electric car charging points, cranking up its drive to expand beyond its oil and gas business and reduce its carbon footprint.”"},
-    {"url":"https://www.hollywoodreporter.com/thr-esq/trump-administration-tells-supreme-court-wipe-decision-upholding-net-neutrality-1132149","title":"Trump Administration Tells Supreme Court to Wipe Out Decision Upholding Net Neutrality"},
-    {"url":"http://subtelforum.com/articles/google-faster-cable-system-is-ready-for-service-boosts-trans-pacific-capacity-and-connectivity/","title":"Google's FASTER is the first trans-Pacific submarine fiber optic cable system designed to deliver 60 Terabits per second (Tbps) of bandwidth using a six-fibre pair cable across the Pacific. It will go live tomorrow, and essentially doubles existing capacity along the route."},
-    {"url":"https://arstechnica.co.uk/gadgets/2017/02/amd-ryzen-price/","title":"AMD Ryzen pricing: $500 for 8-core 1800X CPU, undercutting Intel by $600"},
-    {"url":"https://www.cnbc.com/2018/11/25/bill-gates-it-would-be-tragic-if-us-wont-lead-on-climate-innovation.html","title":"Bill Gates: It would be tragic if U.S. doesn't lead in innovation for cutting emissions"},
-    {"url":"https://www.techdirt.com/articles/20170821/10485338053/state-supreme-court-says-digital-phones-cant-be-searched-without-warrant.shtml","title":"State Supreme Court Says Digital Phones Can't Be Searched Without A Warrant"},
-    {"url":"https://www.techdirt.com/articles/20180410/17590439606/ftc-suddenly-remembers-warranty-void-if-removed-stickers-are-illegal-sends-out-stern-letters-to-manufacturers.shtml","title":"FTC Suddenly Remembers 'Warranty Void If Removed' Stickers Are Illegal, Sends Out Stern Letters To Manufacturers"},
-    {"url":"http://www.dslreports.com/shownews/Dish-Ordered-to-Pay-Record-280-Million-for-Unwanted-Robocalls-139709","title":"Dish Ordered to Pay Record $280 Million for Unwanted Robocalls"},
-    {"url":"http://arstechnica.com/business/2016/03/comcast-failed-to-install-internet-for-10-months-then-demanded-60000-in-fees/","title":"Comcast failed to install Internet for 10 months then demanded $60,000 in fees"},
-    {"url":"http://www.esquire.com/blogs/news/comcast-astroturfing-net-neutrality","title":"This Is How Comcast Is Astroturfing the Net Neutrality Issue: \"Comcast is working with thinktanks like the American Enterprise Institute. AEI fellows are printing op-eds in support of killing Net neutrality throughout media—from WSJ to US News & World Report—without disclosing their ties to Comcast\""},
-    {"url":"https://www.sciencemag.org/news/2019/01/will-world-embrace-plan-s-radical-proposal-mandate-open-access-science-papers","title":"Will the world embrace Plan S, the radical proposal to mandate open access to science papers?"},
-    {"url":"https://www.inverse.com/article/35133-tesla-model-s-sets-new-record-for-distance-traveled-on-one-charge","title":"Tesla Model S Sets New Record For Distance Traveled On One Charge: 1078 km (669.83) miles with Tesla ModelS 100D"},
-    {"url":"https://www.techdirt.com/articles/20190110/13593541373/att-execs-think-really-funny-they-misled-consumers-about-5g-availability.shtml","title":"AT&T Execs Think It's Really Funny They Misled Consumers About 5G Availability"},
-    {"url":"http://forums.macrumors.com/threads/apples-new-thing-ipod.500/","title":"14 years ago Steve Jobs announced the iPod, and this is how people actually reacted..."},
-    {"url":"https://www.hln.be/nieuws/binnenland/belgie-wint-rechtszaak-tegen-facebook-omdat-het-privacy-niet-respecteert~a81e5c64","title":"Belgium wins trial against Facebook for violating privacy laws"},
-    {"url":"http://arstechnica.com/tech-policy/2016/03/paris-terrorist-attacks-burner-phones-not-encryption/","title":"Paris terrorists used burner phones, not encryption, to evade detection - \"Everywhere they went, the attackers left behind their throwaway phones.\""},
-    {"url":"https://www.cnbc.com/2017/09/26/equifax-ceo-retires-following-an-epic-data-breach-affecting-143-million-people.html","title":"Equifax CEO suddenly retires following an epic data breach affecting 143 million people"},
-    {"url":"https://www.admin.ch/gov/en/start/documentation/media-releases.msg-id-59636.html","title":"Switzerland has ruled on a single charger format for mobile telephones"},
-    {"url":"http://arstechnica.com/science/2016/09/feds-go-after-mylan-for-scamming-medicaid-out-of-millions-on-epipen-pricing/","title":"Feds go after Mylan for scamming Medicaid out of millions on EpiPen pricing"},
-    {"url":"http://www.cnbc.com/2016/11/03/google-android-hits-market-share-record-with-nearly-9-in-every-10-smartphones-using-it.html","title":"Google's Android hits market share record with nearly 9 in every 10 smartphones using it"},
-    {"url":"https://www.thisisinsider.com/amazon-warehouse-vickie-shannon-allen-homeless-injury-2018-7","title":"An Amazon staffer is posting YouTube videos of herself living in a warehouse parking lot after an accident at work."},
-    {"url":"https://apnews.com/b9a4ca1d8f0348f39cf9861e5929a555/Spotify-takes-down-Alex-Jones-podcasts-citing-'hate-content'","title":"Spotify takes down Alex Jones podcasts citing 'hate content.'"},
-    {"url":"https://www.independent.co.uk/life-style/gadgets-and-tech/news/apple-watch-update-latest-edition-watchos-5-expensive-out-of-date-obsolete-a8385291.html","title":"Apple Watch: $17,000 smartwatch is obsolete after latest update"},
-    {"url":"https://www.cbsnews.com/news/its-now-cheaper-to-build-a-new-wind-farm-than-to-keep-a-coal-plant-running/","title":"It's now cheaper to build a new wind farm than to keep a coal plant running"},
-    {"url":"https://www.businessinsider.com/facebook-instagram-snapchat-social-media-well-being-2018-11","title":"A new study finds that cutting your time on social media to 30 minutes a day reduces your risk of depression and loneliness"},
-    {"url":"https://gizmodo.com/at-ts-big-plan-for-hbo-is-to-fill-it-with-more-random-t-1827449321","title":"AT&T's Big Plan for HBO Is to Fill It With More Random Trash Like Netflix"},
-    {"url":"https://www.inverse.com/article/39711-elon-musk-falcon-heavy-tesla-roadsters-mars","title":"Elon Musk Makes It Official: Falcon Heavy is Taking Tesla Roadster to Mars"},
-    {"url":"http://www.sciencealert.com/costa-rica-powered-with-100-renewable-energy-for-75-days","title":"Costa Rica powered with 100% renewable energy for 75 straight days"},
-    {"url":"http://mentalfloss.com/uk/business/44942/japan-will-make-its-last-ever-vcr-this-month","title":"Japan Will Make Its Last Ever VCR This Month"},
-    {"url":"https://www.bbc.com/news/technology-44726296","title":"YouTuber in row over copyright infringement of his own song"},
-    {"url":"https://www.theverge.com/2019/1/7/18172355/att-fake-5g-logo-rolling-out-samsung-lg","title":"AT&T misleads customers by updating phones with fake 5G icon"},
-    {"url":"https://www.techdirt.com/articles/20161107/08205135980/att-mocks-google-fibers-struggles-ignores-it-caused-many-them.shtml","title":"AT&T Mocks Google Fiber's Struggles, Ignores It Caused Many Of Them"},
-    {"url":"https://qz.com/1152683/indian-it-layoffs-in-2017-top-56000-led-by-tcs-infosys-cognizant/","title":"56,000 layoffs and counting: India’s IT bloodbath this year may just be the start"},
-    {"url":"https://techcrunch.com/2018/03/23/elon-musk-deletes-own-spacex-and-tesla-facebook-pages-after-deletefacebook/","title":"Elon Musk deletes own, SpaceX and Tesla Facebook pages"},
-    {"url":"http://gothamist.com/2017/06/01/lrad_lawsuit_nypd.php","title":"The NYPD Claimed Its LRAD Sound Cannon Isn't A Weapon. A Judge Disagreed"},
-    {"url":"http://www.huffingtonpost.com/2015/04/06/edward-snowden-john-oliver-dick-pic_n_7008330.html","title":"Snowden: \"The good news is that there's no program named the 'dick pic' program. The bad news... they are still collecting everybody's information, including your dick pics\""},
-    {"url":"https://www.theverge.com/2019/1/13/18178594/fcc-ftc-robocall-complaints-websites-government-shutdown","title":"Consumer protection websites are down due to the government shutdown"},
-    {"url":"https://www.technologyreview.com/s/602284/the-do-not-call-list-has-a-gaping-hole/","title":"The “Do Not Call” List Isn’t Working. Now the FCC is launching the “Robocall Strike Force.\""},
-    {"url":"http://thehill.com/policy/technology/368826-net-neutrality-advocates-look-to-states-after-fcc-repeal","title":"Net neutrality advocates look to states after FCC repeal: 'As of Friday, California, Washington, New York, Rhode Island, Nebraska and Massachusetts have all introduced net neutrality. North Carolina and Illinois are mulling similar legislation.'"},
-    {"url":"https://www.washingtonpost.com/news/the-switch/wp/2016/10/27/the-fcc-just-passed-sweeping-new-rules-to-protect-your-online-privacy/?tid=sm_tw","title":"The FCC Just Passed Sweeping New Rules to Protect Your Online Privacy"},
-    {"url":"http://www.grubstreet.com/2018/01/shoplifting-amazon-go-grocery-store.html","title":"One Person Already Accidentally Shoplifted at Amazon’s New Cashierless Grocery Store"},
-    {"url":"https://www.engadget.com/2016/11/22/tesla-runs-island-on-solar-power/","title":"Tesla runs an entire island on solar power"},
-    {"url":"http://www.mlive.com/news/index.ssf/2016/11/michigans_biggest_electric_pro.html","title":"Michigan's biggest electric provider phasing out coal, despite Trump's stance | \"I don't know anybody in the country who would build another coal plant,\" Anderson said."},
-    {"url":"http://bgr.com/2015/10/15/adobe-flash-player-security-vulnerability-warning/","title":"Adobe confirms major Flash vulnerability, and the only way to protect yourself is to uninstall Flash"},
-    {"url":"https://www.allflicks.net/netflix-has-twice-as-many-u-s-subscribers-as-comcast/","title":"Netflix Has Twice as Many U.S. Subscribers as Comcast"},
-    {"url":"http://motherboard.vice.com/read/valve-bans-game-publisher-after-it-sues-players-that-gave-it-bad-steam-reviews","title":"Valve Bans Game Publisher After It Sues Players That Gave It Bad Steam Reviews"},
-    {"url":"http://www.reuters.com/article/us-facebook-cambridge-analytica-apology/polls-show-facebook-losing-trust-as-firm-uses-ads-to-apologize-idUSKBN1H10AF","title":"Polls show Facebook losing trust as firm uses ads to apologize | Reuters"},
-    {"url":"http://www.wired.co.uk/news/archive/2015-08/07/kim-dotcom-exclusive-interview-mega-2","title":"Kim Dotcom: Mega 3.0 will succeed as a nonprofit \"Copyright extremism has to stop. Hollywood needs to adapt to the internet and not the other way around. They need to make their content available globally at the same time, at a fair price and for any device.\""},
-    {"url":"https://www.techdirt.com/articles/20171106/09481638554/comcast-tries-to-stop-colorado-city-even-talking-about-building-own-broadband-network.shtml","title":"Comcast Tries To Stop Colorado City From Even Talking About Building Its Own Broadband Network"},
-    {"url":"https://www.eff.org/deeplinks/2017/09/just-how-unpopular-how-wrong-facts-how-misguided-fcc-proposal-rollback-network","title":"Just How Unpopular, How Wrong on the Facts, How Misguided Is the FCC Proposal to Rollback Network Neutrality and Broadband Privacy?"},
-    {"url":"https://www.opensecrets.org/orgs/recips.php?id=D000000461&type=P&state=&sort=A&cycle=2014","title":"Comcast has spent nearly $2,000,000 influencing politics in the first half of 2014."},
-    {"url":"http://forum.utorrent.com/topic/95041-warning-epicscale-riskware-silently-installed-with-latest-utorrent/","title":"Popular torrenting software µTorrent has included an automatic cryptocoin-miner in their latest update."},
-    {"url":"https://qz.com/1007227/netflix-nflx-now-has-more-us-subscribers-than-cable-tv/","title":"With more than 50 million US subscribers, Netflix has finally surpassed cable TV"},
-    {"url":"http://motherboard.vice.com/en_au/read/we-need-to-teach-kids-how-to-be-skeptical-of-the-internet","title":"We Need to Teach Kids How to Be Skeptical of the Internet - a Stanford study found \"80% of middle schoolers couldn't tell “sponsored content” from articles, over 80% of high schoolers accepted the validity of photographs without attempting to verify their authenticity\""},
-    {"url":"https://www.techdirt.com/blog/netneutrality/articles/20170710/10071737756/fcc-insists-it-cant-stop-impostors-lying-about-my-views-net-neutrality.shtml","title":"The FCC Insists It Can't Stop Impostors From Lying About My Views On Net Neutrality"},
-    {"url":"https://motherboard.vice.com/en_us/article/mbpezp/fcc-smartphone-data-reclassification","title":"The FCC's next stunt: Reclassifying cell phone data service as 'broadband Internet'."},
-    {"url":"http://www.huffingtonpost.ca/2016/04/12/uber-transparency-report_n_9673770.html","title":"Uber Transparency Report Reveals It Shared Data On 13 Million Users With Government"},
-    {"url":"http://www.myce.com/news/hp-pre-programmed-failure-date-unofficial-non-hp-ink-cartridges-printers-80457/","title":"HP pre-programmed failure date of unofficial/ non-HP ink cartridges in its printers"},
-    {"url":"https://www.theguardian.com/world/2018/jan/28/fitness-tracking-app-gives-away-location-of-secret-us-army-bases","title":"Fitness tracking app gives away location of secret US army bases"},
-    {"url":"http://www.sciencemag.org/news/2018/05/trump-white-house-quietly-cancels-nasa-research-verifying-greenhouse-gas-cuts","title":"Trump White House quietly cancels NASA research verifying greenhouse gas cuts"},
-    {"url":"https://electrek.co/2017/10/05/elon-musk-tesla-rebuild-puerto-ricos-power-grid-batteries-solar/","title":"Elon Musk says Tesla could rebuild Puerto Rico’s power grid with batteries and solar"},
-    {"url":"https://theintercept.com/2016/04/28/new-study-shows-mass-surveillance-breeds-meekness-fear-and-self-censorship/","title":"\"After Snowden showed everyone how much the US tracks people's browsing, there was a 20% decrease in visits to Wikipedia pages about topics relating to terrorism.\""},
-    {"url":"http://www.engadget.com/2015/11/10/tim-cook-talks-encryption/","title":"Apple CEO: \"If you halt or weaken encryption, the people that you hurt are not the folks that want to do bad things. It's the good people. The other people know where to go.\""},
-    {"url":"https://medium.com/charged-tech/apple-just-told-the-world-it-has-no-idea-who-the-mac-is-for-722a2438389b#.8j5koelrj","title":"Apple just told the world it has no idea who the Mac is for"},
-    {"url":"http://www.nytimes.com/2015/11/28/us/politics/bill-gates-expected-to-create-billion-dollar-fund-for-clean-energy.html","title":"Bill Gates to create multibillion-dollar fund to pay for R&D of new clean-energy technologies. “If we create the right environment for innovation, we can accelerate the pace of progress, develop new solutions, and eventually provide everyone with reliable, affordable energy that is carbon free.”"},
-    {"url":"http://fortune.com/2018/12/21/comcast-customers-minnesota-ag-lawsuit/","title":"Comcast swindled customers with rate hikes, bogus equipment charges, lawsuit claims - “It’s hard to shop for cable television if a company plays hide-the-ball on its true prices, and people shouldn’t have to watch their bills for things they didn’t buy.”"},
-    {"url":"http://www.businessinsider.com/failing-to-protect-net-neutrality-would-crush-digital-startups-2017-7","title":"Why failing to protect net neutrality would crush the US's digital startups"},
-    {"url":"http://www.cnbc.com/2017/02/20/mark-cuban-robots-unemployment-and-we-need-to-prepare-for-it.html","title":"Mark Cuban: Robots will ‘cause unemployment and we need to prepare for it’"},
-    {"url":"https://nakedsecurity.sophos.com/2018/08/16/australians-who-wont-unlock-their-phones-could-face-10-years-in-jail/","title":"Australians who won’t unlock their phones could face 10 years in jail"},
-    {"url":"https://www.justice.gov/usao-ndca/pr/former-secret-service-agent-sentenced-scheme-related-silk-road-investigation","title":"Secret Service agent stole 1,600 Bitcoins from Silk Road wallet"},
-    {"url":"https://www.washingtonpost.com/world/national-security/the-nsas-top-talent-is-leaving-because-of-low-pay-and-battered-morale/2018/01/02/ff19f0c6-ec04-11e7-9f92-10a2203f6c8d_story.html?tid=pm_world_pop&utm_term=.637292c3a88f","title":"The NSA’s top talent is leaving because of low pay and flagging morale"},
-    {"url":"https://www.geek.com/tech/400-burger-per-hour-robot-will-put-teenagers-out-of-work-1703546/","title":"400 Burger Per Hour Robot Will Put Teenagers Out Of Work"},
-    {"url":"http://arstechnica.com/tech-policy/2014/08/senator-wants-all-us-cops-to-wear-video-cameras/","title":"Senator wants all US cops to wear video cameras | Ars Technica"},
-    {"url":"http://www.scribblelive.com/Event/Microsoft_launches_Windows_10/140927634","title":"Windows 10 will be a free upgrade from Windows 7 for a full year"},
-    {"url":"https://techcrunch.com/2018/12/10/equifax-breach-preventable-house-oversight-report/","title":"Equifax breach was ‘entirely preventable’ had it used basic security measures, says House report"},
-    {"url":"http://hustlecon.com/broke-artist-believed-in-sean-parker-makes-200-million-off-facebook-stock","title":"Artist who painted Facebook's first office and asked for stock instead of cash is now worth $200m"},
-    {"url":"https://www.bloomberg.com/news/articles/2017-06-20/robots-are-eating-money-managers-lunch","title":"Robots Are Eating Money Managers’ Lunch - \"A wave of coders writing self-teaching algorithms has descended on the financial world, and it doesn’t look good for most of the money managers who’ve long been envied for their multimillion-­dollar bonuses.\""},
-    {"url":"http://bgr.com/2014/10/16/why-is-comcast-so-bad-24/","title":"An entire city tells Comcast it’s not wanted thanks to ‘deplorable and substandard’ customer service"},
-    {"url":"http://www.engadget.com/2016/01/08/you-say-advertising-i-say-block-that-malware/?utm_source=fark&utm_medium=website&utm_content=link","title":"Forbes.com asks users running adblockers to disable blocking to view stories on their site. Then promptly serves up pop-under malware to those who complied."},
-    {"url":"https://hardware.slashdot.org/story/16/06/11/1458246/apple-is-fighting-a-secret-war-to-keep-you-from-repairing-your-phone","title":"Apple Is Fighting A Secret War To Keep You From Repairing Your Phone"},
-    {"url":"http://europa.eu/rapid/press-release_IP-15-5265_en.htm","title":"European Commission welcomes agreement to end roaming charges and to guarantee an open Internet"},
-    {"url":"http://www.cnbc.com/2017/03/01/heres-the-business-bill-gates-would-start-with-elon-musk.html","title":"Bill Gates knows just what business he would start with Elon Musk - he would have the two of them take on energy alternatives. \"We need clean, reliable cheap energy — which we don't have\""},
-    {"url":"http://www.independent.co.uk/news/world/europe/france-coal-power-station-emmanuel-macron-davos-shut-2021-a8176796.html","title":"France to shut all coal-fired power stations by 2021, Macron declares"},
-    {"url":"http://newatlas.com/desktop-metal-3d-printing/50654/","title":"100x faster, 10x cheaper: 3D metal printing is about to go mainstream"},
-    {"url":"http://thenextweb.com/insider/2015/07/15/under-promise-over-deliver/","title":"Amazon Prime Day is on and customers are bummed out by the virtual ‘garage sale’"},
-    {"url":"https://motherboard.vice.com/en_us/article/ne45jd/rand-paul-filibuster-fisa-702-senate","title":"5 Senators Are Filibustering an Attempt to Expand Warrantless Surveillance of Americans - 3 Democrats and 2 Republicans are filibustering the Senate vote on the reauthorization of FISA Section 702."},
-    {"url":"http://www.dslreports.com/shownews/Comcast-Says-It-Wants-to-Charge-Broadband-Users-More-For-Privacy-137567","title":"Comcast Says It Wants to Charge Broadband Users More For Privacy"},
-    {"url":"https://www.theverge.com/2018/10/30/18045410/facebook-bans-proud-boys-far-right-extremist-group-gavin-mcinnes","title":"Facebook has started banning accounts affiliated with far-right group the Proud Boys"},
-    {"url":"http://www.businessinsider.com/tesla-liberty-mutual-create-customize-insurance-package-2017-10?r=US&IR=T","title":"Tesla strikes another deal that shows it's about to turn the car insurance world upside down - InsureMyTesla shows how the insurance industry is bound for disruption as cars get safer with self-driving tech."},
-    {"url":"https://arstechnica.com/science/2018/03/amid-drug-price-increases-pfizer-ceo-gets-61-pay-raise-to-27-9-million/?amp=1","title":"Pfizer CEO gets 61% pay raise—to $27.9 million—as drug prices continue to climb"},
-    {"url":"https://www.utilitydive.com/news/colorado-could-save-25-billion-through-2040-by-replacing-coal-with-clean/545652/","title":"Colorado could save $2.5B through 2040 by replacing coal with clean energy: report"},
-    {"url":"https://www.techdirt.com/articles/20151207/21225233018/two-leading-presidential-candidates-clinton-trump-both-mocked-free-speech-internet.shtml","title":"The Two Leading Presidential Candidates -- Clinton And Trump -- Are Both Mocking Free Speech On The Internet"},
-    {"url":"http://www.cnn.com/2017/03/09/politics/fbi-investigation-continues-into-odd-computer-link-between-russian-bank-and-trump-organization/index.html","title":"Russian bank looked up the address to Trump corporate server 2,820 times, representing 80% of the lookups, according to records. 19% or the remaining 20 were from medical facility chain led by Dick DeVos, the husband of Betsy DeVos."},
-    {"url":"https://www.techdirt.com/articles/20160424/07013134258/cable-industry-threatens-to-sue-if-fcc-tries-to-bring-competition-to-cable-set-top-boxes.shtml","title":"The Cable Industry Threatens To Sue If FCC Tries To Bring Competition To Cable Set Top Boxes"},
-    {"url":"https://www.theverge.com/2018/11/9/18079880/paypal-proud-boys-gavin-mcinnes-antifa","title":"PayPal is canceling accounts used by the Proud Boys, Gavin McInnes, and antifa groups - PayPal said today that it will cancel accounts used by far-right group the Proud Boys as well as multiple accounts from anti-fascist groups."},
-    {"url":"https://techcrunch.com/2016/08/13/spacex-succesfully-launches-another-satellite-brings-home-another-rocket/","title":"SpaceX succesfully launches another satellite, brings home another rocket"},
-    {"url":"http://www.businessinsider.com/mark-cuban-backed-startup-dave-has-landed-13-million-in-funding-2018-4","title":"Mark Cuban is trying to get rid of overdraft fees"},
-    {"url":"http://www.engadget.com/2016/05/17/ibm-research-phase-change-memory/","title":"IBM's optical storage is 50 times faster than flash and is now cheaper than RAM."},
-    {"url":"http://www.indystar.com/story/news/2015/01/19/police-radar-see-through-walls/22007615/","title":"New police radars can \"see\" inside homes; At least 50 U.S. law enforcement agencies quietly deployed radars that let them effectively see inside homes, with little notice to the courts or the public"},
-    {"url":"https://money.cnn.com/2018/07/19/technology/business/tesla-downgrade/index.html?utm_medium=social&utm_content=2018-07-21T21%3A02%3A06&utm_source=twmoney&utm_term=image","title":"24% of Tesla Model 3 orders have been canceled, analyst says"},
-    {"url":"http://www.theguardian.com/commentisfree/2015/apr/08/congress-must-end-mass-nsa-surveillance-with-next-patriot-act-vote","title":"\"In less than 60 days, Congress will be forced to decide if the NSA’s most notorious mass surveillance program lives or dies. And today, over 30 civil liberties organizations launched a nationwide call-in campaign urging them to kill it.\""},
-    {"url":"https://www.politico.com/story/2018/02/27/democrats-fcc-reverse-net-neutrality-426641","title":"Democrats introduce resolution to reverse FCC net neutrality repeal"},
-    {"url":"http://thehill.com/policy/technology/236769-house-effort-would-completely-dismantle-patriot-act","title":"House effort would completely dismantle Patriot Act"},
-    {"url":"https://medium.com/humane-tech/tech-and-the-fake-market-tactic-8bd386e3d382#.gxueb94j3","title":"In one generation, the Internet went from opening up new free markets to creating a series of Fake Markets that exploit society, without most media or politicians even noticing."},
-    {"url":"https://spreadprivacy.com/facebook-whatsapp/","title":"Most Americans aren't aware that Facebook owns WhatsApp"},
-    {"url":"https://www.techdirt.com/articles/20170513/10394837355/fcc-spent-last-week-trying-to-make-net-neutrality-supporters-seem-unreasonable-racist-unhinged.shtml","title":"The FCC Spent Last Week Trying To Make Net Neutrality Supporters Seem Unreasonable, Racist and Unhinged"},
-    {"url":"http://www.telegraph.co.uk/technology/news/11966036/Snapchat-just-reserved-the-rights-to-store-and-use-all-selfies-taken-with-the-device.html","title":"Snapchat just reserved the rights to store and use all selfies taken with the device"},
-    {"url":"https://www.businessinsider.com/fcc-ajit-pai-debunked-ddos-attack-senate-hearing-net-neutrality-john-oliver-2018-8","title":"Congress is set to grill the FCC's chairman for falsely claiming his agency was hit with a cyberattack — here's how it could affect the war over net neutrality"},
-    {"url":"https://www.theregister.co.uk/2017/05/24/fcc_under_cable_company_control/","title":"FCC revised net neutrality rules reveal cable company control of process"},
-    {"url":"http://www.nytimes.com/2018/12/19/business/delete-facebook-account.amp.html","title":"NYTimes: How to Delete Facebook"},
-    {"url":"https://venturebeat.com/2017/11/17/facebook-removes-delete-post-option-from-the-desktop-web-version/","title":"Facebook removes ‘delete post’ option from the desktop web version"},
-    {"url":"http://uk.businessinsider.com/facebook-data-scandal-bigger-than-87-million-users-2018-4","title":"Second Cambridge Analytica whistleblower says 'sex compass' app gathered more Facebook data beyond the 87 million we already knew about"},
-    {"url":"https://www.reuters.com/article/us-election-tech-advertising-lawsuit/washington-state-sues-facebook-google-over-election-ad-disclosure-idUSKCN1J030X","title":"Washington State Is Suing Facebook And Google For Violating Election Advertisement Laws"},
-    {"url":"http://www.businessinsider.com/russian-troll-farm-spent-millions-on-election-interference-2018-2","title":"A Russian troll factory had a $1.25 million monthly budget to interfere in the 2016 US election"},
-    {"url":"http://www.ibtimes.com/chicago-mayor-rahm-emanuel-received-more-100000-comcast-boosting-merger-1676264?utm_content=buffere9697&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer","title":"Chicago Mayor Rahm Emanuel Received More Than $100,000 from Comcast Before Boosting Merger"},
-    {"url":"http://motherboard.vice.com/en_ca/read/if-the-fbi-is-so-worried-about-car-hacking-why-is-it-fighting-encryption","title":"If the FBI Is So Worried About Car Hacking, Why Is It Fighting Encryption?"},
-    {"url":"https://www.bloomberg.com/news/articles/2018-04-23/electric-buses-are-hurting-the-oil-industry","title":"Electric Buses Are Hurting the Oil Industry"},
-    {"url":"https://medium.com/@fightfortheftr/ajit-pais-repeal-of-net-neutrality-officially-goes-into-effect-today-6e03a8991b95","title":"Ajit Pai’s repeal of net neutrality officially goes into effect today. But Congress can still reverse it. Contact your House Reps right now"},
-    {"url":"https://www.techdirt.com/articles/20180215/07195439242/game-studio-threatens-employees-jobs-if-they-dont-write-positive-reviews-own-game-then-steam-pulls-game-entirely.shtml","title":"Game Studio Threatens Employees' Jobs If They Don't Write Positive Reviews Of Own Game, Then Steam Pulls Game Entirely"},
-    {"url":"https://www.schneier.com/essays/archives/2014/02/its_time_to_break_up.html","title":"It's Time to Break Up the NSA"},
-    {"url":"https://arstechnica.com/?post_type=post&p=1191773","title":"Two-week-old Pixel 2 XL displays are already showing burn-in"},
-    {"url":"https://techcrunch.com/2016/09/18/dont-just-pardon-edward-snowden-give-the-man-a-medal/","title":"Don’t just pardon Edward Snowden; give the man a medal"},
-    {"url":"https://www.theverge.com/2018/1/30/16949550/bitcoin-graphics-cards-pc-prices-surge","title":"Bitcoin mania is hurting PC gamers by pushing up GPU prices"},
-    {"url":"http://www.dslreports.com/shownews/Chicago-to-Apply-9-Netflix-Tax-134367","title":"Chicago to Apply 9% 'Netflix Tax'"},
-    {"url":"https://www.theverge.com/2017/6/21/15816974/verizon-tumblr-net-neutrality-internet-politics-david-karp","title":"Verizon is killing Tumblr’s fight for net neutrality"},
-    {"url":"https://www.businessinsider.com/google-pixel-3-telemarketer-call-screen-2018-10","title":"Google's new phone software aims to end telemarketer calls for good"},
-    {"url":"http://qz.com/230603/youtube-like-netflix-is-now-publicly-shaming-internet-providers-for-slow-video/","title":"YouTube, following Netflix, is now publicly shaming internet providers for slow video"},
-    {"url":"https://cleantechnica.com/2017/02/02/garbage-trucks-buses-time-start-talking-big-electric-vehicles/","title":"From Garbage Trucks To Buses, It's Time To Start Talking About Big Electric Vehicles - \"While medium and heavy trucks account for only 4% of America’s +250 million vehicles, they represent 26% of American fuel use and 29% of vehicle CO2 emissions.\""},
-    {"url":"http://www.thedailybeast.com/articles/2016/06/15/a-twitter-bot-is-beating-trump-fans.html","title":"A Twitter Bot Is Beating Trump Fans: Scores of Trump supporters spent Tuesday fighting with an automated Twitter robot that spouts nonsense."},
-    {"url":"https://www.space.com/41599-nasa-moon-space-priorities-jim-bridenstine-update.html","title":"NASA Chief Wants to Send Humans to the Moon — 'To Stay'"},
-    {"url":"https://yro.slashdot.org/story/17/09/10/0128214/techcrunch-equifax-hack-checking-web-site-is-returning-random-results","title":"TechCrunch: Equifax Hack-Checking Web Site Is Returning Random Results"},
-    {"url":"https://krebsonsecurity.com/2017/12/kansas-man-killed-in-swatting-attack/","title":"Kansas Man Killed In ‘SWATting’ Attack; Attacker was same individual who called in fake net-neutrality bomb"},
-    {"url":"http://www.latimes.com/business/hiltzik/la-fi-hiltzik-lifelock-equifax-20170918-story.html","title":"Lifelock offers to protect you from the Equifax breach — by selling you services provided by Equifax."},
-    {"url":"http://www.gamespot.com/articles/hbo-go-blocked-on-ps4-by-comcast-just-like-on-ps3/1100-6425719/","title":"HBO Go Blocked on PS4 by Comcast, Just Like on PS3"},
-    {"url":"https://motherboard.vice.com/en_us/article/ev5mm7/at-the-behest-of-t-mobile-the-fcc-is-undoing-rules-that-make-it-easier-for-small-isps-to-compete-with-big-telecom","title":"At the Behest of T-Mobile, the FCC Is Undoing Rules That Make it Easier for Small ISPs to Compete With Big Telecom"},
-    {"url":"https://www.commondreams.org/views/2018/11/18/biggest-threat-free-speech-no-one-talking-about","title":"The Biggest Threat to Free Speech No One Is Talking About: It's not being mean to reporters, \"The biggest freedom-of-the-press issue is that Trump is working with Comcast and AT&T and Verizon to end net neutrality.\""},
-    {"url":"http://www.theverge.com/2016/9/27/13071330/facebook-whatsapp-user-data-germany-privacy","title":"Germany orders Facebook to stop collecting data on WhatsApp users"},
-    {"url":"http://www.independent.co.uk/life-style/gadgets-and-tech/un-declares-online-freedom-to-be-a-human-right-that-must-be-protected-a7120186.html","title":"UN declares online freedom to be a human right that must be protected"},
-    {"url":"http://www.cbc.ca/news/business/bell-customer-wins-court-battle-over-contract-1.4635118","title":"Customer takes Bell to court and wins, as judge agrees telecom giant can't promise a price, then change it"},
-    {"url":"http://www.businessinsider.com/china-bullet-train-speed-map-photos-tour-2018-5/?r=US&IR=T","title":"I rode China's superfast bullet train that could go from New York to Chicago in 4.5 hours — and it shows how far behind the US really is"},
-    {"url":"https://www.thedailybeast.com/how-trump-will-turn-americas-open-internet-into-an-ugly-version-of-chinas","title":"How Trump Will Turn America’s Open Internet Into an Ugly Version of China’s"},
-    {"url":"https://www.theguardian.com/commentisfree/2018/dec/21/quit-facebook-privacy-scandal-private-messages","title":"Is 2019 the year you should finally quit Facebook? Deleting your Facebook account isn’t a bad New Year resolution – the company has proven yet again it violated public trust"},
-    {"url":"https://www.forbes.com/sites/laurencebradford/2018/06/19/why-we-need-to-talk-about-burnout-in-the-tech-industry/#27e4d6a11406","title":"57% of tech industry employees are suffering from job burnout"},
-    {"url":"http://hn.premii.com/#/article/13778543","title":"94-year-old Lithium-Ion Battery Inventor Introduces Solid State Battery"},
-    {"url":"https://www.cnbc.com/2018/11/21/amazon-exposed-customer-names-and-emails-in-a-technical-error.html","title":"Amazon exposed customer names and emails in a 'technical error'"},
-    {"url":"https://www.theguardian.com/commentisfree/2018/nov/20/facebook-google-antitrust-laws-gilded-age","title":"Break up Facebook (and while we're at it, Google, Apple and Amazon) - Big tech has ushered in a second Gilded Age. We must relearn the lessons of the first, writes the former US labor secretary"},
-    {"url":"https://qz.com/878790/a-lawyer-rewrote-instagrams-terms-of-service-for-kids-now-you-can-understand-all-of-the-private-data-you-and-your-teen-are-giving-up-to-social-media/","title":"A lawyer rewrote Instagram's terms of service for kids. Now you can understand all of the private data you and your teen are giving up to social media"},
-    {"url":"http://time.com/5328463/uganda-social-media-tax/","title":"Uganda Just Rolled Out a 5-Cent Daily Tax to Access Social Media"},
-    {"url":"https://gizmodo.com/trumphotels-org-purchased-by-pranksters-to-promote-amer-1827098727","title":"TrumpHotels.org Purchased by Pranksters to Promote America's Concentration Camps"},
-    {"url":"http://money.cnn.com/2016/04/26/news/companies/mitsubishi-cheating-fuel-tests-25-years/index.html","title":"Mitsubishi: We've been cheating on fuel tests for 25 years"},
-    {"url":"https://medium.com/@fightfortheftr/this-fourth-of-july-us-veterans-are-calling-on-congress-to-restore-net-neutrality-acb89ce767b7","title":"This Fourth of July, US veterans are calling on Congress to restore net neutrality"},
-    {"url":"https://www.techdirt.com/articles/20160410/06272034141/as-isps-push-harder-usage-caps-house-pushes-bill-preventing-fcc-doing-anything-about-it.shtml","title":"As ISPs Push Harder On Usage Caps, House Pushes Bill Preventing The FCC From Doing Anything About It"},
-    {"url":"http://www.rcrwireless.com/20170601/carriers/att-throttling-blocking-allowed-under-title-II-tag6?","title":"AT&T -- Throttling, “filtered service” allowed under Title II: '... AT&T executive said that court intepretations of Title II regulations appear to allow ISPs to slow down or block certain content or traffic types — so long as they are upfront with customers about it.'"},
-    {"url":"https://arstechnica.com/tech-policy/2017/10/former-fcc-chief-asks-fcc-why-the-silence-about-trumps-media-threats/","title":"Tom Wheeler to Ajit Pai: “Why the silence” about Trump’s media threats?"},
-    {"url":"https://gizmodo.com/aclu-wants-release-of-secret-court-order-demanding-face-1830732015","title":"ACLU Wants Release of Secret Court Order Demanding Facebook Build Surveillance Backdoor"},
-    {"url":"https://qz.com/279940/meet-profile-engine-the-spammy-facebook-crawler-hated-by-people-who-want-to-be-forgotten/","title":"From 2007-2010 Facebook allowed a website called ProfileEngine to scrape user data, allowing them to steal the details of over 400 million user profiles, all still accessible on their website."},
-    {"url":"http://www.mobilecomputingtoday.co.uk/339/att-continues-throttle-internet-speeds-opposing-ftc-actions-fccs-rules/","title":"AT&T continues to throttle internet speeds opposing FTC actions and the FCC’s rules"},
-    {"url":"https://theintercept.com/2015/06/20/wikileaks-jacob-appelbaum-google-investigation/","title":"The Obama administration fought a legal battle against Google to secretly obtain the email records of a researcher and journalist associated with WikiLeaks"},
-    {"url":"https://www.ft.com/content/b42f40c2-a6df-11e6-8b69-02899e8bd9d1","title":"Silicon Valley frets over foreign worker crackdown. Trump has warned H-1B visas are being used to bring cheap labour to the US"},
-    {"url":"https://www.cnbc.com/2018/12/01/social-media-detox-christina-farr-quits-instagram-facebook.html","title":"I quit Instagram and Facebook and it made me a lot happier — and that's a big problem for social media companies"},
-    {"url":"https://www.engadget.com/amp/2019/01/08/verizon-t-mobile-burn-att-fake-5g/","title":"AT&T gets burned by rivals over its fake 5G network"},
-    {"url":"https://thehackernews.com/2018/10/apple-macbook-microphone.html","title":"Apple's New MacBook Disconnects Microphone \"Physically\" When Lid is Closed"},
-    {"url":"http://nintendoeverything.com/nintendo-president-satoru-iwata-has-passed-away/","title":"Nintendo president Satoru Iwata has passed away"},
+  {
+    "url": "https://www.congress.gov/bill/115th-congress/house-bill/4585",
+    "title": "Congress has set out a bill to stop the FCC taking away our internet. PLEASE SPREAD THIS AS MUCH AS YOU CAN."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/wjzjv9/net-neutrality-fraud-ny-attorney-general-investigation?utm_source=mbtwitter",
+    "title": "The FCC Is Blocking a Law Enforcement Investigation Into Net Neutrality Comment Fraud"
+  },
+  {
+    "url": "https://www.alexa.com/topsites/countries/US",
+    "title": "Reddit just passed Facebook as #3 most popular website in US"
+  },
+  {
+    "url": "http://static.techspot.com/news/71865-congressmen-demand-investigation-fcc-chairman-ajit-pai-sinclair.html",
+    "title": "Congressmen demand investigation of FCC Chairman Ajit Pai, Sinclair Broadcast Group"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/08/verizon-throttled-fire-departments-unlimited-data-during-calif-wildfire/",
+    "title": "Verizon throttled fire department’s “unlimited” data during Calif. wildfire"
+  },
+  {
+    "url": "https://townhall.com/columnists/bobbarr/2017/12/20/massive-fraud-in-net-neutrality-process-is-a-crime-deserving-of-justice-department-attention-n2424724",
+    "title": "Massive Fraud in Net Neutrality Process is a Crime Deserving of Justice Department Attention"
+  },
+  {
+    "url": "https://www.thelocal.fr/20171228/french-lawsuit-launched-against-apple-for-alleged-crime-of-slowing-down-iphones",
+    "title": "A lawsuit against Apple is launched in France, one of the only countries where planned obsolescence is explicitly illegal"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/j5vn9k/apple-blocking-net-neutrality-app-wehe",
+    "title": "Apple Is Blocking an App That Detects Net Neutrality Violations From the App Store: Apple told a university professor his app \"has no direct benefits to the user.\""
+  },
+  {
+    "url": "http://www.netimperative.com/2019/01/netflix-would-lose-57-of-their-subscribers-if-they-added-commercials/",
+    "title": "Netflix ‘would lose 57% of their subscribers if they added commercials’"
+  },
+  {
+    "url": "https://www.macrumors.com/2017/12/21/apple-lawsuit-slowing-down-old-iphone-models/",
+    "title": "Apple Being Sued for 'Purposefully Slowing Down Older iPhone Models'"
+  },
+  {
+    "url": "https://www.c-span.org/video/?445642-1/us-senate-vote-reinstating-net-neutrality-rules-3pm&live=",
+    "title": "Senate votes in favor of overturning FCC on Net Neutrality"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/d3q45v/bittorrent-usage-increases-netflix-streaming-sites",
+    "title": "The rise of Netflix competitors has pushed consumers back toward piracy - BitTorrent usage has bounced back because there's too many streaming services, and too much exclusive content."
+  },
+  {
+    "url": "https://www.allflicks.net/74-of-netflix-subscribers-would-rather-cancel-their-subscription-than-see-ads/",
+    "title": "74% of Netflix Subscribers Would Rather Cancel Their Subscription Than See Ads"
+  },
+  {
+    "url": "https://www.inquisitr.com/4790689/reddits-the_donald-was-one-of-the-biggest-havens-for-russian-propaganda-during-2016-election-analysis-finds/",
+    "title": "Reddit’s The_Donald Was One Of The Biggest Havens For Russian Propaganda During 2016 Election, Analysis Finds"
+  },
+  {
+    "url": "https://www.dailydot.com/layer8/ajit-pai-resign-petition-white-house-we-the-people/",
+    "title": "White House must now respond to the people asking for FCC Chairman Ajit Pai’s resignation over net neutrality"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171030/11255938512/dead-people-mysteriously-support-fccs-attack-net-neutrality.shtml",
+    "title": "Dead People Mysteriously Support The FCC's Attack On Net Neutrality"
+  },
+  {
+    "url": "http://resistancereport.com/news/cards-humanity-creator-just-pledged-buy-publish-congresss-browser-history/",
+    "title": "‘Cards Against Humanity’ Creator Just Pledged To Buy and Publish Congress’s Browser History"
+  },
+  {
+    "url": "https://www.nytimes.com/2017/12/14/technology/net-neutrality-repeal-vote.html",
+    "title": "F.C.C. Repeals Net Neutrality Rules"
+  },
+  {
+    "url": "https://www.inverse.com/article/39994-nebraska-proposes-reinstate-net-neutrality",
+    "title": "Nebraska Introduces Law to Re-Instate Net Neutrality - ‘The “Internet Neutrality Act” (LB856) would restore the former federal rules and prohibit broadband internet service providers from “limiting or restricting access to web sites, applications, or content.”’"
+  },
+  {
+    "url": "https://techcrunch.com/2018/08/06/fcc-admits-it-was-never-actually-hacked/",
+    "title": "FCC admits it was never actually hacked."
+  },
+  {
+    "url": "https://news.sky.com/story/scientist-stephen-hawking-has-died-aged-76-11289119",
+    "title": "Stephen Hawking has passed away at 76 years old"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171120/11253438653/fcc-plan-to-use-thanksgiving-to-hide-attack-net-neutrality-vastly-underestimates-looming-backlash.shtml",
+    "title": "FCC Plan To Use Thanksgiving To 'Hide' Its Attack On Net Neutrality Vastly Underestimates The Looming Backlash"
+  },
+  {
+    "url": "https://www.inquisitr.com/4685704/fcc-has-reportedly-been-using-dead-peoples-social-media-accounts-to-spread-propaganda/",
+    "title": "FCC Has Reportedly Been Using Dead People’s Social Media Accounts To Spread Propaganda: The FCC might be making pro-repeal comments on your or even your dead relatives' behalf."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171122/09473038669/fcc-releases-net-neutrality-killing-order-hopes-youre-too-busy-cooking-turkey-to-read-it.shtml",
+    "title": "FCC Releases Net Neutrality Killing Order, Hopes You're Too Busy Cooking Turkey To Read It"
+  },
+  {
+    "url": "https://www.thewrap.com/netflix-comes-out-in-support-for-net-neutrality-tells-fcc-we-will-see-you-in-court/",
+    "title": "Netflix comes out for net neutrality, tells FCC 'We will see you in court'."
+  },
+  {
+    "url": "http://www.verizonprotests.com/",
+    "title": "The new chairman of the FCC was a top lawyer at Verizon. Now he's calling for a vote to kill net neutrality. We’re protesting at retail stores across the U.S. to demand that Congress stop Verizon’s FCC from destroying the Internet as we know it."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/mb4ezy/top-voting-machine-vendor-admits-it-installed-remote-access-software-on-systems-sold-to-states",
+    "title": "Top Voting Machine Vendor Admits It Installed Remote-Access Software on Systems Sold to States - Remote-access software and modems on election equipment 'is the worst decision for security short of leaving ballot boxes on a Moscow street corner.'"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/09/ajit-pai-calls-californias-net-neutrality-rules-illegal/",
+    "title": "Ajit Pai calls California’s net neutrality rules “illegal” - California senator replies: The rules are \"necessary and legal because Chairman Pai abdicated his responsibility to ensure an open Internet\""
+  },
+  {
+    "url": "http://thehill.com/policy/technology/363110-group-of-senators-calls-on-fcc-to-delay-net-neutrality-vote",
+    "title": "Group of 27 Dem senators calls on FCC to delay net neutrality vote"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171214/09383738811/two-separate-studies-show-that-vast-majority-people-who-said-they-support-ajit-pais-plan-were-fake.shtml",
+    "title": "Two Separate Studies Show That The Vast Majority Of People Who Said They Support Ajit Pai's Plan... Were Fake"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/i-know-youre-tired-of-hearing-about-net-neutrality-ba2ef1c51939",
+    "title": "I know you’re tired of hearing about net neutrality. I’m tired of writing about it. But the Senate is about to vote, and it’s time to pay attention"
+  },
+  {
+    "url": "https://www.cnbc.com/2017/11/22/n-y-attorney-general-slams-the-fcc-over-net-neutrality-investigation.html",
+    "title": "New York attorney general slams the FCC for 'refusal to assist' investigation into fake comments about net neutrality"
+  },
+  {
+    "url": "http://www.miaminewtimes.com/news/miami-frustrated-with-fpl-after-hurricane-irma-9666311",
+    "title": "Due to excessive lobbying from FPL, Florida residents without power due to the hurricane are not permitted to use their own solar panels"
+  },
+  {
+    "url": "http://www.popularmechanics.com/how-to/blog/what-you-need-to-know-about-rosettas-mission-to-land-on-a-comet-17416959",
+    "title": "It's now official - Humanity has landed a probe on a comet!"
+  },
+  {
+    "url": "https://gizmodo.com/35-states-tell-the-fcc-to-get-off-its-ass-and-do-someth-1829637040",
+    "title": "35 States Tell the FCC to Get Off Its Ass and Do Something About Spoofed Robocalls"
+  },
+  {
+    "url": "https://nationaleconomicseditorial.com/2017/11/27/americans-fiber-optic-internet/",
+    "title": "Americans Taxed $400 Billion For Fiber Optic Internet That Doesn’t Exist"
+  },
+  {
+    "url": "https://arstechnica.com/science/2018/07/elon-musk-making-kid-sized-submarine-to-rescue-teens-in-thailand-cave/",
+    "title": "Elon Musk making “kid-sized submarine” to rescue teens in Thailand cave: \"Construction complete in about 8 hours,\" the tech billionaire tweeted Saturday."
+  },
+  {
+    "url": "https://www.meo.pt/internet/internet-movel/telemovel/pacotes-com-telemovel",
+    "title": "In Portugal, with no net neutrality, internet providers are starting to split the net into packages. This is the future of the Internet if the FCC gets its way. It's not theory. It's happening already."
+  },
+  {
+    "url": "https://www.theverge.com/2018/4/16/17245010/elizabeth-pierce-fraud-charges-bdac-fcc-ajit-pai",
+    "title": "Broadband advisor picked by FCC Chairman Ajit Pai arrested on fraud charges"
+  },
+  {
+    "url": "https://www.usatoday.com/story/news/politics/2018/04/04/facebook-gave-most-contributions-house-committee-question-zuckerberg-also-got-most-contributions-fac/486313002/",
+    "title": "Facebook Donated to 46 of 55 Members on Committee that Will Question Zuckerberg"
+  },
+  {
+    "url": "http://www.theverge.com/2017/3/29/15100620/congress-fcc-isp-web-browsing-privacy-fire-sale?utm_source=dlvr.it&utm_medium=twitter",
+    "title": "The 265 members of Congress who sold you out to ISPs, and how much it cost to buy them - The Verge"
+  },
+  {
+    "url": "http://www.adweek.com/creativity/burger-king-deviously-explains-net-neutrality-by-making-people-wait-longer-for-whoppers/",
+    "title": "Burger King Deviously Explains Net Neutrality by Making People Wait Longer for Whoppers"
+  },
+  {
+    "url": "http://time.com/4770205/john-oliver-fcc-net-neutrality/",
+    "title": "John Oliver Is Calling on You to Save Net Neutrality, Again"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2018/02/07/fidelity_astroturf_city_broadband/",
+    "title": "Mystery Website Attacking City-Run Broadband Was Run by a Telecom Company"
+  },
+  {
+    "url": "https://venturebeat.com/2017/09/14/chrome-will-no-longer-autoplay-content-with-sound-in-january-2018/",
+    "title": "Chrome will no longer autoplay content with sound in January 2018."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/scotus-cell-location-privacy-op-ed",
+    "title": "The Supreme Court Phone Location Case Will Decide the Future of Privacy - Later this year, the Supreme Court will decide if police can track a person’s cell phone location without a warrant. It's the most important privacy case in a generation."
+  },
+  {
+    "url": "https://www.cnet.com/news/lyft-will-offer-discounted-rides-to-voters-during-midterm-elections/",
+    "title": "Lyft will offer discounted rides to voters during US midterm elections. Voters in underserved communities will get free rides."
+  },
+  {
+    "url": "https://act.represent.us/sign/Net_neutrality_lobbying_Comcast_Verizon/",
+    "title": "Comcast, Verizon, and AT&T have spent $572 MILLION on lobbying the government to kill net neutrality"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/12/ajit-pai-claims-net-neutrality-hurt-small-isps-but-data-says-otherwise/",
+    "title": "Ajit Pai claims net neutrality hurt small ISPs, but data says otherwise."
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/03/today-senators-will-vote-allow-isps-sell-internet-history-end-fcc-online-privacy-rules/",
+    "title": "Today, Senators will vote to allow ISPs to sell your internet history and end FCC online privacy rules"
+  },
+  {
+    "url": "https://www.thenation.com/article/if-trumps-fcc-repeals-net-neutrality-elites-will-rule-the-internet-and-the-future/",
+    "title": "If Trump’s FCC Repeals Net Neutrality, Elites Will Rule the Internet—and the Future"
+  },
+  {
+    "url": "https://www.nytimes.com/2018/02/15/technology/fcc-sinclair-ajit-pai.html?smid=tw-share",
+    "title": "Ajit Pai Being Investigated for Improper Coordination With Sinclair Broadcasting"
+  },
+  {
+    "url": "http://cnbc.com/id/105437071",
+    "title": "Twitter permanently bans Alex Jones and Infowars accounts"
+  },
+  {
+    "url": "https://www.buzzfeednews.com/article/kevincollier/feds-investigation-net-neutrality-comments",
+    "title": "The Feds Are Now Investigating The Millions Of Anti-Net Neutrality Comments Filed With Stolen Identities"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/at-t-paid-200-000-to-trumps-attorney-michael-cohen-and-the-payments-stop-right-after-trump-s-3356687f4827",
+    "title": "AT&T paid $200,000 to Trump’s attorney, Michael Cohen, and the payments stop right after Trump’s FCC pick Ajit Pai repealed net neutrality"
+  },
+  {
+    "url": "http://www.slate.com/blogs/future_tense/2017/11/28/comcast_wants_you_to_think_it_supports_net_neutrality_while_it_pushes_for.html",
+    "title": "Comcast Wants You to Think It Supports Net Neutrality While It Pushes for Net Neutrality to Be Destroyed"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/26-Senators-Support-CRA-Reversal-of-FCC-Attack-on-Net-Neutrality-140933",
+    "title": "26 Senators Support CRA Reversal of FCC Attack on Net Neutrality: an uphill effort to reverse the FCC's repeal via the Congressional Review Act (CRA) is gaining steam."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/wj3gx5/house-democrats-who-havent-supported-net-neutrality-yet-have-all-taken-money-from-telecoms",
+    "title": "House Democrats Who Haven’t Supported Net Neutrality Yet Have All Taken Money from Telecoms - The deadline to pass the piece of legislation that would allow Congress to overturn the repeal of net neutrality is quickly approaching, yet many Democrats are staying mum."
+  },
+  {
+    "url": "https://gizmodo.com/leaked-video-shows-fcc-chair-ajit-pai-roasting-himself-1821134881",
+    "title": "Leaked Video Shows FCC Chair Ajit Pai Roasting Himself With 'Jokes' About Being a Verizon Shill"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/ATT-Met-With-Ajit-Pai-in-Barcelona-Shortly-After-Cohen-Payment-141844",
+    "title": "AT&T Met With Ajit Pai in Barcelona Shortly After Cohen Payment"
+  },
+  {
+    "url": "http://news.sky.com/story/mps-formally-request-zuckerberg-answer-questions-11297936",
+    "title": "Mark Zuckerberg has been sent a formal request to appear before MPs and answer questions regarding a growing scandal about user data"
+  },
+  {
+    "url": "https://www.windowscentral.com/microsoft-please-stop-trying-install-third-party-apps-my-clean-windows-10-install",
+    "title": "Hey, Microsoft, stop installing third-party apps on clean Windows 10 installs!"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/02/12/update-mozilla-will-re-file-suit-fcc-protect-net-neutrality/",
+    "title": "Update: Mozilla Will Re-File Suit Against FCC to Protect Net Neutrality"
+  },
+  {
+    "url": "http://www.thesocialmemo.org/2015/07/reddit-ceo-ellen-pao-vast-majority-of.html",
+    "title": "Reddit CEO Ellen Pao: \"The Vast Majority of Reddit Users are Uninterested in\" Victoria Taylor, Subreddits Going Private"
+  },
+  {
+    "url": "https://techcrunch.com/2018/05/23/representatives-rip-fcc-chairman-pais-lack-of-candor-and-double-down-on-net-neutrality-questions/",
+    "title": "13 Congress members tell Pai to stop giving evasive answers about net neutrality"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2019/jan/01/amazon-fulfillment-center-warehouse-employees-union-new-york-minnesota",
+    "title": "'We are not robots': Amazon warehouse employees push to unionize"
+  },
+  {
+    "url": "https://gizmodo.com/gop-data-firm-accidentally-leaks-personal-details-of-ne-1796211612",
+    "title": "GOP Data Firm Accidentally Leaks Personal Details of Nearly 200 Million American Voters"
+  },
+  {
+    "url": "https://thenextweb.com/opinion/2018/06/11/rip-net-neutrality-ajit-pais-fuck-you-to-the-american-people-becomes-official/",
+    "title": "RIP net neutrality: Ajit Pai's 'fuck you' to the American people becomes official."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/12/comcast-rejected-by-small-town-residents-vote-for-municipal-fiber-instead/",
+    "title": "Comcast rejected by small town—residents vote for municipal fiber instead"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180605/07420739969/e-mails-show-fcc-made-up-ddos-attack-to-downplay-john-oliver-effect.shtml",
+    "title": "E-Mails Show FCC Made Up DDOS Attack To Downplay The 'John Oliver Effect'"
+  },
+  {
+    "url": "https://www.nbcnews.com/technology/exclusive-your-employer-may-share-your-salary-equifax-might-sell-1B8173066",
+    "title": "Equifax sells your salary history to debt collectors, financial service companies, and prospective employers"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/43a5kg/80-percent-net-neutrality-comments-bots-astroturfing",
+    "title": "More Than 80% Of All Net Neutrality Comments Were Sent By Bots, Researchers Say - 95% of all organic comments favored net neutrality"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/03/17-house-representatives-introduced-bill-let-telecoms-sell-personal-internet-history/",
+    "title": "These are the 17 House Representatives that introduced a bill to let telecoms sell your personal internet history"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/the-fcc-is-preparing-to-weaken-the-definition-of-broadband-140987",
+    "title": "The FCC is preparing to weaken the definition of broadband - \"Under this new proposal, any area able to obtain wireless speeds of at least 10 Mbps down, 1 Mbps would be deemed good enough for American consumers.\""
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2017-11-15/killing-net-neutrality-rules-is-said-readied-for-december-vote",
+    "title": "FCC Plans December Vote to Kill Net Neutrality Rules"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/documents-show-ajit-pai-met-with-at-t-execs-right-after-the-company-started-paying-michael-cohen-6d5f0eac0557",
+    "title": "Documents show Ajit Pai met with AT&T execs right after the company started paying Michael Cohen. Congress needs to overturn the FCC’s net neutrality repeal and investigate."
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/this-is-kind-of-a-big-deal-c23def03f0f8",
+    "title": "This is kind of a big deal. Two Senators, one Republican and one Democrat, who were impersonated during net neutrality repeal, call on FCC to investigate millions of fake comments"
+  },
+  {
+    "url": "http://www.businessinsider.com/intel-ceo-krzanich-sold-shares-after-company-was-informed-of-chip-flaw-2018-1",
+    "title": "Intel was aware of the chip vulnerability when its CEO sold off $24 million in company stock"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2018/05/08/equifax_breach_may_2018/",
+    "title": "Equifax reveals full horror of its data breach - \"146.6 million names, 146.6 million dates of birth, 145.5 million social security numbers, 99 million address information and 209,000 payment cards (number and expiry date). There were also 38,000 US drivers' licenses and 3,200 passport details.\""
+  },
+  {
+    "url": "https://www.engadget.com/2017/12/15/fcc-harlem-shake-video-fair-use/",
+    "title": "The FCC's 'Harlem Shake' video may violate copyright law -- The agency apparently didn't get permission to use the song"
+  },
+  {
+    "url": "http://mashable.com/2017/11/02/facebook-phony-accounts-admission/?utm_campaign=Feed%3A+Mashable+%28Mashable%29&utm_cid=Mash-Prod-RSS-Feedburner-All-Partial&utm_source=feedburner&utm_medium=feed",
+    "title": "Facebook admits to nearly as many fake or clone accounts as the U.S. population"
+  },
+  {
+    "url": "https://www.theverge.com/2017/3/29/15100620/congress-fcc-isp-web-browsing-privacy-fire-sale?platform=hootsuite",
+    "title": "The 265 members of Congress who sold you out to ISPs"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2018/12/20/facebook_disaster/",
+    "title": "Mark Zuckerberg did everything in his power to avoid Facebook becoming the next MySpace – but forgot one crucial detail… No one likes a lying asshole"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Lawmaker-Disturbed-That-FCC-Made-up-DDOS-Lied-to-Press-141963",
+    "title": "Lawmaker 'Disturbed' That FCC Made up DDOS, Lied to Press"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/reddit-its-friday-5d3811f1a6a8",
+    "title": "It’s Friday. The FCC just announced that the repeal of net neutrality will officially go into effect in one month unless Congress stops it. The Senate will vote on Wednesday. We have a job to do."
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/GOP-Busted-Using-Cable-Lobbyist-Net-Neutrality-Talking-Points-139647",
+    "title": "GOP Busted Using Cable Lobbyist Net Neutrality Talking Points: email from GOP leadership... included a \"toolkit\" (pdf) of misleading or outright false talking points that, among other things, attempted to portray net neutrality as \"anti-consumer.\""
+  },
+  {
+    "url": "https://gizmodo.com/a-new-senate-bill-would-hit-robocallers-with-a-10-000-1830502632?rev=1542409291860&utm_campaign=socialflow_gizmodo_twitter&utm_source=gizmodo_twitter&utm_medium=socialflow",
+    "title": "A New Senate Bill Would Hit Robocallers With Up to a $10,000 Fine for Every Call"
+  },
+  {
+    "url": "https://www.theverge.com/2017/5/10/15610744/anti-net-neutrality-fake-comments-identities",
+    "title": "Fake anti-net neutrality comments were sent to the FCC using names and addresses of people without their consent"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2017/12/12/warning-against-abdication-duty-senators-demand-fcc-abandon-net-neutrality-vote",
+    "title": "Warning Against Abdication of Duty, Senators Demand FCC Abandon Net Neutrality Vote: Ajit Pai's plan would leave the U.S. with a \"gaping consumer protection void,\" say 39 senators"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2017/03/congress-debates-reversing-course-decades-consumer-privacy-protections?link_id=8&can_id=a6c53469a0fc060cebd5a72ffb651879&source=email-vote-is-tomorrow-6&email_referrer=vote-is-tomorrow-6&email_subject=vote-is-tomorrow",
+    "title": "Tomorrow the privacy of everyone in the United States will be on the floor of the House of Representatives. Call your rep right now. Tell them to vote NO on repealing the FCC broadband privacy rules."
+  },
+  {
+    "url": "https://www.theverge.com/2018/7/10/17556144/fcc-charge-225-review-complaints",
+    "title": "The FCC wants to charge you $225 to review your complaints"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/07/lawsuit-seeks-ajit-pais-net-neutrality-talks-with-internet-providers/#p3",
+    "title": "FCC getting sued for hiding from & ignoring multiple FoIA requests"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180615/07410640047/ajit-pai-now-trying-to-pretend-that-everybody-supported-net-neutrality-repeal.shtml",
+    "title": "Ajit Pai Now Trying To Pretend That Everybody Supported Net Neutrality Repeal"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/03/minnesota-senate-votes-58-9-pass-internet-privacy-protections-response-repeal-fcc-privacy-rules/",
+    "title": "Minnesota Senate votes 58-9 to pass Internet privacy protections in response to repeal of FCC privacy rules"
+  },
+  {
+    "url": "http://www.bbc.co.uk/news/science-environment-42969020",
+    "title": "Elon Musk's Falcon Heavy rocket launches successfully"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/remember-that-california-democrat-who-helped-at-t-eviscerate-a-net-neutrality-bill-there-e02636427958",
+    "title": "Remember that California Democrat who helped AT&T eviscerate a net neutrality bill? We’re gonna put up a billboard in his district"
+  },
+  {
+    "url": "http://thehill.com/policy/technology/376844-washington-becomes-first-state-to-pass-net-neutrality-law-after-fcc-repeal",
+    "title": "Washington becomes first state to pass net neutrality law after FCC repeal - “All Washingtonians should enjoy equal and unfettered access to the educational, social and economic power of the Internet. I’m proud that we're helping lead the way to preserve these rules, ensuring a level playing field.”"
+  },
+  {
+    "url": "https://www.forbes.com/sites/jaymcgregor/2017/02/20/reddit-is-being-manipulated-by-big-financial-services-companies/#4739b1054c92",
+    "title": "Reddit is being regularly manipulated by large financial services companies with fake accounts and fake upvotes via seemingly ordinary internet marketing agencies. -Forbes"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2017/06/dont-be-fooled-comcast-pr-machine-it-has-always-opposed-open-internet",
+    "title": "Don't Be Fooled by the Comcast PR Machine: It Has Always Opposed Internet Freedom"
+  },
+  {
+    "url": "http://www.iicom.org/events/telecommunications-and-media-forum/item/tmf-washington-2017",
+    "title": "FCC Chair Pai who is carrying out Verizon's plan to end net neutrality is speaking at Verizon headquarters tomorrow."
+  },
+  {
+    "url": "http://www.bloomberg.com/news/articles/2015-07-10/ellen-pao-resigns-as-reddit-interim-ceo-after-user-revolt",
+    "title": "Ellen Pao Resigns as Reddit Interim CEO After User Revolt"
+  },
+  {
+    "url": "https://news.vice.com/en_us/article/xw9n3q/we-posed-as-100-senators-to-run-ads-on-facebook-facebook-approved-all-of-them",
+    "title": "We posed as 100 Senators to run ads on Facebook. Facebook approved all of them."
+  },
+  {
+    "url": "http://www.engadget.com/2015/02/26/fcc-net-neutrality/",
+    "title": "FCC approves net neutrality rules, reclassifies broadband as a utility"
+  },
+  {
+    "url": "http://forums.xfinity.com/t5/Customer-Service/Are-you-aware-Comcast-is-injecting-400-lines-of-JavaScript-into/td-p/3009551",
+    "title": "Are you aware? Comcast is injecting 400+ lines of JavaScript into web pages."
+  },
+  {
+    "url": "http://www.businessinsider.com/senate-democrats-are-forcing-a-vote-on-net-neutrality-2018-1?r=US&IR=T",
+    "title": "Senate Democrats have made a brilliant move to try and save an open internet. They only need a simple majority to win this vote. While that's a long shot, there's still a good reason for them to force a vote: It will force Republican senators to take a public stand on this hot-button issue."
+  },
+  {
+    "url": "http://www.bloomberg.com/news/articles/2015-07-04/reddit-restores-most-of-site-after-moderator-led-blackouts",
+    "title": "Reddit CEO Pao Under Fire as Users Protest Removal of Executive"
+  },
+  {
+    "url": "https://medium.com/@ainiesta/how-instagram-closed-my-account-and-gave-it-to-a-football-celebrity-625a6a770eb3",
+    "title": "How Instagram closed my account and gave it to a football celebrity"
+  },
+  {
+    "url": "http://www.pcgamer.com/verizon-vp-jokes-at-planting-a-brainwashed-fcc-chairman-ajit-pai-says-awesome/",
+    "title": "Verizon VP jokes at planting a 'brainwashed' FCC chairman, Ajit Pai says 'awesome'"
+  },
+  {
+    "url": "https://www.politico.com/story/2017/11/20/net-neutrality-repeal-fcc-251824",
+    "title": "FCC to seek total repeal of net neutrality rules, sources say"
+  },
+  {
+    "url": "https://news.cgtn.com/news/7a49444d34557a6333566d54/share_p.html",
+    "title": "Does the world really need a new iPhone every year?Apple and other tech firms have been criticized for deliberately making products with short life spans so consumers quickly find them obsolete and resort to buying the latest model."
+  },
+  {
+    "url": "https://www.dailykos.com/stories/2018/2/23/1744321/-Say-goodnight-to-net-neutrality-as-AT-T-just-rolled-out-internet-fast-lanes",
+    "title": "Say goodnight to net neutrality as AT&T just rolled out 'internet fast lanes'"
+  },
+  {
+    "url": "https://gizmodo.com/europes-gdpr-is-killing-email-marketing-to-the-disappo-1826880645",
+    "title": "Europe's GDPR is Killing Email Marketing, to the Disappointment of No One"
+  },
+  {
+    "url": "https://www.digitalmusicnews.com/2018/03/07/comcast-xfinity-paypal-net-neutrality/",
+    "title": "Comcast Found ‘Accidentally’ Blocking Legitimate Sites — Including PayPal and Steam"
+  },
+  {
+    "url": "http://www.androidauthority.com/fcc-pai-cherry-picking-data-repeal-net-neutrality-803801/",
+    "title": "FCC Chairman Ajit Pai accused of cherry-picking data to repeal net neutrality"
+  },
+  {
+    "url": "https://thenextweb.com/facebook/2018/02/01/i-salute-the-1-million-north-americans-who-ditched-facebook-last-quarter/",
+    "title": "I salute the 1 million North Americans who ditched Facebook last quarter"
+  },
+  {
+    "url": "https://thenextweb.com/gadgets/2017/08/31/stop-trying-to-kill-the-headphone-jack/#.tnw_gg3ed6Xc",
+    "title": "Stop trying to kill the headphone jack"
+  },
+  {
+    "url": "https://www.vox.com/2018/4/10/17220290/mark-zuckerberg-apologize-testimony",
+    "title": "Mark Zuckerberg has been apologizing for reckless privacy violations since he was a freshman - Enough is enough."
+  },
+  {
+    "url": "https://www.forbes.com/sites/thomasbrewster/2019/01/14/feds-cant-force-you-to-unlock-your-iphone-with-finger-or-face-judge-rules/",
+    "title": "Feds Can't Force You To Unlock Your iPhone With Finger Or Face, Judge Rules"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/05/9-senators-proposed-bill-kill-net-neutrality-called-restoring-internet-freedom-act/",
+    "title": "These 9 Senators proposed a bill to kill net neutrality called the \"Restoring Internet Freedom Act\""
+  },
+  {
+    "url": "http://www.foxbusiness.com/features/2017/07/24/amazon-jacked-up-prime-day-prices-misleading-consumers-says-vendor.html",
+    "title": "Amazon jacked up Prime Day prices, misleading consumers, says vendor. We had an agreement that the suggested price of the product would be $9.99. On Amazon Prime Day the product was listed at $15.42 and then exed it out to put '$9.99 for Amazon Prime Day.'"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170620/10455137631/supreme-court-says-you-cant-ban-people-internet-no-matter-what-theyve-done.shtml",
+    "title": "Supreme Court Says You Can't Ban People From The Internet, No Matter What They've Done"
+  },
+  {
+    "url": "https://www.fightforthefuture.org/news/2017-11-24-breaking-first-republican-lawmaker-to-publicly/",
+    "title": "First Republican lawmaker to publicly oppose the FCC’s radical net neutrality repeal"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/wjkmbn/verizon-firefighters-join-fight-restore-net-neutrality",
+    "title": "Pissed Off by Verizon, Firefighters Join the Fight to Restore Net Neutrality - First responders join a chorus of angry Americans tired of big telecom’s nonsense."
+  },
+  {
+    "url": "http://www.dailydot.com/politics/anti-net-neutrality-op-eds-time-wall-street-journal/",
+    "title": "Columnists in the Wall Street Journal and TIME are publishing anti-Net Neutrality op-eds without disclosing that they're taking money from ISP's"
+  },
+  {
+    "url": "https://torrentfreak.com/fox-stole-a-game-clip-used-it-in-family-guy-dmcad-the-original-160520/",
+    "title": "Fox dowloaded a game clip from YouTube, used it in Family Guy and DCMA'd the original."
+  },
+  {
+    "url": "https://www.wired.com/story/a-new-bill-wants-jail-time-for-execs-who-hide-data-breaches/",
+    "title": "A New Bill Wants Jail Time for Execs Who Hide Data Breaches"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/it-begins-trumps-fcc-launches-attack-on-net-neutrality-transparency-rules",
+    "title": "It Begins: Trump’s FCC Launches Attack on Net Neutrality Transparency Rules"
+  },
+  {
+    "url": "https://gizmodo.com/last-minute-push-to-restore-net-neutrality-stymied-by-d-1831023390",
+    "title": "Last-Minute Push to Restore Net Neutrality Stymied by Democrats Flush With Telecom Cash."
+  },
+  {
+    "url": "https://arstechnica.com/gaming/2018/03/how-a-norwegian-comment-section-turned-chaos-into-order-with-a-simple-quiz/",
+    "title": "How a Norwegian comment section turned chaos into order—with a simple quiz: \"Readers had to prove they read a story before they were able to comment on it.\""
+  },
+  {
+    "url": "http://komonews.com/news/local/washington-state-to-sue-comcast-for-100m",
+    "title": "Washington state to sue Comcast for $100M. A news release says the lawsuit accuses Comcast of \"engaging in a pattern of deceptive practices.\""
+  },
+  {
+    "url": "http://wesa.fm/post/pai-pai-stop-lies-pittsburghers-protest-suppport-net-neutrality#stream/0",
+    "title": "“Pai, Pai, Stop the Lies,\" Pittsburghers Protest In Suppport Of Net Neutrality"
+  },
+  {
+    "url": "https://www.dslreports.com/shownews/80-Cut-the-Cord-Because-Cable-TV-is-Simply-Too-Expensive-139758",
+    "title": "80% Cut the Cord Because Cable TV is Simply Too Expensive"
+  },
+  {
+    "url": "https://marketingland.com/study-telecoms-have-been-throttling-youtube-and-netflix-since-demise-of-net-neutrality-247346",
+    "title": "Study: Telecoms have been throttling YouTube and Netflix since demise of net neutrality"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/01/gop-senator-says-shell-vote-to-restore-net-neutrality-rules/",
+    "title": "GOP senator says she’ll vote to restore net neutrality rules"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/zmqmkw/comcast-net-neutrality-investment-tax-cut",
+    "title": "Comcast announced it's spending $10 billion annually on infrastructure upgrades, which is the same amount it spent before net neutrality repeal."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/11/voters-reject-cable-lobby-misinformation-campaign-against-muni-broadband/",
+    "title": "Sorry, Comcast: Voters say “yes” to city-run broadband in Colorado"
+  },
+  {
+    "url": "https://techcrunch.com/2016/10/03/amazon-bans-incentivized-reviews-tied-to-free-or-discounted-products/",
+    "title": "Amazon bans incentivized reviews tied to free or discounted products"
+  },
+  {
+    "url": "https://statescoop.com/dozens-of-mayors-sign-letter-supporting-resolution-to-restore-net-neutrality",
+    "title": "Dozens of mayors sign letter supporting resolution to restore net neutrality"
+  },
+  {
+    "url": "https://www.washingtonpost.com/politics/ivanka-trump-used-a-personal-email-account-to-send-hundreds-of-emails-about-government-business-last-year/2018/11/19/6515d1e0-e7a1-11e8-a939-9469f1166f9d_story.html",
+    "title": "Ivanka Trump used a personal email account to send hundreds of emails about government business last year"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/7xwknx/republican-members-of-congress-fcc-letter",
+    "title": "Here's a List of the Members of Congress Who Just Told Ajit Pai to Repeal Net Neutrality - And how much money they've taken from the telecom industry."
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/2018/08/25/verizon-and-t-worst-offenders-throttling-but-we-have-some-solutions/1089132002/",
+    "title": "Verizon, instead of apologizing, we have a better idea --stop throttling"
+  },
+  {
+    "url": "https://www.dslreports.com/shownews/New-Bill-Would-Stop-States-From-Banning-Broadband-Competition-141088",
+    "title": "New Bill Would Stop States From Banning Broadband Competition"
+  },
+  {
+    "url": "https://timesofindia.indiatimes.com/business/india-business/internet-to-remain-free-and-fair-in-india-govt-approves-net-neutrality/articleshow/64948838.cms?from=mdr",
+    "title": "Internet to remain free and fair in India: Govt approves Net Neutrality"
+  },
+  {
+    "url": "http://www.telegraph.co.uk/technology/2016/03/24/microsofts-teen-girl-ai-turns-into-a-hitler-loving-sex-robot-wit/",
+    "title": "Microsoft's 'teen girl' AI, Tay, turns into a Hitler-loving sex robot within 24 hours"
+  },
+  {
+    "url": "http://exstreamist.com/netflix-has-almost-4x-as-many-streaming-subscribers-as-comcast-has-cable-subscribers/",
+    "title": "Netflix Has Almost 4x as Many Streaming Subscribers as Comcast has Cable Subscribers"
+  },
+  {
+    "url": "https://www.fightforthefuture.org/news/2018-09-28-facebook-caught-automatically-blocking-ap-and/",
+    "title": "Facebook caught automatically blocking AP and Guardian stories about the their massive data breach"
+  },
+  {
+    "url": "https://gizmodo.com/do-not-i-repeat-do-not-download-onavo-facebook-s-vam-1822937825",
+    "title": "Do Not, I Repeat, Do Not Download Onavo, Facebook’s Vampiric VPN Service"
+  },
+  {
+    "url": "https://www.fightforthefuture.org/news/2016-10-06-yahoo-let-the-nsa-read-your-email-before-you-even/",
+    "title": "Yahoo let the NSA read your email before you even opened it. Yahoo was just revealed to be the very first US internet company to build a program, at the request of US Intelligence Services, to search every single incoming message of every single user in real time."
+  },
+  {
+    "url": "https://www.inverse.com/article/39671-in-the-wake-of-net-neutrality-prepare-for-internet-fast-lanes",
+    "title": "With Net Neutrality Dead, Proposed Bill Promises Internet \"Fast Lanes\" - It’s pay to browse fast in the post-net neutrality age."
+  },
+  {
+    "url": "https://www.extremetech.com/internet/283522-att-plans-to-fire-7000-people-despite-tax-breaks-net-neutrality-repeal",
+    "title": "AT&T plans to fire 7000 people despite tax breaks/net neutrality repeal"
+  },
+  {
+    "url": "https://medium.com/@Laila/here-are-the-256-representatives-that-just-voted-to-reauthorize-and-expand-unconstitutional-nsa-b5b9cceedcb3",
+    "title": "Here are the 256 representatives that just voted to reauthorize and expand unconstitutional NSA spying"
+  },
+  {
+    "url": "https://www.wired.com/story/san-francisco-municipal-fiber/amp",
+    "title": "San Francisco just took a huge step towards internet utopia, becoming the first major city to pledge to connect all homes and businesses to a fiber optic network"
+  },
+  {
+    "url": "https://www.independent.co.uk/life-style/gadgets-and-tech/news/facebook-mark-zuckerberg-quit-investor-scott-stringer-a8286451.html",
+    "title": "Billion-Dollar Facebook Investor Tells Mark Zuckerberg To Quit As Chairman"
+  },
+  {
+    "url": "http://www.theverge.com/2014/11/10/7185933/fcc-should-reclassify-internet-as-utility-obama-says",
+    "title": "Obama says FCC should reclassify internet as a utility"
+  },
+  {
+    "url": "https://qz.com/1501696/facebook-owns-instagram-and-whatsapp-so-delete-them-too/",
+    "title": "You’re not quitting Facebook if you still use Instagram and WhatsApp"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/11/02/real-teeth-senators-bill-would-punish-ceos-20-years-jail-violating-consumer-privacy",
+    "title": "'Real Teeth': Senator's Bill Would Punish CEOs With Up to 20 Years in Jail for Violating Consumer Privacy Rules"
+  },
+  {
+    "url": "https://www.nytimes.com/2017/04/17/business/dealbook/steve-ballmer-serves-up-a-fascinating-data-trove.html?referer=",
+    "title": "Steve Ballmer Serves Up a Fascinating Data Trove - \"On Tuesday, Mr. Ballmer plans to make public... a stealth start-up... called USAFacts. The database is perhaps the first nonpartisan effort to create a fully integrated look at revenue and spending across federal, state and local governments.\""
+  },
+  {
+    "url": "https://torrentfreak.com/ip-address-is-not-enough-to-identify-pirate-us-court-of-appeals-rules-180828/",
+    "title": "IP Address is Not Enough to Identify Pirate, US Court of Appeals Rules"
+  },
+  {
+    "url": "http://www.businessinsider.com/att-gigapower-tackles-google-fiber-in-kansas-city--but-its-charging-more-for-privacy-2015-2",
+    "title": "AT&T is charging customers an extra $29 a month if they want to opt out of the company’s “Internet Preferences” program, which tracks “the webpages you visit, the time you spend on each, the links or ads you see and follow, and the search terms you enter.”"
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/the-switch/wp/2018/01/15/the-senates-push-to-overrule-the-fcc-on-net-neutrality-now-has-50-votes-democrats-say/?utm_term=.6f21047b421a",
+    "title": "The Senate’s push to overrule the FCC on net neutrality now has 50 votes"
+  },
+  {
+    "url": "http://www.bbc.com/news/technology-41760968",
+    "title": "Nazi forums closed as Reddit purges 'violent content' - Reddit has closed down several extremist forums after updating its policy regarding violent content."
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/The-FCC-is-Lying-When-It-Claims-Net-Neutrality-Hurt-Investment-140782",
+    "title": "The FCC is Lying When It Claims Net Neutrality Hurt Investment"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-usa-internet/twenty-two-states-ask-u-s-appeals-court-to-reinstate-net-neutrality-rules-idUSKCN1L605W",
+    "title": "Twenty-two states ask U.S. appeals court to reinstate 'net neutrality' rules"
+  },
+  {
+    "url": "https://gizmodo.com/senators-demand-fcc-answer-for-fake-comments-after-real-1826213294",
+    "title": "Senators demand FCC answer for fake comments after realizing their identities were stolen."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/11/comcast-forced-to-pay-refunds-after-its-hidden-fees-hurt-customers-credit/",
+    "title": "Comcast forced to pay refunds after its hidden fees hurt customers’ credit"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2017-10-30/record-winds-in-germany-spur-free-electricity-at-weekend-chart",
+    "title": "There Was So Much Wind Power In Germany This Weekend, Consumers Got Free Energy - Power prices turned negative as wind output reached 39,409 megawatts on Saturday, equivalent to the output of about 40 nuclear reactors."
+  },
+  {
+    "url": "https://www.theverge.com/2018/7/26/17615634/amazon-rekognition-aclu-mug-shot-congress-facial-recognition",
+    "title": "Amazon’s facial recognition matched 28 members of Congress to criminal mugshots"
+  },
+  {
+    "url": "http://uk.businessinsider.com/amazon-warehouse-workers-have-to-pee-into-bottles-2018-4",
+    "title": "Amazon warehouse workers pee into bottles because they are scared of being punished for taking a comfort break"
+  },
+  {
+    "url": "https://gizmodo.com/fcc-commissioner-blasts-her-own-agency-for-withhold-evi-1821133018",
+    "title": "FCC Commissioner Blasts Her Own Agency for Withholding Evidence of Fraud"
+  },
+  {
+    "url": "https://arstechnica.com/information-technology/2018/03/facebook-scraped-call-text-message-data-for-years-from-android-phones/",
+    "title": "Facebook scraped call, text message data for years from Android phones."
+  },
+  {
+    "url": "http://arstechnica.com/gadgets/2015/07/google-officially-ends-forced-google-integration-first-up-youtube/",
+    "title": "Google officially ends forced Google+ integration on YouTube"
+  },
+  {
+    "url": "https://www.commondreams.org/views/2017/11/19/fake-news-only-beginning-fcc-votes-let-monopolies-decide-what-local-news-you-see",
+    "title": "Fake News Is Only the Beginning. The FCC Votes to Let Monopolies Decide What Local News You See"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/04/congresswoman-rosen-introduces-restoring-american-privacy-act-2017-reverse-s-j-res-34/",
+    "title": "Congresswoman Rosen introduces Restoring American Privacy Act of 2017 to reverse S.J. Res. 34"
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/the-switch/wp/2017/11/16/the-fcc-just-repealed-decades-old-rules-blocking-broadcast-media-mergers/?utm_term=.0ed42f1a0d8e",
+    "title": "The FCC just repealed a 42-year-old rule blocking broadcast media mergers"
+  },
+  {
+    "url": "https://money.cnn.com/2018/08/04/news/companies/wells-fargo-mortgage-modification/index.html",
+    "title": "Wells Fargo says hundreds of customers lost homes after computer glitch; Hundreds of people had their homes foreclosed on after software used by Wells Fargo incorrectly denied them mortgage modifications"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/04/dont-like-privacy-violations-dont-use-the-internet-gop-lawmaker-says/",
+    "title": "Why one Republican voted to kill privacy rules: “Nobody has to use the Internet”"
+  },
+  {
+    "url": "https://gizmodo.com/amazon-workers-demand-jeff-bezos-cancel-face-recognitio-1827037509",
+    "title": "Amazon Workers Demand Jeff Bezos Cancel Face Recognition Contracts With Law Enforcement"
+  },
+  {
+    "url": "https://electrek.co/2017/02/12/tesla-crash-dead-drunk-driver/",
+    "title": "Tesla crash: father of dead driver blames Tesla’s ‘rocketship-like’ acceleration for his daughter’s death - \"the police revealed that both Speckman and McCarthy were intoxicated at the time of the accident.\""
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/12/att-says-it-never-blocked-apps-fails-to-mention-how-it-blocked-facetime/",
+    "title": "AT&T says it never blocked apps, fails to mention how it blocked FaceTime."
+  },
+  {
+    "url": "http://mashable.com/2016/09/01/reliance-jio-launch-tariff-plans-india/",
+    "title": "India's richest man launches 4G LTE network in the country, offers unlimited free voice calls, cheapest data in the world"
+  },
+  {
+    "url": "https://theoutline.com/post/2558/death-of-the-internet-net-neutrality-donald-trump-alt-right-gamergate-facebook-twitter",
+    "title": "The death of the internet: If we lose this, we lose everything. | The Outline"
+  },
+  {
+    "url": "https://www.reddit.com/r/KeepOurNetFree/comments/7jdsev/ajit_pai_has_personal_financial_interests_in/",
+    "title": "Ajit Pai has personal financial interests in ending net neutrality"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Big-ISPs-Spent-1-Million-Attacking-Colorado-Community-Broadband-140849",
+    "title": "Big ISPs Spent $1 Million Attacking Colorado Community Broadband - “ISPs like Comcast and CenturyLink spent nearly $1 million dollars trying to prevent one Colorado community from even discussing creative, community-driven solutions to the broadband competition problem.”"
+  },
+  {
+    "url": "https://techcrunch.com/2016/08/23/good-riddance/",
+    "title": "Google will soon start punishing mobile sites that show hard-to-dismiss popups"
+  },
+  {
+    "url": "https://arstechnica.com/?post_type=post&p=1429891",
+    "title": "Man sues feds after being detained for refusing to unlock his phone at airport"
+  },
+  {
+    "url": "https://tech.slashdot.org/story/17/11/23/149208/cloudflare-might-be-exploring-a-way-to-slow-down-fcc-chairman-ajit-pais-home-internet-speeds",
+    "title": "Cloudflare Might Be Exploring a Way To Slow Down FCC Chairman Ajit Pai's Home Internet Speeds"
+  },
+  {
+    "url": "http://www.theverge.com/ces/2017/1/3/14126382/new-hp-spectre-x360-laptop-2017-announced-price-release-date-ces",
+    "title": "HP made a laptop slightly thicker to add 3 hours of battery life"
+  },
+  {
+    "url": "http://www.ajc.com/business/former-gov-roy-barnes-others-file-equifax-data-breach-class-action/x1byRfcdw2ABAkxpFerrBL/",
+    "title": "Lawsuit filed in Atlanta U.S. District Court faults Equifax for “gargantuan failures to secure and safeguard consumers’ personally identifiable information … and for failing to provide timely, accurate and adequate notice”"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/04/france-seizes-france-com-from-man-whos-had-it-since-94-so-he-sues/?comments=1",
+    "title": "France seizes France.com from man who’s had it since ‘94, so he sues"
+  },
+  {
+    "url": "http://thehill.com/policy/technology/364937-netflix-rips-net-neutrality-repeal-this-is-the-beginning-of-a-longer-legal",
+    "title": "Netflix rips net neutrality repeal: ‘This is the beginning of a longer legal battle’"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/01/31/google-facebook-data-privacy-concerns-out-of-control-commentary.html",
+    "title": "Google and Facebook are watching our every move online. It's time to make them stop"
+  },
+  {
+    "url": "https://www.theverge.com/2017/9/11/16290730/equifax-chatbots-ai-joshua-browder-security-breach",
+    "title": "Chatbot lets you sue Equifax for up to $25,000 without a lawyer."
+  },
+  {
+    "url": "http://www.billgeeks.com/comcast-broadcast-tv-fee/",
+    "title": "Comcast Subscribers Are Paying Up To $1.9 Billion a Year for Over-the-Air Channels They Can Get Free"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/30/18203413/robocalls-spam-text-calls-2018-analysis-hiya",
+    "title": "Robocallers blasted Americans with 26.3 billion spam calls last year - Robocalls are up 46 percent from 2017"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171205/12420338750/fcc-tried-to-hide-net-neutrality-complaints-against-isps.shtml",
+    "title": "The FCC Tried To Hide Net Neutrality Complaints Against ISPs"
+  },
+  {
+    "url": "https://www.multichannel.com/news/netflix-could-lose-8-percent-of-subscribers",
+    "title": "Netflix Loses 8% of Consumers with $1 Price Increase: Study"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/ATT-Lays-Off-Up-to-1400-Employees-Just-Before-Christmas-140923",
+    "title": "AT&T Lays Off Up to 1400 Employees Just Before Christmas"
+  },
+  {
+    "url": "https://www.politico.com/story/2018/01/01/equifax-data-breach-congress-action-319631",
+    "title": "After Equifax breach, anger but no action in Congress. The aftermath of the data breach played out like a familiar script: White-hot bipartisan outrage, then hearings and proposals that went nowhere."
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Senators-Press-Ajit-Pai-on-DDOS-Attack-His-Agency-Made-Up-141999",
+    "title": "Senators Press Ajit Pai on DDOS Attack His Agency Made Up"
+  },
+  {
+    "url": "http://www.bbc.com/news/technology-40057855",
+    "title": "Net neutrality: 'Dead people' signing FCC consultation"
+  },
+  {
+    "url": "http://www.theverge.com/2017/4/26/15439622/fcc-net-neutrality-internet-freedom-isp-ajit-pai",
+    "title": "The fight for net neutrality is officially back on"
+  },
+  {
+    "url": "https://thepiratebay.se/",
+    "title": "After being down for 51 days, the original Pirate Bay is back online."
+  },
+  {
+    "url": "https://wikileaks.org/ciav7p1/",
+    "title": "Vault 7: CIA Hacking Tools Revealed"
+  },
+  {
+    "url": "https://www.wired.com/story/fcc-retracts-a-plan-to-discourage-consumer-complaints/",
+    "title": "FCC Retracts a Plan to Discourage Consumer Complaints"
+  },
+  {
+    "url": "https://www.wired.com/story/fcc-wants-to-kill-net-neutrality-congress-will-pay-the-price/",
+    "title": "FCC Wants to Kill Net Neutrality. Congress Will Pay the Price"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/02/rancher-finds-creepy-and-un-american-spy-cam-tied-to-his-tree-sues-feds/",
+    "title": "Man removes feds’ spy cam, they demand it back, he refuses and sues"
+  },
+  {
+    "url": "https://arstechnica.com/?post_type=post&p=1423479",
+    "title": "Ajit Pai buries 2-year-old speed test data in appendix of 762-page report"
+  },
+  {
+    "url": "http://www.businessinsider.com/shareholders-mulling-suit-against-intel-over-ceos-stock-sale-2018-1",
+    "title": "'These are bad facts for him': Intel CEO's $24 million stock sale before disclosing the chip flaw could trigger lawsuits, SEC inquiry"
+  },
+  {
+    "url": "http://www.theverge.com/2016/10/19/13330158/t-mobile-unlimited-data-settlement-fine-discount-free-data?utm_campaign=theverge&utm_content=chorus&utm_medium=social&utm_source=twitter",
+    "title": "T-Mobile will pay a $48 million fine for throttling ‘unlimited data’ plans"
+  },
+  {
+    "url": "https://www.cnet.com/news/almost-half-of-us-cell-phone-calls-will-be-scams-by-next-year-says-report/",
+    "title": "Almost half of US cellphone calls will be scams by next year, says report"
+  },
+  {
+    "url": "http://regated.com/2016/09/paul-combetta-asking-destroy-evidence/",
+    "title": "Hillary Clinton IT Paul Combetta Asked How To Destroy Evidence On Reddit"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Senator-Doesnt-Buy-FCC-Justification-for-Killing-Net-Neutrality-139993",
+    "title": "Senator Doesn't Buy FCC Justification for Killing Net Neutrality"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/11/comcast-quietly-drops-promise-not-to-charge-tolls-for-internet-fast-lanes/",
+    "title": "Comcast quietly drops promise not to charge tolls for Internet fast lanes"
+  },
+  {
+    "url": "https://www.businessinsider.com/ios-12-shortcut-uses-iphone-to-record-police-during-traffic-stop-2018-10",
+    "title": "'Siri, I'm getting pulled over': a new shortcut for iPhones can automatically record the police"
+  },
+  {
+    "url": "https://www.theage.com.au/world/north-america/new-report-shows-russia-used-every-major-social-media-tool-to-help-trump-20181217-p50mn8.html",
+    "title": "New report shows Russia used every major social media tool to help Trump."
+  },
+  {
+    "url": "http://www.ndtv.com/world-news/bose-headphones-spy-on-listeners-lawsuit-1683707",
+    "title": "Bose headphones spy on listeners and sell personally identifiable information to third parties without permission: Lawsuit"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2018-04-25/american-cities-are-fighting-big-business-over-wireless-internet-and-they-re-losing",
+    "title": "American Cities Are Fighting Big Business Over Wireless Internet, and They’re Losing: “It’s often lost on the public just how badly they’re being screwed”"
+  },
+  {
+    "url": "https://techcrunch.com/2018/10/11/pro-privacy-search-engine-duckduckgo-hits-30m-daily-searches-up-50-in-a-year/",
+    "title": "Pro-privacy search engine DuckDuckGo hits 30M daily searches, up 50% in a year"
+  },
+  {
+    "url": "https://www.phonearena.com/news/Apple-rejects-app-that-finds-net-neutrality-violations_id101750",
+    "title": "Apple has a change of heart and approves an app that finds net neutrality violations"
+  },
+  {
+    "url": "https://www.businessinsider.com/france-bans-children-using-phones-at-school-2018-9/",
+    "title": "France has banned all children under 15 from using their phones in school"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/07/californias-net-neutrality-bill-strong-again-because-you-spoke-out",
+    "title": "California's Net Neutrality Bill Is Strong Again Because You Spoke Out"
+  },
+  {
+    "url": "http://arstechnica.com/tech-policy/2017/08/dont-kill-net-neutrality-before-making-complaints-public-groups-tell-fcc/",
+    "title": "Stop hiding 47,000 net neutrality complaints, advocates tell FCC chair"
+  },
+  {
+    "url": "https://deletefacebook.com/",
+    "title": "How To Permanently Delete A Facebook Account"
+  },
+  {
+    "url": "http://consumerist.com/2014/08/10/comcast-tells-customer-the-only-reason-hes-getting-bogus-charges-refunded-is-because-he-recorded-call/",
+    "title": "Comcast Tells Customer The Only Reason He’s Getting Bogus Charges Refunded Is Because He Recorded Call"
+  },
+  {
+    "url": "https://phys.org/news/2018-06-court-danger-posed-cannons.html",
+    "title": "US court confirms danger posed by 'sound cannons'. \"The problem posed by protesters in the street did not justify the use of force, much less force capable of causing serious injury, such as hearing loss,\" the court said in its ruling."
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2018-03-20/facebook-sees-tesla-sized-chunk-vanish-from-market-cap-in-2-days",
+    "title": "Facebook Just Lost More Than Tesla's Entire Market Cap in Two Days"
+  },
+  {
+    "url": "https://betanews.com/2018/12/04/duckduckgo-study-google-search-personalization/",
+    "title": "Privacy-focused DuckDuckGo finds Google personalizes search results even for logged out and incognito users"
+  },
+  {
+    "url": "https://www.gov.ca.gov/2018/09/30/governor-brown-issues-legislative-update-22/",
+    "title": "Gov. Brown signs California Net Neutrality Bill SB 822"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/08/georgia-defends-voting-system-despite-243-percent-turnout-in-one-precinct/",
+    "title": "Georgia defends voting system despite 243-percent turnout in one precinct"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/19/18189559/google-maps-speed-limits-android-and-ios-apps",
+    "title": "Google Maps will now display speed limits for its Android and iOS apps"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/xwvg34/ajit-pai-net-neutrality-heist",
+    "title": "Yes, Net Neutrality Is Being Stolen From Us in a Fucked Up, Undemocratic Heist"
+  },
+  {
+    "url": "https://www.greentechmedia.com/articles/read/new-bipartisan-legislation-would-repeal-trump-admin-solar-tariffs",
+    "title": "New Bipartisan Legislation Would Repeal Trump’s Solar Tariffs: “I don’t know what good can possibly come as a consequence of stifling the growth of solar power.”"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/kznxde/hawaii-ballistic-missile-warning-no-testing-system",
+    "title": "Hey, Hawaii: The Telecom Industry Lobbied Against Testing for Emergency Alert System - Everyone in Hawaii received a ballistic missile threat today under a system that currently has no good testing protocols."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/05/jails-are-replacing-in-person-visits-with-video-calling-services-theyre-awful/",
+    "title": "Jails are replacing visits with video calls—inmates and families hate it"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2019/01/25/fcc_accused_of_colluding/",
+    "title": "FCC accused of colluding with Big Cable to game 5G legal challenge"
+  },
+  {
+    "url": "https://venturebeat.com/2018/04/17/chrome-66-arrives-with-autoplaying-content-blocked-by-default/",
+    "title": "Chrome 66 arrives with autoplaying content blocked by default."
+  },
+  {
+    "url": "https://customer.comcast.com/help-and-support/internet/data-usage-what-are-the-different-plans-launching?ref=1",
+    "title": "Comcast to begin charging for data usage on home internet the same way cell phone companies are charging for data"
+  },
+  {
+    "url": "https://www.theverge.com/2018/8/31/17805892/california-sb822-net-neutrality-law-vote",
+    "title": "California passes strongest net neutrality law in the country"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20181018/08242940864/streaming-exclusives-will-drive-users-back-to-piracy-industry-is-largely-oblivious.shtml",
+    "title": "Streaming Exclusives Will Drive Users Back To Piracy And The Industry Is Largely Oblivious"
+  },
+  {
+    "url": "https://consumerist.com/2016/06/22/comcast-admits-it-incorrectly-debited-1775-from-account-tells-me-to-sort-it-out-with-bank/",
+    "title": "Comcast Admits It Incorrectly Debited $1,775 From Account, Tells Me To Sort It Out With Bank"
+  },
+  {
+    "url": "https://www.xda-developers.com/android-dns-over-tls-website-privacy/",
+    "title": "Android getting \"DNS over TLS\" support to stop ISPs from knowing what websites you visit"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2018/04/30/net_neutrality_senate_democrats/",
+    "title": "Democrats need just one more senator (and then a miracle) to reverse US net neutrality death"
+  },
+  {
+    "url": "http://fortune.com/2018/01/06/google-microsoft-amazon-internet-association-net-neutrality/",
+    "title": "Google, Microsoft, and Amazon’s Trade Group Joining Net Neutrality Court Challenge"
+  },
+  {
+    "url": "http://gizmodo.com/fcc-chair-ajit-pai-cant-come-up-with-a-single-plausible-1797286906?IR=T",
+    "title": "FCC Chair Ajit Pai Can't Come Up With a Single Plausible Reason Not to Screw Up the Entire US Internet"
+  },
+  {
+    "url": "https://www.newscientist.com/article/mg24032052-900-time-to-break-academic-publishings-stranglehold-on-research/",
+    "title": "Time to break academic publishing’s stranglehold on research - Science journals are laughing all the way to the bank, locking the results of publicly funded research behind exorbitant paywalls. A campaign to make content free must succeed"
+  },
+  {
+    "url": "https://www.buzzfeednews.com/article/ryanhatesthis/reddits-largest-pro-trump-subreddit-appears-to-have-been",
+    "title": "Reddit's Largest Pro-Trump Subreddit Appears To Have Been Targeted By Russian Propaganda For Years"
+  },
+  {
+    "url": "https://techcrunch.com/2017/08/06/10-members-of-congress-rake-fcc-over-the-coals-in-official-net-neutrality-comment/",
+    "title": "10 Members of Congress rake FCC over the coals in official net neutrality comment"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170123/07582236547/google-ting-netflix-dare-to-suggest-that-maybe-giant-anti-competitive-isps-shouldnt-be-writing-state-telecom-laws.shtml",
+    "title": "Google, Ting, Netflix Dare To Suggest That Maybe Giant, Anti-Competitive ISPs Shouldn't Be Writing State Telecom Laws"
+  },
+  {
+    "url": "https://gizmodo.com/ajit-pai-is-suddenly-very-concerned-about-whether-tech-1828819118?IR=T",
+    "title": "Ajit Pai Is Suddenly Very Concerned About Whether Tech Companies Are Censoring Conservatives"
+  },
+  {
+    "url": "https://arstechnica.com/?post_type=post&p=1357875",
+    "title": "Ajit Pai loses in court—FCC can’t kill broadband subsidy in Tribal areas"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2017/06/isps-across-country-tell-chairman-pai-not-repeal-network-neutrality",
+    "title": "More than 40 ISPs Across the Country Tell Chairman Pai to Not Repeal Network Neutrality and Maintain Title II Enforcement"
+  },
+  {
+    "url": "https://supporters.eff.org/donate",
+    "title": "If the FCC succeeds in dismantling net neutrality, it’ll be up to organisations like the EFF to mount a legal challenge. Now more than ever, it’s time to donate to the EFF!"
+  },
+  {
+    "url": "http://housely.com/complaints-against-police-officers-with-body-cameras-drop-93-percent/",
+    "title": "Complaints Against Police Officers With Body Cameras Drop 93 Percent"
+  },
+  {
+    "url": "http://www.businessinsider.com/nsa-hack-apple-fbi-2016-8",
+    "title": "The NSA hack proves Apple was right to fight the FBI"
+  },
+  {
+    "url": "https://www.vanityfair.com/news/2018/03/zuckerberg-hits-users-with-the-hard-truth-you-agreed-to-this?utm_source=quora",
+    "title": "Zuckerberg Hits Users with the Hard Truth: You Agreed to This"
+  },
+  {
+    "url": "https://www.theverge.com/2017/5/24/15682240/fcc-net-neutrality-proposal-sees-few-changes",
+    "title": "2.6 million comments in, the FCC has changed almost nothing about its net neutrality proposal"
+  },
+  {
+    "url": "http://motherboard.vice.com/read/lawmakers-have-snuck-cisa-into-a-bill-that-is-guaranteed-to-become-a-law",
+    "title": "Lawmakers Have Snuck CISA Into a Bill That Is Guaranteed to Become a Law"
+  },
+  {
+    "url": "http://www.salon.com/2017/07/30/fight-for-your-right-to-fix-your-own-iphone/",
+    "title": "Fight for your right to fix your own iPhone: The \"Right-to-Repair\" movement fights corporate rules that keep you from fixing your own broken stuff"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/ISPs-Gave-8X-More-Cash-to-Politicians-That-Axed-FCC-Privacy-Rule-139377",
+    "title": "ISPs Gave 8X More Cash to Politicians That Axed FCC Privacy Rule"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/03/12/11-mayors-applauded-refusing-do-business-companies-dont-support-net-neutrality",
+    "title": "11 Mayors Applauded for Refusing to Do Business With Companies That Don't Support Net Neutrality: \"Town by town, city by city, local leaders are taking back everyone's right to connect and communicate.\""
+  },
+  {
+    "url": "http://hosted.ap.org/dynamic/stories/U/US_NET_NEUTRALITY_STAY_DENIED?SITE=AP&SECTION=HOME&TEMPLATE=DEFAULT&CTIME=2015-06-11-18-51-15",
+    "title": "Court says net neutrality rules will go into effect today: Rules that treat the Internet like a public utility and prevent companies from blocking or slowing down some online traffic will go into effect today after a federal appeals court refused to delay them"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/03/24-senators-introduced-bill-let-telecoms-sell-private-internet-history/",
+    "title": "These are the 24 Senators that introduced a bill to let telecoms sell your private internet history"
+  },
+  {
+    "url": "http://www.businessinsider.com/china-social-credit-system-punishments-and-rewards-explained-2018-4",
+    "title": "China has started ranking citizens with a creepy 'social credit' system - here's what you can do wrong, and the embarrassing, demeaning ways they can punish you"
+  },
+  {
+    "url": "https://www.vanityfair.com/news/2018/11/mark-zuckerberg-has-never-cared-about-your-privacy",
+    "title": "“He doesn’t believe in it”: Mark Zuckerberg has never cared about your privacy, and he’s not going to change."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/12/fcc-still-withholding-isps-responses-to-net-neutrality-complaints/",
+    "title": "Democrat asks why FCC is hiding ISPs’ answers to net neutrality complaints: 'FCC apparently still hasn't released thousands of documents containing the responses ISPs made to net neutrality complaints.'"
+  },
+  {
+    "url": "https://www.upi.com/Top_News/US/2018/03/06/Rhode-Island-bill-would-charge-20-fee-to-unblock-Internet-porn/8441520319464/",
+    "title": "Rhode Island bill would charge $20 fee to unblock Internet porn"
+  },
+  {
+    "url": "http://www.bbc.com/news/technology-33379571",
+    "title": "Reddit in uproar after staff sacking"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/kzvndz/trumps-cybersecurity-advisor-rudy-giuliani-thinks-his-twitter-was-hacked-because-someone-took-advantage-of-his-typo",
+    "title": "Trump’s Cybersecurity Advisor Rudy Giuliani Thinks His Twitter Was Hacked Because Someone Took Advantage of His Typo"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2016/07/fourth-amendment-caucus-defeats-patriot-act-expansion-in-congress/",
+    "title": "Fourth Amendment Caucus defeats Patriot Act expansion in Congress"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/ev5b3k/net-neutrality-fcc-zero-consumer-comments-cited",
+    "title": "The FCC Cited Zero of the 22 Million Consumer Comments in its 218-Page Net Neutrality Repeal: \"Despite the millions of comments, letters, and calls received, this Order cites, not even one consumer comment.\""
+  },
+  {
+    "url": "http://www.cnbc.com/id/102808806",
+    "title": "Calling for Reddit’s CEO to step down reaches 14,000 (now 18,000 plus)"
+  },
+  {
+    "url": "https://slate.com/news-and-politics/2018/07/facebook-says-infowars-valid-opinion-and-analysis-but-what-about-the-martian-slave-colony.html?via=recirc_recent",
+    "title": "Facebook Says InfoWars, Which Reported That NASA Has a Slave Colony on Mars, Is a Valid Source of “Opinion and Analysis”"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2016/09/police-routinely-misuse-state-federal-databases-stalk-romantic-interests-business-partners-family-even/",
+    "title": "Police routinely misuse state and federal databases to stalk romantic interests, business partners, family, and even each other"
+  },
+  {
+    "url": "https://www.scribblrs.com/google-now-penalizing-mobile-ads/",
+    "title": "Google Has Finally Started Penalizing Mobile Websites With Intrusive Pop-Up Ads"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/03/att-and-verizon-data-cap-exemptions-would-be-banned-by-california-bill/",
+    "title": "Calif. weighs toughest net neutrality law in US—with ban on paid zero-rating. Bill would recreate core FCC net neutrality rules and be tougher on zero-rating."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/12/obama-didnt-force-fcc-to-impose-net-neutrality-investigation-found/",
+    "title": "Obama didn't force FCC to impose net neutrality, investigation found"
+  },
+  {
+    "url": "http://www.independent.co.uk/environment/france-petrol-diesel-ban-vehicles-cars-2040-a7826831.html",
+    "title": "France will 'ban all petrol and diesel vehicles by 2040'"
+  },
+  {
+    "url": "http://www.truth-out.org/opinion/item/25563-should-the-internet-be-like-the-public-library",
+    "title": "Every American town should do what Rockport, Maine and Chattanooga, Tennessee have done and build a publically-owned fiber-optic network. If they can't afford to do that, the state or federal government should step in and help them finish the job, just like we did with electric power in the 1930s"
+  },
+  {
+    "url": "https://thenextweb.com/insider/2017/05/11/hp-is-shipping-audio-drivers-with-a-built-in-keylogger/",
+    "title": "HP is shipping audio drivers with a built-in keylogger"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/gyab5m/its-now-clear-none-of-the-supposed-benefits-of-killing-net-neutrality-are-real",
+    "title": "It's Now Clear None of the Supposed Benefits of Killing Net Neutrality Are Real - Network investment is down, layoffs abound, and networks are falling apart. This isn’t the glorious future Ajit Pai promised."
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/23/18193539/hulu-price-change-subscription-ads-live-tv-2019",
+    "title": "Hulu drops to just $5.99 per month after Netflix’s price hikes"
+  },
+  {
+    "url": "http://gu.com/p/4g8ab?CMP=Share_AndroidApp_reddit_is_fun",
+    "title": "Uninstalling Facebook app saves up to 20% of Android battery life"
+  },
+  {
+    "url": "http://www.washingtonpost.com/blogs/the-switch/wp/2015/06/17/att-just-got-hit-with-a-100-million-fine-after-slowing-down-its-unlimited-data/",
+    "title": "AT&T just got hit with a $100 million fine after slowing down its ‘unlimited’ data"
+  },
+  {
+    "url": "http://www.networkworld.com/article/3195466/security/fcc-should-produce-logs-to-prove-multiple-ddos-attacks-stopped-net-neutrality-comments.html",
+    "title": "FCC should produce logs to prove ‘multiple DDoS attacks’ stopped net neutrality comments"
+  },
+  {
+    "url": "http://www.extremetech.com/computing/230794-woman-wins-10000-judgment-against-microsoft-for-forced-windows-10-upgrade",
+    "title": "Woman wins $10,000 judgment against Microsoft for forced Windows 10 upgrade"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/FCC-Boss-Ajit-Pai-Annoyed-As-Neutrality-Fight-Heads-to-the-House-141860",
+    "title": "FCC Boss Ajit Pai Annoyed As Neutrality Fight Heads to the House"
+  },
+  {
+    "url": "https://unfairplay.ca/",
+    "title": "Bell and other companys are working together to try and censor the internet in Canada, here's a link to were you can find more info on what's happening and how you can help stop them"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Verizon-Apple-Continue-to-Lobby-Against-Your-Right-to-Repair-141134",
+    "title": "Verizon, Apple Continue to Lobby Against Your 'Right to Repair'"
+  },
+  {
+    "url": "https://www.inverse.com/article/39507-mesh-networks-net-neutrality-fcc",
+    "title": "Without Net Neutrality, Is It Time To Build Your Own Internet? Here's what you need to know about mesh networking."
+  },
+  {
+    "url": "http://fortune.com/2018/02/28/google-right-to-be-forgotten-europe-reasons-eu/",
+    "title": "Google says European politicians and government officials have used the \"right to be forgotten\" to delete 34000 articles about themselves from search results in Europe"
+  },
+  {
+    "url": "http://www.gospelherald.com/articles/68478/20161202/elon-musk-beats-out-mark-zuckerburg-steve-jobs-as-the-most-admired-tech-leader.htm",
+    "title": "Elon Musk Beats Out Mark Zuckerburg, Steve Jobs As The Most Admired Tech Leader"
+  },
+  {
+    "url": "http://arstechnica.com/gaming/2016/08/pokemon-go-sheds-more-than-10m-users/",
+    "title": "Pokémon Go loses its luster, sheds more than 10 million users. Engagement, downloads, and time spent in the app are fading fast."
+  },
+  {
+    "url": "http://www.alexa.com/topsites/countries/US",
+    "title": "Reddit Is Now The 4th Most Popular Site In The US"
+  },
+  {
+    "url": "https://www.techdirt.com/blog/netneutrality/articles/20170213/14460536703/comcast-att-are-paying-minority-groups-to-support-killing-net-neutrality.shtml",
+    "title": "Comcast, AT&T Are Paying Minority Groups To Support Killing Net Neutrality"
+  },
+  {
+    "url": "http://theantimedia.org/trump-mass-surveillance-privacy/amp/",
+    "title": "Trump Quietly Nominates Mass Surveillance Advocate To \"Protect\" Your Privacy Rights"
+  },
+  {
+    "url": "http://www.bbc.com/news/world-us-canada-38721056",
+    "title": "Trump pulls out of TPP trade deal"
+  },
+  {
+    "url": "http://www.timescall.com/opinion/letterstotheeditor/ci_31916956/stan-gelb-encourage-congress-restore-net-neutrality",
+    "title": "“Polls show that over 80 percent of Republicans support net neutrality, while Democrat support is even higher, because almost everyone now knows that the internet is a prime part of our constitutional right to free speech.”"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/01/15/will-ajit-pais-fcc-probe-hawaii-false-alarm-expose-role-telecom-giants-played",
+    "title": "Will Ajit Pai's FCC Probe into Hawaii False Alarm Expose Role Telecom Giants Played in Blocking Emergency System Upgrades? '...it was telecom giants, including his former employer Verizon, that played a specific and outsized role in preventing the implementation of several key safeguards.'"
+  },
+  {
+    "url": "http://fortune.com/2017/08/26/trump-cybersecurity-advisors-resign/",
+    "title": "Seven cybersecurity members resign from Trump's advisory panel citing \"insufficient attention to the growing threats\""
+  },
+  {
+    "url": "http://bgr.com/2015/11/02/comcast-vs-google-fiber-facebook-post/",
+    "title": "Comcast's attempt to bash Google Fiber on Facebook backfires hilariously as its own customers respond by hammering it with complaints"
+  },
+  {
+    "url": "http://exstreamist.com/people-arent-cancelling-netflix-because-of-price-increases-theyre-cancelling-because-the-library-is-shrinking/",
+    "title": "People Aren’t Cancelling Netflix Because of Price Increases, They’re Cancelling Because the Library is Shrinking"
+  },
+  {
+    "url": "https://www.technologyreview.com/s/607908/the-worlds-largest-wind-turbines-have-started-generating-power-in-england/",
+    "title": "The World’s Largest Wind Turbines Have Started Generating Power in England - A single revolution of a turbine’s blades can power a home for 29 hours."
+  },
+  {
+    "url": "http://www.boredpanda.com/microsoft-paint-ebook-illustrations-camp-redblood-pat-hines/",
+    "title": "Guy Sucks At Photoshop, Spends 10 Years Mastering Microsoft Paint To Illustrate His Book"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/ne9qdq/warranty-void-if-removed-stickers-illegal-ftc",
+    "title": "FTC Says 'Warranty Void If Removed' Stickers Are Bullshit, Warns Manufacturers - Federal law says you can repair your own things, and manufacturers cannot force you to use their own repair services."
+  },
+  {
+    "url": "https://futurism.com/its-official-humans-are-going-to-mars-nasa-has-unveiled-their-mission/",
+    "title": "It's official. Humans are going to Mars. NASA has unveiled their plan."
+  },
+  {
+    "url": "http://consumerist.com/2014/10/06/unhappy-customer-comcast-told-my-employer-about-complaint-got-me-fired/",
+    "title": "Unhappy Customer: Comcast told my employer about my complaint, got me fired"
+  },
+  {
+    "url": "http://www.defenseone.com/politics/2017/08/trump-cybersecurity-advisers-resign-moral-protest/140535/",
+    "title": "Trump Cybersecurity Advisers Resign In ‘Moral’ Protest"
+  },
+  {
+    "url": "https://www.revealnews.org/blog/a-judge-unsealed-a-trove-of-internal-facebook-documents-following-our-legal-action/",
+    "title": "Federal judge unseals trove of internal Facebook documents about how it made money off children"
+  },
+  {
+    "url": "https://www.theverge.com/2018/9/7/17833748/apple-just-permanently-banned-infowars-from-the-app-store",
+    "title": "Apple just permanently banned Infowars from the App Store"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/vbympa/net-neutrality-fcc-inspector-general-report",
+    "title": "Internal FCC Report Shows Republican Net Neutrality Narrative Is False"
+  },
+  {
+    "url": "https://arstechnica.com/video/2017/06/the-u-s-government-is-removing-scientific-data-from-the-internet/",
+    "title": "The US government is removing scientific data from the Internet"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2017-09-07/three-equifax-executives-sold-stock-before-revealing-cyber-hack",
+    "title": "Three Equifax Managers Sold Stock Before Cyber Hack Was Revealed"
+  },
+  {
+    "url": "http://gizmodo.com/at-t-launches-fake-5g-network-in-desperate-attempt-to-s-1794645881",
+    "title": "AT&T Launches Fake 5G Network in Desperate Attempt to Seem Innovative"
+  },
+  {
+    "url": "https://thenextweb.com/apps/2017/03/10/windows-10-is-bringing-shitty-ads-to-file-explorer-heres-how-to-turn-them-off/",
+    "title": "Windows 10 is bringing shitty ads to File Explorer, here's how to turn them off"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-usa-equifax-cfpb/exclusive-u-s-consumer-protection-official-puts-equifax-probe-on-ice-sources-idUSKBN1FP0IZ",
+    "title": "U.S. consumer protection official puts Equifax probe on ice"
+  },
+  {
+    "url": "http://www.vox.com/energy-and-environment/2017/2/7/14533618/solar-jobs-coal",
+    "title": "There are now twice as many solar jobs as coal jobs in the US"
+  },
+  {
+    "url": "http://arstechnica.com/staff/2016/11/its-time-to-get-rid-of-the-facebook-news-feed-because-its-not-news/",
+    "title": "It’s time to get rid of the Facebook “news feed,” because it’s not news"
+  },
+  {
+    "url": "http://www.theverge.com/2015/8/24/9196969/twitter-shuts-down-politwoops-diplotwoops",
+    "title": "Twitter shuts down 30 sites dedicated to saving politicians' deleted tweets"
+  },
+  {
+    "url": "https://www.thesun.co.uk/news/3672676/british-airways-boss-tries-gag-staff-it-failure/",
+    "title": "British Airways boss 'tries to gag staff' on IT meltdown which has hit 300,000 passengers after 'inexperienced staff outsourced to India didn't know to launch back up system'"
+  },
+  {
+    "url": "http://cordcutt.in/76-of-netflix-subscribers-think-netflix-can-replace-traditional-tv/",
+    "title": "76% of Netflix Subscribers Think Netflix Can Replace Traditional TV"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/09/did-russia-meddle-with-net-neutrality-comments-nyt-sues-fcc-to-find-out/",
+    "title": "NYT sues FCC, says it hid evidence of Russia meddling in net neutrality repeal"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/08/16/complete-joke-democrats-ripped-totally-failing-grill-fcc-chair-ajit-pai-over-net",
+    "title": "'Complete Joke': Democrats Ripped for Totally Failing to Grill FCC Chair Ajit Pai Over Net Neutrality Cyberattack Lies"
+  },
+  {
+    "url": "https://www.businessinsider.com/can-hackers-take-entire-countries-offline-2018-12",
+    "title": "Someone is trying to take entire countries offline and cybersecurity experts say 'it's a matter of time because it's really easy"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/08/11-representatives-21-senators-stood-fcc-regarding-net-neutrality/",
+    "title": "These are the 11 Representatives and 21 Senators that have stood up to the FCC regarding net neutrality"
+  },
+  {
+    "url": "https://www.axios.com/sean-parker-facebook-exploits-a-vulnerability-in-humans-2507917325.html",
+    "title": "Sean Parker: Facebook was designed to exploit human \"vulnerability\""
+  },
+  {
+    "url": "https://www.cnet.com/news/ticketmaster-partners-with-scalpers-to-rip-you-off-two-undercover-reporters-say",
+    "title": "Ticketmaster partners with scalpers to rip you off, two undercover reporters say. The company is reportedly helping ticket resellers violate its own terms of use."
+  },
+  {
+    "url": "https://www.theverge.com/2018/6/13/17461464/apple-update-graykey-ios-police-hacking",
+    "title": "Apple will update iOS to block police hacking tool"
+  },
+  {
+    "url": "https://www.theverge.com/2018/3/2/17071586/trump-video-game-violence-summit-esa-gun-control",
+    "title": "Video game companies unaware of Trump’s summit on video game violence - The meeting is supposed to take place next week"
+  },
+  {
+    "url": "http://money.cnn.com/2015/11/05/technology/facebook-tsu/index.html",
+    "title": "Facebook is blocking any link to Tsu.co on every platform it owns, including Messenger and Instagram. It even…deleted more than 1 million Facebook posts that ever mentioned Tsu.co…Tsu is a new social network that claims to share its advertising revenue with its users."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/ywb83y/justin-trudeau-is-very-concerned-with-fcc-plan-to-roll-back-net-neutrality-donald-trump",
+    "title": "Justin Trudeau Is ‘Very Concerned’ With FCC’s Plan to Roll Back Net Neutrality"
+  },
+  {
+    "url": "https://www.purdue.edu/newsroom/releases/2018/Q4/unlimited-data-draining-your-wallet-your-plan-costs-more-in-u.s.-than-those-in-most-developed-countries.html",
+    "title": "Americans pay more for wireless data than consumers in most other developed countries"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/kzg8yy/ajit-pai-net-neutrality-speech",
+    "title": "FCC Chair Ajit Pai Falsely Claims Killing Net Neutrality Will Help Sick and Disabled People"
+  },
+  {
+    "url": "http://gadgets.ndtv.com/internet/news/reddit-country-local-home-pages-1723573",
+    "title": "Reddit Is Testing Country-Specific Home Pages; People Across the World See Different Stories. If You Are Not a Fan of the Idea, Speak Now"
+  },
+  {
+    "url": "https://www.cbc.ca/news/thenational/complete-control-apple-accused-of-overpricing-restricting-device-repairs-1.4859099",
+    "title": "'Complete control': Apple accused of overpricing, restricting device repairs"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2017/jul/12/ajit-pai-fcc-net-neutrality-open-internet",
+    "title": "Ajit Pai: the man who could destroy the open internet - The FCC chairman leading net neutrality rollback is a former Verizon employee and whose views on regulation echo those of broadband companies"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/09/you-gave-facebook-your-number-security-they-used-it-ads",
+    "title": "You Gave Facebook Your Number For Security. They Used It For Ads."
+  },
+  {
+    "url": "https://hothardware.com/news/nvidia-tells-retailers-to-sell-to-gamers-not-cryptominers",
+    "title": "NVIDIA Tells Retailers To Sell To Gamers, Not Cryptominers As GPU Shortage Causes Extreme Price Gouging"
+  },
+  {
+    "url": "http://www.thedailybeast.com/almost-all-of-fccs-new-advisory-panel-works-for-telecoms",
+    "title": "Almost All of FCC’s New Advisory Panel Works for Telecoms"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/08/14/denouncing-wanton-disregard-congress-and-american-people-dems-call-ajit-pai-come",
+    "title": "Denouncing 'Wanton Disregard for Congress and the American People,' Dems Call on Ajit Pai to Come Clean About False FCC Cyberattack"
+  },
+  {
+    "url": "http://www.washingtontimes.com/news/2016/jul/23/twitter-users-erupt-dncleaks-disappears-from-trend/",
+    "title": "Twitter users erupt: #DNCLeaks disappears from trending news as WikiLeaks emails released"
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/nation-now/2018/07/26/facebook-mark-zuckerberg-net-worth-drops/843178002/",
+    "title": "Facebook CEO Mark Zuckerberg loses more than $15 billion in wealth in a single day"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/zmd9a5/tim-cook-to-investors-people-bought-fewer-new-iphones-because-they-repaired-their-old-ones",
+    "title": "Tim Cook to Investors: People Bought Fewer New iPhones Because They Repaired Their Old Ones - Apple finally says that repair hurts its bottom line."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/08/comcast-sues-vermont-to-avoid-building-550-miles-of-new-cable-lines/",
+    "title": "Comcast sues Vermont to avoid building 550 miles of new cable lines - Vermont is trying to make Comcast bring TV and Internet to unserved areas."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/05/california-net-neutrality-bill-that-att-hates-is-coming-to-new-york-too/",
+    "title": "California net neutrality bill that AT&T hates is coming to New York, too | Ars Technica"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2017/11/17/big_cable_fcc_net_neutrality/",
+    "title": "Big Cable's pillow talk with FCC to forbid US states from writing own net neutrality rules"
+  },
+  {
+    "url": "http://www.wired.co.uk/article/uk-broadband-speeds-fibre-to-the-home",
+    "title": "Your ISP now has to stop lying to you about broadband speeds - New rules around broadband advertising will usher in a depressing new era of honesty about the UK's cripplingly out-dated internet infrastructure"
+  },
+  {
+    "url": "https://www.fastcompany.com/40537222/washington-just-passed-the-countrys-toughest-net-neutrality-legislation",
+    "title": "Washington just passed the country’s toughest net neutrality legislation"
+  },
+  {
+    "url": "https://www.retaildetail.eu/en/news/elektronica/eu-aims-abolish-planned-obsolescence",
+    "title": "EU aims to abolish planned obsolescence"
+  },
+  {
+    "url": "https://www.engadget.com/amp/2017/09/08/uber-federal-investigation-hell-program/",
+    "title": "Uber is under federal investigation for spying on Lyft drivers."
+  },
+  {
+    "url": "https://www.commondreams.org/newswire/2018/08/14/ajit-pais-fcc-lied-congress-about-net-neutrality-they-should-act-now-reverse",
+    "title": "Ajit Pai’s FCC Lied to Congress About Net Neutrality. They Should Act Now to Reverse the Repeal"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/microsoft/man-sues-microsoft-seeking-new-copy-of-windows-7-after-forced-windows-10-upgrade/",
+    "title": "Man sues Microsoft seeking new copy of Windows 7 after forced Windows 10 upgrade"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20151118/08474732854/after-endless-demonization-encryption-police-find-paris-attackers-coordinated-via-unencrypted-sms.shtml",
+    "title": "After Endless Demonization Of Encryption, Police Find Paris Attackers Coordinated Via Unencrypted SMS"
+  },
+  {
+    "url": "https://gizmodo.com/mark-zuckerberg-thinks-you-dont-trust-facebook-because-1832040327",
+    "title": "Mark Zuckerberg Thinks You Don't Trust Facebook Because You Don't 'Understand' It"
+  },
+  {
+    "url": "https://www.engadget.com/2018/05/31/fulfilled-by-amazon-counterfeit-fake/",
+    "title": "Amazon needs to get a handle on its counterfeit problem. Fulfilled by Amazon should be a badge of trust, not a legal loophole."
+  },
+  {
+    "url": "https://www.theverge.com/2018/3/22/17150870/google-chrome-autoplay-videos-sound-mute-update",
+    "title": "Google Chrome’s next update will finally block autoplay videos that have sound"
+  },
+  {
+    "url": "https://www.kommersant.ru/doc/3386016",
+    "title": "Russia revoked .ru domain of racist Daily Stormer"
+  },
+  {
+    "url": "http://thehill.com/opinion/technology/357774-federal-move-to-undo-internet-freedom-would-make-us-more-like-russia-not",
+    "title": "Federal move to undo internet freedom would make US more like Russia, not less"
+  },
+  {
+    "url": "https://www.digitalmusicnews.com/2018/03/29/los-angeles-broadband-net-neutrality/",
+    "title": "Los Angeles Wants to Build Its Own Citywide Broadband Network - It would be one of the largest municipal broadband networks in the world. Now, Los Angeles is studying an aggressive plan to protect net neutrality."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/12/fcc-still-hiding-possible-evidence-of-russia-meddling-in-net-neutrality-comments/",
+    "title": "“What is the FCC hiding?” Pai still won’t release net neutrality server logs - FCC denies NYT appeal, says producing requested records is too hard."
+  },
+  {
+    "url": "http://www.ibtimes.co.uk/opdomesticterrorism-anonymous-hackers-take-down-over-dozen-neo-nazi-sites-new-wave-attacks-1647385",
+    "title": "Anonymous hackers take down over a dozen neo-Nazi sites in new wave of attacks."
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/energy-environment/wp/2017/02/07/trumps-energy-plan-doesnt-mention-solar-an-industry-that-just-added-51000-jobs/?utm_term=.a633afab6945",
+    "title": "Trump’s energy plan doesn’t mention solar, an industry that just added 51,000 jobs"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/09/judge-fcc-cant-hide-records-that-may-explain-net-neutrality-comment-fraud/",
+    "title": "Judge: FCC can’t hide records that may explain net neutrality comment fraud"
+  },
+  {
+    "url": "https://www.multichannel.com/news/rep-khanna-releases-internet-bill-of-rights",
+    "title": "Rep. Khanna Releases Internet Bill of Rights - Would restore net neutrality rules, require opt in for personal info use"
+  },
+  {
+    "url": "https://qz.com/1509095/hospital-to-post-the-costs-of-medical-services/",
+    "title": "Finally, U.S. hospitals will have to post their prices online."
+  },
+  {
+    "url": "http://time.com/money/5205630/mark-zuckerberg-net-worth-facebook-stock/",
+    "title": "Mark Zuckerberg Has Lost $5 Billion So Far Today Amid Facebook Data Controversy"
+  },
+  {
+    "url": "http://search.slashdot.org/story/15/06/11/1223236/ask-toolbar-now-considered-malware-by-microsoft",
+    "title": "Ask Toolbar Now Considered Malware By Microsoft"
+  },
+  {
+    "url": "http://mashable.com/2016/09/07/iphone-headphone-jack-courage/?utm_cid=hp-hh-sec#CSiVtmuEXiqZ",
+    "title": "No, Apple, killing your headphone jack is not \"courage\""
+  },
+  {
+    "url": "http://trai.gov.in/notifications/press-release/trai-releases-recommendations-net-neutrality",
+    "title": "India just got strongest regulations on Net Neutrality in the world"
+  },
+  {
+    "url": "http://www.thedailybeast.com/articles/2016/04/21/hillary-pac-spends-1-million-to-correct-commenters-on-reddit-and-facebook.html",
+    "title": "Hillary PAC Spends $1 Million to ‘Correct’ Commenters on Reddit and Facebook: FEC loopholes mean Correct the Record can openly coordinate with Clinton’s campaign."
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Ajit-Pais-FCC-Cant-Stop-Lying-About-Net-Neutrality-141221",
+    "title": "Ajit Pai's FCC Can't Stop Lying About Net Neutrality"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/09/ajit-pai-helped-charter-kill-consumer-protection-rules-in-minnesota/",
+    "title": "Ajit Pai helped Charter kill consumer-protection rules in Minnesota"
+  },
+  {
+    "url": "http://www.theverge.com/2016/11/14/13630722/google-fake-news-advertising-ban-2016-us-election",
+    "title": "Google will soon ban fake news sites from using its ad network"
+  },
+  {
+    "url": "https://futurism.com/germany-just-smashed-an-energy-record-generating-85-electricity-from-renewables/",
+    "title": "Germany Just Smashed an Energy Record, Generating 85% Electricity From Renewables"
+  },
+  {
+    "url": "https://www.engadget.com/2018/11/06/fcc-caller-id-authentication-2019/",
+    "title": "FCC pushes carriers to implement caller ID authentication by 2019 to block spam and scam robocalls from going through."
+  },
+  {
+    "url": "http://apps.fcc.gov/ecfs/proceeding/view?name=14-28",
+    "title": "I'm calling shenanigans - FCC Comments for Net Neutrality drop from 700,000 to 200,000"
+  },
+  {
+    "url": "http://arstechnica.com/business/2015/02/fcc-overturns-state-laws-that-protect-isps-from-local-competition/",
+    "title": "FCC overturns state laws that protect ISPs from local competition"
+  },
+  {
+    "url": "https://www.theguardian.com/games/2018/dec/17/fresh-prince-actor-sues-fortnite-for-use-carlton-dance",
+    "title": "Fresh Prince actor sues Fortnite for use of 'iconic' Carlton dance - Alfonso Ribeiro wants to stop the makers of Fortnite and NBA 2K from using the dance he first performed on the 1990s sitcom"
+  },
+  {
+    "url": "http://thenextweb.com/apps/2016/01/15/uh-oh-controversial/",
+    "title": "F.lux creators call Apple out for releasing Night Shift after banning their app"
+  },
+  {
+    "url": "https://www.independent.co.uk/life-style/gadgets-and-tech/news/trump-news-google-search-results-twitter-rigged-us-president-a8510736.html",
+    "title": "President Trump claims Google is rigging search results to make him look bad."
+  },
+  {
+    "url": "https://www.cnbc.com/2019/01/03/apples-losses-since-peak-exceed-the-value-of-496-of-sp-500.html",
+    "title": "Apple's value has lost $446 billion since peaking in October, which is greater than the total market value of Facebook (or nearly any other US company)"
+  },
+  {
+    "url": "http://thehill.com/policy/technology/380691-aclu-urges-cities-to-build-public-broadband-networks-to-protect-net",
+    "title": "ACLU urges cities to build public broadband to protect net neutrality"
+  },
+  {
+    "url": "http://www.theverge.com/2016/5/11/11656088/payday-loan-ads-banned-from-google",
+    "title": "Google bans ads for payday loans"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2016/08/court-rules-isps-not-need-give-information-alleged-pirates-copyright-infringers/",
+    "title": "Court rules that ISPs do not need to give up information on alleged pirates, copyright infringers"
+  },
+  {
+    "url": "http://www.theverge.com/2017/4/27/15447394/fcc-net-neutrality-roll-back-startups-letter-y-combinator",
+    "title": "Kill net neutrality and you’ll kill us, say 800 US startups"
+  },
+  {
+    "url": "http://gizmodo.com/the-new-cispa-bill-is-literally-exactly-the-same-as-the-1679496808",
+    "title": "The New CISPA Bill Is Literally Exactly the Same as the Last One"
+  },
+  {
+    "url": "https://arstechnica.com/science/2017/09/solar-now-costs-6-per-kilowatt-hour-beating-government-goal-by-3-years/",
+    "title": "Solar now costs 6¢ per kilowatt-hour, beating government goal by 3 years"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/gymdbq/sinclair-broadcasting-media-consolidation-regulations",
+    "title": "The Sinclair Horrorshow Is the Result of Decades of Failing to Take Media Consolidation Worries Seriously - An FCC commissioner says the agency has become a rubber stamp for Sinclair Broadcasting."
+  },
+  {
+    "url": "http://www.theverge.com/2017/2/17/14649018/youtube-ending-unskippable-30-second-ads-2018",
+    "title": "YouTube will kill unskippable 30-second ads next year"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/04/11/goldman-asks-is-curing-patients-a-sustainable-business-model.html",
+    "title": "Goldman Sachs asks in biotech research report: 'Is curing patients a sustainable business model?'"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/11/27/read-google-employees-open-letter-protesting-project-dragonfly.html",
+    "title": "Google employees: We no longer believe the company places values over profits"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180620/12174040079/att-successfully-derails-californias-tough-new-net-neutrality-law.shtml",
+    "title": "AT&T Successfully Derails California's Tough New Net Neutrality Law"
+  },
+  {
+    "url": "https://consumerist.com/2017/06/15/netflix-changes-its-mind-decides-maybe-it-does-care-about-net-neutrality-again/",
+    "title": "Netflix Changes Its Mind, Decides Maybe It Does Care About Net Neutrality Again"
+  },
+  {
+    "url": "https://cei.org/blog/uber-wants-make-it-illegal-operate-your-own-self-driving-car-cities",
+    "title": "Uber Wants to Make It Illegal to Operate Your Own Self-Driving Car in Cities"
+  },
+  {
+    "url": "http://www.businessinsider.com/netflix-catalog-size-shrinks-2016-9",
+    "title": "Netflix's catalog has shrunk by a whopping 50% in the past few years"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/FCC-Refuses-to-Release-47000-Net-Neutrality-Complaints-139977",
+    "title": "FCC Refuses to Release 47,000 Net Neutrality Complaints"
+  },
+  {
+    "url": "https://wikileaks.org/tpp-ip3/WikiLeaks-TPP-IP-Chapter/WikiLeaks-TPP-IP-Chapter-051015.pdf",
+    "title": "TPP leaked: final draft of the intellectual property chapter, which some claim will destroy the internet as we know it, made available by Wikileaks"
+  },
+  {
+    "url": "http://www.theregister.co.uk/2017/10/11/trump_protest_website_privacy_latest/",
+    "title": "Judge says US govt has 'no right to rummage' through anti-Trump protest website logs"
+  },
+  {
+    "url": "https://www.yahoo.com/news/house-democrats-call-investigation-fcc-190101716.html",
+    "title": "House Democrats Call for Investigation of FCC Chairman Over Sinclair Merger"
+  },
+  {
+    "url": "http://www.ibtimes.co.uk/sci-hub-russian-neuroscientist-running-pirate-bay-scientists-48-million-free-academic-papers-1543926?",
+    "title": "Sci-Hub: Russian neuroscientist running 'Pirate Bay for scientists' with 48 million free academic papers"
+  },
+  {
+    "url": "http://www.huffingtonpost.com/entry/57e43749e4b05d3737be5784?timestamp=1474574566927",
+    "title": "77% of Ad Blocking Users Feel Guilty about Blocking Ads; \"The majority of ad blocking users are not downloading ad blockers to remove online advertising completely, but rather to fix user-experience problems\""
+  },
+  {
+    "url": "https://www.recode.net/2018/3/27/17170552/snapchat-api-data-sharing-facebook",
+    "title": "Snapchat is building the same kind of data-sharing API that just got Facebook into trouble."
+  },
+  {
+    "url": "https://www.wired.com/story/ajit-pais-plan-will-take-broadband-away-from-poor-people/",
+    "title": "Ajit Pai’s Plan Will Take Broadband Away From Poor People"
+  },
+  {
+    "url": "https://duckduckgo.com/traffic",
+    "title": "DuckDuckGo Traffic is Exploding"
+  },
+  {
+    "url": "https://www.theverge.com/2018/4/30/17303086/bill-gates-trump-white-house-science-advisor",
+    "title": "Bill Gates told Trump that being his science adviser is ‘not a good use of my time.’"
+  },
+  {
+    "url": "https://www.theroot.com/netneutrality-us-supreme-court-hands-over-a-major-vic-1830269778",
+    "title": "#NetNeutrality: Supreme Court Hands Over a Major Victory for Open Internet Advocates"
+  },
+  {
+    "url": "https://www.theguardian.com/money/2016/dec/31/french-workers-win-legal-right-to-avoid-checking-work-email-out-of-hours",
+    "title": "French workers win legal right to avoid checking work email out-of-hours"
+  },
+  {
+    "url": "http://jeffreyfossett.com/2017/05/13/fcc-filings.html",
+    "title": "FCC Filings Overwhelmingly Support Net Neutrality Once Spam is Removed [Data Analysis]"
+  },
+  {
+    "url": "https://techcrunch.com/2017/11/21/the-fccs-craven-net-neutrality-vote-announcement-makes-no-mention-of-the-22-million-comments-filed/",
+    "title": "The FCC’s craven net neutrality vote announcement makes no mention of the 22 million comments filed"
+  },
+  {
+    "url": "https://www.fightforthefuture.org/news/2017-10-26-the-fcc-will-soon-vote-to-kill-net-neutrality-but/",
+    "title": "The FCC will soon vote to kill net neutrality. But Congress can stop them if they hear from constituents now."
+  },
+  {
+    "url": "https://www.masslive.com/politics/index.ssf/2018/11/us_sen_ed_markey_says_mobile_c.html",
+    "title": "US Sen. Ed Markey says mobile carriers' alleged throttling practices highlight need for 'net neutrality'"
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/the-watch/wp/2016/03/10/surprise-nsa-data-will-soon-routinely-be-used-for-domestic-policing-that-has-nothing-to-do-with-terrorism",
+    "title": "Surprise! NSA data will soon routinely be used for domestic policing that has nothing to do with terrorism"
+  },
+  {
+    "url": "http://www.cnet.com/news/amazons-next-noise-canceling-headphones-could-turn-off-when-someone-yells-your-name/",
+    "title": "Amazon patents a noise-canceling headphone that automatically turns off when it detects certain sound patterns, frequencies or key words like a name."
+  },
+  {
+    "url": "http://english.alarabiya.net/en/News/middle-east/2017/12/31/Iran-cuts-off-Internet-service-in-several-cities-as-mass-protests-erupt.html",
+    "title": "Iran cuts off internet access in several cities as mass protests continue."
+  },
+  {
+    "url": "http://www.csmonitor.com/World/Passcode/Passcode-Voices/2016/0419/Opinion-Burr-Feinstein-antiencryption-bill-a-firing-offense",
+    "title": "Sens. Richard Burr (R) of North Carolina and Dianne Feinstein (D) of California should be stripped of their positions for introducing a bill that would endanger American digital security and privacy."
+  },
+  {
+    "url": "https://www.recode.net/2017/7/25/16026184/mark-zuckerberg-artificial-intelligence-elon-musk-ai-argument-twitter",
+    "title": "Mark Zuckerberg thinks AI fearmongering is bad. Elon Musk thinks Zuckerberg doesn’t know what he’s talking about."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170919/10061338239/fcc-sued-ignoring-foia-request-investigating-fraudulent-net-neutrality-comments.shtml",
+    "title": "FCC Sued For Ignoring FOIA Request Investigating Fraudulent Net Neutrality Comments"
+  },
+  {
+    "url": "http://www.thelocal.se/20151127/swedish-court-we-cannot-ban-pirate-bay",
+    "title": "Swedish court: \"We cannot ban Pirate Bay.\" In a landmark decision, a Swedish court on Friday ruled that the country's internet service providers cannot be forced to block controversial Swedish file-sharing site Pirate Bay."
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Porn-Companies-Join-The-Fight-For-Net-Neutrality-139831",
+    "title": "Porn Companies Join The Fight For Net Neutrality: \"Without [net neutrality], the cable and wireless companies that control internet access will have unfair power to pick winners and losers in the market,\" Corey Price, VP of Pornhub,"
+  },
+  {
+    "url": "https://www.engadget.com/2016/08/11/adblock-plus-bypasses-facebooks-attempt-to-restrict-ad-blockers/",
+    "title": "Adblock Plus bypasses Facebook's attempt to restrict ad blockers. \"It took only two days to find a workaround.\""
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/tennessee-could-give-taxpayers-americas-fastest-internet-for-free-but-it-will-give-comcast-and-atandt-dollar45-million-instead",
+    "title": "Tennessee Could Give Taxpayers America's Fastest Internet For Free, But It Will Give Comcast and AT&T $45 Million Instead"
+  },
+  {
+    "url": "https://arstechnica.com/gaming/2018/08/netflix-begins-testing-ads-for-its-own-series-between-binge-season-episodes/",
+    "title": "Netflix will now interrupt series binges with video ads for its other series"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2017/mar/10/elon-musk-i-can-fix-south-australia-power-network-in-100-days-or-its-free",
+    "title": "Elon Musk: I can fix South Australia power network in 100 days or it's free"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2017/aug/20/elon-musk-killer-robots-experts-outright-ban-lethal-autonomous-weapons-war",
+    "title": "Elon Musk leads 116 experts calling for outright ban on killer robots - Open letter signed by Tesla chief and Google’s Mustafa Suleyman urges UN to block use of lethal autonomous weapons to prevent third age of war"
+  },
+  {
+    "url": "https://www.recode.net/2017/8/26/16205010/hurricane-harvey-texas-att-verizon-wireless-telecom-emergency-alert-system",
+    "title": "Before Hurricane Harvey, wireless carriers lobbied against upgrades to a national emergency alert system - A wonky debate at the FCC has real-life consequences, and public-safety officials aren’t happy"
+  },
+  {
+    "url": "http://gizmodo.com/the-fbi-says-its-malware-isn-t-malware-because-the-fbi-1783537208",
+    "title": "The FBI Says Its Malware Isn’t Malware Because the FBI Is Good"
+  },
+  {
+    "url": "http://torrentfreak.com/pirate-bay-founder-will-wear-handcuffs-to-carry-fathers-coffin-140917/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+Torrentfreak+%28Torrentfreak%29",
+    "title": "Pirate Bay Founder \"Will Wear Handcuffs\" to Carry Father's Coffin \"While the Pirate Bay founder will be allowed to attend the funeral, prison staff have told him he can expect to carry the coffin while wearing handcuffs. For someone convicted of copyright offenses with just 50 days sentence left ..\""
+  },
+  {
+    "url": "https://www.businessinsider.com/facebook-approved-political-ads-paid-for-by-cambridge-analytica-2018-10",
+    "title": "We ran 2 fake ads pretending to be Cambridge Analytica — and Facebook failed to catch that they were frauds"
+  },
+  {
+    "url": "https://arstechnica.com/information-technology/2018/07/att-promised-lower-prices-after-time-warner-merger-its-raising-them-instead/",
+    "title": "AT&T promised lower prices after Time Warner merger—it’s raising them instead."
+  },
+  {
+    "url": "https://techcrunch.com/2017/05/16/fcc-commissioner-net-neutrality-is-doomed-if-were-silent/",
+    "title": "FCC commissioner: ‘Net neutrality is doomed if we’re silent’"
+  },
+  {
+    "url": "http://arstechnica.com/business/2014/12/data-caps-limited-competition-a-recipe-for-trouble-in-home-internet-service/",
+    "title": "The FCC is not addressing home data caps because \"the number of consumer complaints regarding Usage Based Pricing by fixed providers appears to be small\". Go increase the number! Link in comments."
+  },
+  {
+    "url": "https://www.techspot.com/news/75754-spectrum-allegedly-throttled-content-providers-netflix-riot-games.html",
+    "title": "Spectrum allegedly throttled content providers Netflix and Riot Games for money. So much for that Net Neutrality rollback"
+  },
+  {
+    "url": "https://gizmodo.com/ajit-pai-refuses-to-brief-lawmakers-over-phone-tracking-1831750774",
+    "title": "Ajit Pai Refuses to Brief Lawmakers Over Phone-Tracking Scandal, Dubiously Blames Shutdown"
+  },
+  {
+    "url": "http://www.theregister.co.uk/2017/01/07/tv_anchor_says_alexa_buy_me_a_dollhouse_and_she_does/?mt=1483795705927",
+    "title": "TV anchor says live on-air 'Alexa, order me a dollhouse' – story on accidental Alexa order sets off Alexa-powered Echo boxes around San Diego on their own shopping sprees"
+  },
+  {
+    "url": "http://www.theverge.com/2016/7/11/12147600/nintendos-stock-pokemon-go",
+    "title": "Pokémon Go's success adds $7.5 billion to Nintendo's market value"
+  },
+  {
+    "url": "http://bgr.com/2014/07/28/twc-vs-google-netflix/",
+    "title": "Time Warner Cable hilariously claims that Google and Netflix are the real threats to net neutrality"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/06/ajit-pais-fcc-lied-about-ddos-attack-ex-chairs-statement-indicates/",
+    "title": "Ajit Pai’s FCC lied about “DDoS” attack, ex-chair’s statement indicates - Wheeler: There was no \"coverup\" of 2014 DDoS attack, because there was no DDoS."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/11/cops-pull-over-tesla-cruising-on-a-freeway-with-apparently-asleep-driver/",
+    "title": "It took seven miles to pull over a Tesla with a seemingly asleep driver - The driver was arrested for drunk driving."
+  },
+  {
+    "url": "https://gizmodo.com/least-transparent-fcc-ever-goes-dark-as-former-it-chief-1826631088",
+    "title": "A former FCC senior official who issued false statements to reporters, claiming a cyberattack hobbled the agency’s comment system in 2014 and that the ex-chairman ordered it kept quiet, is now backpedaling amid renewed scrutiny by U.S. lawmakers and a wholesale denial by the former chairman himself."
+  },
+  {
+    "url": "https://motherboard.vice.com/read/five-states-are-considering-bills-to-legalize-the-right-to-repair-electronics",
+    "title": "Five States Are Considering Bills to Legalize the 'Right to Repair' Electronics"
+  },
+  {
+    "url": "http://www.bbc.co.uk/news/world-us-canada-47036515",
+    "title": "US charges China's Huawei with fraud"
+  },
+  {
+    "url": "https://www.pbs.org/newshour/politics/texans-say-voting-machines-are-flipping-selections-to-the-other-party",
+    "title": "Texans say voting machines are flipping selections to the other party"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/wjmddq/study-finds-that-leaving-facebook-makes-you-happier-and-less-informed",
+    "title": "Leaving Facebook Makes You Happier, less politically informed, more active in IRL activities, and less likely to go back to Facebook."
+  },
+  {
+    "url": "https://www.latimes.com/world/europe/la-fg-germany-coal-power-20190126-story.html",
+    "title": "Germany to close all 84 of its coal-fired power plants, will rely primarily on renewable energy"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Comcast-Accused-Again-of-Billing-Fraud-140942",
+    "title": "Comcast Accused (Again) of Billing Fraud: \"Comcast may have signed up more than half of all SPP subscribers without their consent,\" and in numerous instances charged customers for the SPP plan after telling them it was \"free.\""
+  },
+  {
+    "url": "https://techcrunch.com/2017/12/28/trump-500-internal-server-error-obama-joke/",
+    "title": "Trump’s website is coded with a broken server error message that blames Obama"
+  },
+  {
+    "url": "https://www.businessinsider.com/googles-top-executives-stopped-posting-on-google-at-least-a-year-ago-2018-10",
+    "title": "The biggest clue that Google+ was long dead - Google's top executives stopped using it up to 3 years ago"
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/2018/04/08/apple-co-founder-steve-wozniak-says-hes-leaving-facebook/497392002/",
+    "title": "Apple co-founder Steve Wozniak says he's leaving Facebook"
+  },
+  {
+    "url": "https://www.wired.com/story/warrantless-us-spying-is-set-to-expire-soon-let-it-die",
+    "title": "Warrantless US Spying Is Set to Expire Soon. Let It Die"
+  },
+  {
+    "url": "http://www.nationalreview.com/article/421516/stop-internet-streaming-tax",
+    "title": "As of July 1, 2015, citizens of Chicago who enjoy their Netflix, Spotify, Pandora, Amazon Prime, Xbox Live, and/or PlayStation Network subscriptions are now subject to the city’s 9 percent “Amusement Tax” for the privilege."
+  },
+  {
+    "url": "https://www.politico.com/story/2018/06/18/senate-rejects-trumps-rescue-of-chinese-firm-zte-652459",
+    "title": "Senate rejects Trump’s rescue of Chinese firm ZTE"
+  },
+  {
+    "url": "https://www.cnet.com/news/net-neutrality-is-officially-dead-fcc-ajit-pai-now-what",
+    "title": "Net neutrality is officially dead. Now what? - The FCC has taken the final step in erasing the 2015 rules protecting the internet."
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/news/2018/04/22/google-amazon-push-power-companies-solar-and-wind-blow-coal/438020002/",
+    "title": "Tech firms like Google, Amazon push power companies toward solar and wind, a blow to coal"
+  },
+  {
+    "url": "https://www.theverge.com/2018/5/1/17308418/fcc-commissioner-orielly-trump-law",
+    "title": "FCC commissioner broke the law by advocating for Trump, officials find"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/qvajpv/michigan-teen-right-to-repair",
+    "title": "This 17-Year-Old Has Become Michigan's Leading Right to Repair Advocate - When Surya Raghavendran dropped his iPhone, he learned to repair it himself. Now he wants to protect that right for everyone in his home state of Michigan."
+  },
+  {
+    "url": "http://newnetworks.com/ShortSCANDALSummary.htm",
+    "title": "Just a reminder You already paid for High Speed Fiber Optic Infrastructure in the USA."
+  },
+  {
+    "url": "http://informitv.com/2014/11/12/president-obama-calls-for-net-neutrality/",
+    "title": "President Obama calls for net neutrality, demanding no blocking, no throttling, increased transparency, and no paid prioritization"
+  },
+  {
+    "url": "https://www.theverge.com/2017/8/9/16114530/net-neutrality-crusade-against-verizon-alex-nguyen-fcc",
+    "title": "As net neutrality dies, one man wants to make Verizon pay for its sins"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2018/08/20/mozilla-files-arguments-against-the-fcc-latest-step-in-fight-to-save-net-neutrality/",
+    "title": "Mozilla files arguments against the FCC – latest step in fight to save net neutrality"
+  },
+  {
+    "url": "https://www.nature.com/articles/d41586-018-05357-w",
+    "title": "Sucking carbon dioxide from air is cheaper than scientists thought"
+  },
+  {
+    "url": "https://gizmodo.com/facebook-fined-just-645-000-in-uk-over-cambridge-analy-1829989116",
+    "title": "Facebook Fined Just $645,000 in UK Over Cambridge Analytica Scandal, Money It Makes in Less Than 10 Minutes"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20181009/11353140804/new-verizon-ad-hopes-to-make-you-forget-it-throttled-firefighters-no-reason.shtml",
+    "title": "New Verizon Ad Hopes To Make You Forget It Throttled Firefighters For No Reason"
+  },
+  {
+    "url": "https://www.mercurynews.com/2018/08/23/california-state-assembly-plans-hearing-on-verizon-throttling-of-firefighters-data/",
+    "title": "California State Assembly plans hearing on Verizon throttling of firefighters’ data"
+  },
+  {
+    "url": "http://theantimedia.org/google-to-begin-alerting-users-if-gmail-account-is-targeted-by-government/",
+    "title": "Google To Begin Alerting Users if Gmail Account is Targeted by Government"
+  },
+  {
+    "url": "http://www.zdnet.com/article/snoopers-charter-expansive-new-spying-powers-becomes-law/",
+    "title": "Britain just passed the \"most extreme surveillance law ever passed in a democracy\""
+  },
+  {
+    "url": "https://nakedsecurity.sophos.com/2018/11/01/passcodes-are-protected-by-fifth-amendment-says-court/",
+    "title": "Passcodes are protected by Fifth Amendment, says court"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20160603/06530234613/broadband-ceos-admit-usage-caps-are-nothing-more-than-toll-uncompetitive-markets.shtml",
+    "title": "Broadband CEOs Admit Usage Caps Are Nothing More Than A Toll On Uncompetitive Markets"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171023/11391838461/michigan-lawmaker-flees-twitter-after-reports-highlight-she-helped-att-push-anti-competition-broadband-law.shtml",
+    "title": "Michigan Lawmaker Flees Twitter After Reports Highlight She Helped AT&T Push Anti-Competition Broadband Law"
+  },
+  {
+    "url": "https://qz.com/930512/the-most-striking-thing-about-the-wikileaks-cia-data-dump-is-how-little-most-people-cared/",
+    "title": "The most striking thing about the WikiLeaks CIA data dump is how little most people cared"
+  },
+  {
+    "url": "https://www.wired.com/story/fcc-pledges-openness-just-dont-ask-to-see-complaints/",
+    "title": "FCC Pledges Openness – Just Don't Ask To See Complaints: \"The FCC seems more concerned with helping Big Cable than living up to his promise.\""
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171129/23412638704/after-attacking-random-hollywood-supporters-net-neutrality-ajit-pai-attacks-internet-companies.shtml",
+    "title": "After Attacking Random Hollywood Supporters Of Net Neutrality, Ajit Pai Attacks Internet Companies"
+  },
+  {
+    "url": "https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/",
+    "title": "Introducing the New Firefox: Firefox Quantum"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/06/13/shallow-best-and-ridiculous-worst-analysis-eviscerates-fcc-chairs-arguments-killing",
+    "title": "'Shallow at Best and Ridiculous at Worst': Analysis Eviscerates FCC Chair's Arguments for Killing Net Neutrality"
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/2017/09/12/internet-companies-too-big-ftc-chair-says-more-than-market-share-counts/656394001/",
+    "title": "Internet companies too big? FTC chair says more than market share counts: “we are spiraling towards a dystopian future where a few giant technology companies will ultimately gain sustained control over our economic lives.”"
+  },
+  {
+    "url": "https://gizmodo.com/the-nra-quadrupled-its-digital-ad-budget-after-parkland-1824050808",
+    "title": "The NRA Quadrupled Its Digital Ad Budget After Parkland Killings, Flooding Facebook and YouTube"
+  },
+  {
+    "url": "http://www.ibtimes.com/fbi-forced-twitter-share-user-data-without-legal-warrant-company-reveals-gag-orders-2482632",
+    "title": "FBI Forced Twitter To Share User Data Without Legal Warrant, Company Reveals As Gag Orders Lifted"
+  },
+  {
+    "url": "https://techcrunch.com/2017/10/24/congress-votes-to-disallow-consumers-from-suing-equifax-and-other-companies-with-arbitration-agreements/",
+    "title": "Congress votes to disallow consumers from suing Equifax and other companies with arbitration agreements."
+  },
+  {
+    "url": "http://motherboard.vice.com/read/jailbreaking-iphone-rooting-android-does-not-void-warranty",
+    "title": "Companies Can’t Legally Void the Warranty for Jailbreaking or Rooting Your Phone"
+  },
+  {
+    "url": "https://www.fastcompany.com/40445949/ex-chair-tom-wheeler-dismantles-fccs-argument-to-abandon-net-neutrality",
+    "title": "Ex-FCC Chair Tom Wheeler Dismantles The Case For Abandoning Net Neutrality - The Trump FCC is simply doing the bidding of Comcast, AT&T, Verizon, and Charter in its quest to abandon rules against blocking, slowing, or speeding internet traffic, Wheeler says."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/08/att-absurdly-claims-that-most-legitimate-net-neutrality-comments-favor-repeal/?comments=1",
+    "title": "AT&T absurdly claims that most “legitimate” net neutrality comments favor repeal"
+  },
+  {
+    "url": "http://www.washingtonpost.com/opinions/kickstarter-ceo-fccs-fast-lane-internet-plan-threatens-free-exchange-of-ideas/2014/07/04/a52ffd2a-fcbc-11e3-932c-0a55b81f48ce_story.html?tid=rssfeed",
+    "title": "FCC’s ‘fast lane’ Internet plan threatens free exchange of ideas \"Once a fast lane exists, it will become the de facto standard on the Web. Sites unwilling or unable to pay up will be buffered to death: unloadable, unwatchable and left out in the cold.\""
+  },
+  {
+    "url": "http://thehill.com/blogs/congress-blog/judicial/360895-senate-chooses-wall-street-over-consumers-seniors-and-service",
+    "title": "Senate chooses Wall Street over consumers, seniors, and service members - “senators decided that consumers should lose the right to hold massive financial institutions like Wells Fargo and Equifax accountable.”"
+  },
+  {
+    "url": "http://qz.com/859860/bill-gates-is-leading-a-new-1-billion-fund-focused-on-combatting-climate-change-through-innovation/",
+    "title": "Bill Gates and investors worth $170 billion are launching a fund to fight climate change through energy innovation"
+  },
+  {
+    "url": "http://www.freeingenergy.com/the-market-has-spoken-clean-energy-just-became-the-cheapest-source-of-electricity/",
+    "title": "The market has spoken – clean energy just became the cheapest source of electricity"
+  },
+  {
+    "url": "https://rietta.com/blog/2016/04/08/feinstein-burr-encryption-bill/",
+    "title": "U.S. Senate Bill Seeks to Ban Effective Encryption, Making Security Illegal"
+  },
+  {
+    "url": "http://www.zdnet.com/article/fcc-will-not-publish-evidence-of-alleged-ddos-attack/",
+    "title": "FCC says it was hit by a DDoS attack, but refuses to show any evidence"
+  },
+  {
+    "url": "https://mashable.com/2018/07/23/net-neutrality-cra-campaign-donations-scorecard/#BGAUEdVuCqqT",
+    "title": "Here's how much money anti-net neutrality members of Congress have received from the telecom industry"
+  },
+  {
+    "url": "http://gawker.com/former-reddit-ceo-youre-all-screwed-1717901652",
+    "title": "Former Reddit CEO Yishan Wong's latest big reveal: Reddit’s board has been itching to purge hate-based subreddits since the beginning. And recently, the only thing stopping them had been... Ellen Pao. Whoops."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20161220/12411836320/company-bricks-users-software-after-he-posts-negative-review.shtml",
+    "title": "Company Bricks User's Software After He Posts A Negative Review"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/d3dz7z/comcast-and-centurylink-spent-dollar50k-in-seattle-to-support-a-mayoral-candidate-who-opposes-community-owned-internet",
+    "title": "Comcast and CenturyLink Spent $50K in Seattle to Support a Mayoral Candidate Who Opposes Community-Owned Internet"
+  },
+  {
+    "url": "https://www.tremr.com/movements/facebook-facing-heavy-criticism-after-removing-major-atheist-pages",
+    "title": "Facebook Facing Heavy Criticism After Removing Major Atheist Pages"
+  },
+  {
+    "url": "https://www.theverge.com/2018/5/9/17334602/apple-targeting-apps-location-data-sharing-third-parties",
+    "title": "Apple is reportedly removing apps that share your location data with third parties"
+  },
+  {
+    "url": "http://www.theguardian.com/commentisfree/2015/jun/01/guardian-view-on-surveillance-after-edward-snowden-outlaw-rewrites-law",
+    "title": "Edward Snowden deserves a pardon at home, or else asylum in western Europe, for revealing truths that US lawmakers have recognised required a response."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/bj49j8/fcc-falsely-claims-community-broadband-an-ominous-threat-to-the-first-amendment",
+    "title": "FCC falsely claims community broadband an 'ominous threat to the first amendment.'"
+  },
+  {
+    "url": "https://www.businessinsider.com/facebook-employees-react-nyt-report-leadership-scandals-2018-11",
+    "title": "Facebook employees react to the latest scandals: “Why does our company suck at having a moral compass?”"
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2017/aug/30/24-hours-left-to-protect-net-neutrality",
+    "title": "We've got less than 24 hours left to protect net neutrality - There are few government regulations that are more popular than net neutrality rules. Now, they might be scrapped"
+  },
+  {
+    "url": "http://www.gamerevolution.com/features/free-speech-under-attack-youtuber--repair-specialist-louis-rossmann-alludes-to-apple-lawsuit",
+    "title": "Apple is suing a man that teaches people to repair their Macbooks [ORIGINAL WORKING LINK]"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2019/01/28/apple_iphone_batteries/",
+    "title": "Apple: You can't sue us for slowing down your iPhones because you, er, invited us into, uh, your home... we can explain"
+  },
+  {
+    "url": "https://www.businessinsider.com/mit-grad-made-a-robot-to-detect-water-pipe-leaks-2018-9",
+    "title": "A 28-year-old MIT graduate has created a leak-detecting robot that could eliminate some of the 2 trillion gallons of wasted drinking water annually"
+  },
+  {
+    "url": "https://www.pri.org/stories/2017-12-31/big-money-backing-out-fossil-fuel-industry-moving-greener-alternatives",
+    "title": "Big money is backing out of fossil fuel industry, moving into greener alternatives - “follow the dollar to see where the future of energy is headed, globally.”"
+  },
+  {
+    "url": "http://www.independent.co.uk/news/world/americas/fbi-director-james-comey-no-absolute-privacy-a7619621.html",
+    "title": "FBI Director James Comey says 'absolute privacy' does not exist in the US"
+  },
+  {
+    "url": "https://np.reddit.com/r/privacy/comments/3l4apg/avg_anti_virus_just_updated_there_privacy_policy/",
+    "title": "AVG anti virus just updated there privacy policy. it says that they can and will sell your browsing history to 3rd parties."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/bj4ez3/motorola-becomes-first-smartphone-company-to-sell-diy-repair-kits-to-its-customers",
+    "title": "Motorola Becomes First Smartphone Company to Sell DIY Repair Kits to Its Customers"
+  },
+  {
+    "url": "https://www.hcn.org/issues/50.21/nuclear-energy-a-new-generation-of-environmentalists-is-learning-to-stop-worrying-and-love-nuclear-power",
+    "title": "Is nuclear energy the key to saving the planet? A new generation of environmentalists is learning to stop worrying and love atomic power."
+  },
+  {
+    "url": "https://www.recode.net/2019/1/6/18171035/apple-samsung-tv-service-strategy",
+    "title": "Apple is going to sell its Apple TV service on Samsung TVs, because Apple wants to be a service company: Tim Cook can’t just rely on Apple customers anymore — he needs to sell things to people who don’t buy Apple products."
+  },
+  {
+    "url": "https://www.theverge.com/circuitbreaker/2018/2/20/17031256/worlds-largest-ssd-drive-samsung-30-terabyte-pm1643",
+    "title": "Samsung unveils world’s largest SSD with whopping 30TB of storage. It’s the most memory ever crammed into a 2.5-inch form factor — enough to store 5,700 full HD movies"
+  },
+  {
+    "url": "https://www.ft.com/content/57c9f432-de6d-11e7-a0d4-0944c5f49e46",
+    "title": "Nanobots kill off cancerous tumours as fiction becomes reality - Researchers inject tiny devices into the bloodstream to deliver drugs with precision"
+  },
+  {
+    "url": "https://www.fightforthefuture.org/news/2018-09-15-ajit-pai-seems-really-upset-about-the-california/",
+    "title": "Ajit Pai seems really upset about the California net neutrality bill that passed with bipartisan support"
+  },
+  {
+    "url": "https://news.bitcoin.com/update-bitcoiners-use-tor-warned/",
+    "title": "Unless congress stops it, the FBI wants to mass-hack computers, especially targeting Tor and Bitcoin users"
+  },
+  {
+    "url": "https://www.theguardian.com/science/2017/jul/19/give-robots-an-ethical-black-box-to-track-and-explain-decisions-say-scientists?CMP=twt_a-science_b-gdnscience",
+    "title": "Robots should be fitted with an “ethical black box” to keep track of their decisions and enable them to explain their actions when accidents happen, researchers say."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/08/isps-want-to-be-utilities-but-only-to-get-more-money-from-the-government/",
+    "title": "ISPs say they can’t expand broadband unless gov’t gives them more money: Industry asks for handouts, arguing that broadband is essential—like a utility."
+  },
+  {
+    "url": "https://www.techdirt.com/blog/netneutrality/articles/20150123/05191129787/hey-just-silly-thought-maybe-its-time-we-stop-letting-comcast-att-write-state-telecom-law.shtml",
+    "title": "Hey, Just A Silly Thought: Maybe It's Time We Stop Letting Comcast And AT&T Write State Telecom Law?"
+  },
+  {
+    "url": "https://www.techdirt.com/blog/netneutrality/articles/20170722/03252237838/verizon-throttles-netflix-subscribers-test-it-doesnt-inform-customers-about.shtml",
+    "title": "Verizon Throttles Netflix Subscribers In 'Test' It Doesn't Inform Customers About"
+  },
+  {
+    "url": "https://medium.com/@jtabish/five-republicans-have-opposed-the-fccs-plan-we-need-to-tweet-the-rest-of-them-d7ade9df19bf",
+    "title": "Five Republicans have opposed the FCC’s plan. We need to convince the rest of them."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/qvx3ep/whats-happening-with-lifeline-fcc-program",
+    "title": "Congress Is Trying to Stop Ajit Pai from Taking Broadband Assistance Away from the Poor: \"The Lifeline program provides subsidized communications services to low-income Americans, many of whom rely on it as their only way to access the internet.\""
+  },
+  {
+    "url": "http://www.businessinsider.com/why-political-ads-should-be-regulated-online-2017-9?",
+    "title": "When it comes to political ads, it's time for Facebook and Google to be held to the same standards as ABC and CBS"
+  },
+  {
+    "url": "https://dailym.ai/2DstYb2",
+    "title": "China 'launches an app that tells you if you are within 500 yards of someone in debt - and encourages you to report them if they seem capable of paying up'"
+  },
+  {
+    "url": "https://mybroadband.co.za/news/software/269659-google-has-slowed-down-youtube-on-firefox-and-edge-mozilla-exec.html",
+    "title": "Google has slowed down YouTube on Firefox and Edge according to Mozilla exec"
+  },
+  {
+    "url": "https://torrentfreak.com/kickasstorrents-brought-back-to-life-by-original-staffers-161216/",
+    "title": "KickassTorrents Brought Back to Life by Original Staffers"
+  },
+  {
+    "url": "https://edition.cnn.com/2018/12/14/tech/facebook-billion-dollar-fine/index.html",
+    "title": "Facebook could face billion dollar fine for data breaches"
+  },
+  {
+    "url": "http://www.usatoday.com/story/money/2017/01/29/gates-warns-against-denying-climate-change/97214936/",
+    "title": "Bill Gates warned against denying climate change and pushed for more innovation in clean energy, during an event Friday at Columbia University"
+  },
+  {
+    "url": "http://www.commondreams.org/news/2016/12/15/nsa-inspector-who-criticized-snowden-not-using-official-channels-found-guilty",
+    "title": "NSA Inspector Who Criticized Snowden for Not Using 'Official' Channels Found Guilty of Retaliating Against Whistleblower Who Did Just That"
+  },
+  {
+    "url": "http://www.businessinsider.com/people-increased-facebook-usage-after-cambridge-analytica-scandal-2018-5",
+    "title": "The backlash that never happened: New data shows people actually increased their Facebook usage after the Cambridge Analytica scandal."
+  },
+  {
+    "url": "https://www.cnet.com/news/wpa3-wi-fi-is-here-and-its-harder-to-hack/",
+    "title": "WPA3 Wi-Fi is here, and it's harder to hack - That's good, because the last update was during the George W. Bush administration."
+  },
+  {
+    "url": "http://reneweconomy.com.au/teslas-price-shock-solar-battery-as-cheap-as-grid-power-22265/",
+    "title": "Tesla's price shock: Solar + battery as cheap as grid power -... \"The price per kWh stored and re-used has halved in less than a yea\""
+  },
+  {
+    "url": "https://qz.com/1103874/the-us-government-underestimated-solar-energy-installation-in-the-us-by-4813-along-with-renewable-wind-and-solar-generation/",
+    "title": "The US government underestimated solar energy installation in the US by 4,813%"
+  },
+  {
+    "url": "https://www.salon.com/2018/08/19/gop-leader-accuses-twitter-of-censoring-conservatives-finds-out-his-user-settings-was-hiding-tweets/",
+    "title": "GOP leader accuses Twitter of censoring conservatives, finds out his user settings was hiding tweets"
+  },
+  {
+    "url": "https://theintercept.com/2017/09/23/police-schedule-7-uk-rabbani-gchq-passwords/",
+    "title": "Airport police demanded activist’s passwords. He refused. Now faces prison in UK"
+  },
+  {
+    "url": "https://torrentfreak.com/pirate-bay-founders-acquitted-in-criminal-copyright-case-150710/",
+    "title": "Pirate bay founders acquitted in criminal copyright case"
+  },
+  {
+    "url": "http://bgr.com/2015/01/06/google-vs-verizon-att-wireless/",
+    "title": "Google wants to make wireless networks that will free you from AT&T and Verizon’s data caps"
+  },
+  {
+    "url": "https://nypost.com/2018/09/01/stop-treating-tech-jerks-like-gods/",
+    "title": "Stop treating tech jerks like gods"
+  },
+  {
+    "url": "https://arstechnica.com/?post_type=post&p=1198755",
+    "title": "Republican tax plan kills electric vehicle credit"
+  },
+  {
+    "url": "https://github.com/mandatoryprogrammer/NorthKoreaDNSLeak",
+    "title": "North Korea accidentally leaks DNS for .kp: only 28 domains"
+  },
+  {
+    "url": "http://motherboard.vice.com/read/reddit-admits-its-front-page-is-broken-is-working-on-an-entirely-new-algorithm",
+    "title": "Reddit Admits Its Front Page Is Broken, Is Working on an Entirely New Algorithm"
+  },
+  {
+    "url": "https://www.bostonglobe.com/business/2018/12/30/here-why-this-western-mass-town-rejected-comcast-and-built-its-own-broadband-network/w8RdFWzwGLiRqWviYIBL2M/story.html",
+    "title": "This Western Mass. town rejected Comcast and built its own broadband network - The Boston Globe"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2019-01-08/samsung-phone-users-get-a-shock-they-can-t-delete-facebook",
+    "title": "Samsung Phone Users Perturbed to Find They Can't Delete Facebook"
+  },
+  {
+    "url": "http://qz.com/263950/hbo-is-now-seriously-considering-whether-to-offer-hbo-go-without-cable-tv/",
+    "title": "HBO is now “seriously considering” whether to offer HBO Go without cable TV"
+  },
+  {
+    "url": "https://shanghai.ist/2018/08/16/chinas-first-fully-homegrown-web-browser-found-to-be-google-chrome-clone/",
+    "title": "China’s first ‘fully homegrown’ web browser found to be Google Chrome clone"
+  },
+  {
+    "url": "https://www.androidcentral.com/all-major-us-carriers-give-your-real-time-location-info-third-parties",
+    "title": "All major U.S. carriers give your real-time location info to third parties"
+  },
+  {
+    "url": "https://www.theverge.com/2018/6/27/17511500/att-admin-fee-increase-wireless-bill-cover-costs",
+    "title": "AT&T more than doubles ‘admin fee’ for every wireless customer | Increase will net telecom giant $800 million a year"
+  },
+  {
+    "url": "https://www.telegraph.co.uk/news/2017/05/19/instagram-ranked-worst-social-network-young-peoples-mental-health/",
+    "title": "Instagram ranked worst social network for young people's mental health"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/29/18202602/san-francisco-facial-recognition-ban-proposal",
+    "title": "San Francisco proposal would ban government facial recognition use in the city"
+  },
+  {
+    "url": "http://www.streamingobserver.com/netflix-now-allows-download-programming/",
+    "title": "Netflix Now Allows You to Download Content for Offline Viewing"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180426/11195739727/cord-cutting-is-obvious-result-70-spike-cable-tv-prices-since-2000.shtml",
+    "title": "Cord Cutting Is The Obvious Result Of A 70% Spike In Cable TV Prices Since 2000"
+  },
+  {
+    "url": "https://thehill.com/policy/technology/425926-court-rejects-fcc-request-to-delay-net-neutrality-case",
+    "title": "Court rejects FCC request to delay net neutrality case"
+  },
+  {
+    "url": "https://www.bloomberg.com/view/articles/2018-10-08/google-privacy-glitch-no-we-did-not-consent-to-this",
+    "title": "No, Google, We Did Not Consent to This - The company knew about a privacy glitch and kept quiet. That has to stop."
+  },
+  {
+    "url": "http://venturebeat.com/2015/06/10/pornhub-is-crowdfunding-3-4m-to-explore-the-final-frontier/",
+    "title": "PornHub is crowdfunding $3.4M to shoot a sex tape in space"
+  },
+  {
+    "url": "http://customwire.ap.org/dynamic/stories/U/US_COMMUNITY_SOLAR_POWER?SITE=AP&SECTION=HOME&TEMPLATE=DEFAULT",
+    "title": "US utilities seek sun as Trump sides with coal, fossil fuels | Solar growth is so extensive and has so much momentum behind it that we're at the point where you can't put the genie back in the bottle,\" said Jeffrey R.S. Brownson, a Pennsylvania State University professor who studies solar adoption"
+  },
+  {
+    "url": "http://www.alternet.org/economy/chris-hedges-tpp-most-brazen-corporate-power-grab-american-history",
+    "title": "The TPP is the Most Brazen Corporate Power Grab in American History: It's worst than any of us feared"
+  },
+  {
+    "url": "http://heatst.com/tech/germany-considers-fining-facebook-522000-per-fake-news-item/",
+    "title": "Germany Considers Fining Facebook $522,000 Per Fake News Item"
+  },
+  {
+    "url": "http://www.mirror.co.uk/tech/reddit-brings-down-north-koreas-8881736",
+    "title": "Reddit brings down North Korea's entire internet after links to country's 28 websites are posted online"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/03/please-dont-take-broadband-away-from-poor-people-democrats-tell-fcc-chair/",
+    "title": "Please don’t take broadband away from poor people, Democrats tell FCC chair"
+  },
+  {
+    "url": "https://www.engadget.com/2018/09/28/zuckerberg-facebook-page-hacker-livestream/",
+    "title": "Hacker says he'll livestream deletion of Zuckerberg's Facebook page"
+  },
+  {
+    "url": "https://hothardware.com/news/google-fiber-scales-back-tv-service-to-focus-solely-on-gigabit-internet",
+    "title": "Google Fiber Scales Back TV Service To Focus Solely On High-Speed Internet"
+  },
+  {
+    "url": "http://money.cnn.com/2017/12/07/technology/anheuser-busch-tesla/index.html",
+    "title": "Anheuser-Busch orders 40 Tesla trucks"
+  },
+  {
+    "url": "https://gizmodo.com/british-police-identify-two-russian-suspects-in-novicho-1827710334",
+    "title": "British Police Identify Two Russian Suspects in Novichok Poisonings Using Facial Recognition Tech"
+  },
+  {
+    "url": "http://www.dailydot.com/politics/trump-closing-the-internet-up-in-some-way/?tw=dd",
+    "title": "Donald Trump wants to close up the Internet, saying \"We have to go see Bill Gates,” to better understand the Internet and then possibly “close it up.”“We’re losing a lot of people because of the Internet.”"
+  },
+  {
+    "url": "https://www.cbsnews.com/news/80-percent-of-mass-shooters-showed-no-interest-in-video-games-researcher-says/",
+    "title": "80 percent of mass shooters showed no interest in video games, researcher says"
+  },
+  {
+    "url": "http://thehill.com/policy/technology/367929-senate-bill-to-reverse-net-neutrality-repeal-wins-30th-co-sponsor-ensuring",
+    "title": "Senate bill to reverse net neutrality repeal gains 30th co-sponsor, ensuring floor vote"
+  },
+  {
+    "url": "https://www.theguardian.com/uk-news/2018/oct/06/police-drone-finds-girl-16-who-called-999-to-report",
+    "title": "UK Police drone finds girl, 16, who called 999 to report rape - The force said the thermal drone was used to find the girl and guide officers to her within minutes."
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/yw5bpv/fcc-caf-auction-final-census-blocks",
+    "title": "The FCC Disqualified a Bunch of Rural Communities from Receiving Internet Funding After Big Telecom Said They Already Have Internet"
+  },
+  {
+    "url": "http://www.commondreams.org/news/2017/03/23/here-are-50-gop-senators-who-just-sacrificed-your-broadbandprivacy-corporate-profits",
+    "title": "Here Are the 50 GOP Senators Who Just Sacrificed Your #BroadbandPrivacy to Corporate Profits: 'Extremely disappointing that the Senate voted today to sacrifice the privacy rights of Americans in the interest of protecting the profits of major internet companies'"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170213/14460536703/comcast-att-are-paying-minority-groups-to-support-killing-net-neutrality.shtml",
+    "title": "Comcast, AT&T Are Paying Minority Groups To Support Killing Net Neutrality"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/12/19/zuckerberg-must-resign-now-outrage-after-report-shows-facebook-let-corporate",
+    "title": "'Zuckerberg Must Resign Now': Outrage After Report Shows Facebook Let Corporate Partners Read Users' Private Messages"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/08/shunned-by-godaddy-and-google-racist-daily-stormer-moves-to-russian-domain/",
+    "title": "Racist Daily Stormer moves to Russian domain after losing .com address"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/12/centurylink-blocks-internet-access-falsely-claims-state-law-required-it/",
+    "title": "CenturyLink blocked its customers’ Internet access in order to show an ad - Utah customers were booted offline until they acknowledged security software ad."
+  },
+  {
+    "url": "https://www.bloomberg.com/view/articles/2018-01-03/americans-should-have-more-control-over-their-data",
+    "title": "Americans Should Have More Control Over Their Data - In Europe, internet users will soon get to decide how their online activity is tracked. The U.S. should follow suit."
+  },
+  {
+    "url": "http://www.popularmechanics.com/technology/gadgets/a19607/apple-ceo-we-will-take-this-iphone-case-to-the-supreme-court/",
+    "title": "Apple CEO: We Will Take This iPhone Case to the Supreme Court"
+  },
+  {
+    "url": "http://undergroundreporter.org/fbi-quiet-biometrics-database/",
+    "title": "The Federal Bureau of Investigation (FBI) is attempting to suppress information about a massive database which contains fingerprints, palm prints, iris, voice, and face scans, as well as other biometric data, of millions of Americans."
+  },
+  {
+    "url": "http://fortune.com/2018/11/08/mark-zuckerberg-facebook-reputation/",
+    "title": "Facebook Is the Least Trusted Major Tech Company When it Comes to Safeguarding Personal Data, Poll Finds"
+  },
+  {
+    "url": "http://www.marketwatch.com/story/400-college-professors-say-consumers-should-be-able-to-sue-equifax-and-other-financial-institutions-2017-09-25",
+    "title": "400 college professors say consumers should be able to sue Equifax and other financial institutions - The professors sent a letter to senators protesting mandatory arbitration clauses"
+  },
+  {
+    "url": "https://www.bloombergquint.com/business/2018/09/22/draft-order-for-trump-would-crack-down-on-google-facebook#gs.BHhDros",
+    "title": "The White House has drafted an executive order for President Donald Trump’s signature that would instruct federal antitrust and law enforcement agencies to open investigations into the business practices of Alphabet Inc.’s Google, Facebook Inc. and other social media companies."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20160329/15041234047/71-want-dark-net-shut-down-showing-most-have-no-idea-what-dark-net-is.shtml",
+    "title": "71% Want The Dark Net Shut Down, Showing Most Have No Idea What The Dark Net Is"
+  },
+  {
+    "url": "http://arstechnica.com/tech-policy/2015/03/nypd-caught-red-handed-sanitizing-police-brutality-wikipedia-entries/",
+    "title": "NYPD caught red-handed sanitizing police brutality Wikipedia entries"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/yes-the-fcc-repeal-entered-the-federal-register-today-but-that-does-not-mean-net-neutrality-is-dd149af408e9",
+    "title": "Yes, the FCC repeal entered the Federal Register today, but that does NOT mean net neutrality is dead. We now have 60 legislative days to overrule the FCC using the Congressional Review Act, and there’s a massive online protest planned this Tuesday."
+  },
+  {
+    "url": "https://www.theverge.com/2018/7/5/17535814/uk-face-recognition-police-london-accuracy-completely-comfortable",
+    "title": "London police chief ‘completely comfortable’ using facial recognition with 98 percent false positive rate"
+  },
+  {
+    "url": "https://www.businessinsider.com/ibm-is-reportedly-nearing-a-deal-to-acquire-redhat-the-software-company-valued-at-20-billion-2018-10",
+    "title": "IT'S OFFICIAL: IBM is acquiring software company Red Hat for $34 billion"
+  },
+  {
+    "url": "http://gizmodo.com/the-sony-pictures-hack-exposed-budgets-layoffs-and-3-1665739357/1666122168/+ace",
+    "title": "Sony hack is potentially the worst in history. 100 TB stolen, including unreleased movies & scripts, medical records, 3800 SSNs, etc."
+  },
+  {
+    "url": "http://www.bbc.co.uk/news/world-europe-36423250",
+    "title": "Longest Tunnel in the World Opened Today: 57 km from Switzerland to Italy underneath Alps; Took 17 Years to Build."
+  },
+  {
+    "url": "https://mashable.com/2018/01/24/nsa-core-values-honesty-deleted.amp",
+    "title": "The NSA literally deleted 'trust' and 'honesty' from its core values"
+  },
+  {
+    "url": "http://www.networkworld.com/article/3077932/windows/credibility-and-trust-microsoft-blows-it.html",
+    "title": "Credibility and trust: Microsoft blows it by forcing Windows 10 on users"
+  },
+  {
+    "url": "http://electrek.co/2015/05/28/ford-follow-teslas-lead-and-open-all-their-electric-vehicles-patents/",
+    "title": "Ford follows Tesla’s lead and opens all their electric vehicle patents"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/04/dear-fcc-destroying-net-neutrality-not-restoring-internet-freedom/",
+    "title": "Dear FCC: Destroying net neutrality is not \"Restoring Internet Freedom\""
+  },
+  {
+    "url": "https://www.eff.org/takedowns/sony-finally-admits-it-doesnt-own-bach-and-it-only-took-public-pressure",
+    "title": "Sony Finally Admits It Doesn’t Own Bach and It Only Took Public Pressure"
+  },
+  {
+    "url": "https://finance.yahoo.com/news/apple-fans-returning-macbook-pros-154205304.html",
+    "title": "Apple fans are returning their new MacBook Pros that cost a minimum of $2,800 because they can't reach the advertised speeds"
+  },
+  {
+    "url": "https://www.pcworld.com/article/3284186/mobile/bring-back-the-headphone-jack-why-usb-c-audio-still-doesnt-work.html",
+    "title": "Bring back the headphone jack: Why USB-C audio still doesn't work"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2018/08/08/us_broadband_competition/",
+    "title": "Surprise, surprise. Here comes Big Cable to slay another rule that helps small ISPs compete"
+  },
+  {
+    "url": "http://uk.businessinsider.com/adblock-plus-facebook-blocking-ad-blockers-is-anti-user-2016-8?r=US&IR=T",
+    "title": "Adblock Plus says Facebook's decision to block ad blockers is 'anti-user'"
+  },
+  {
+    "url": "http://thehill.com/blogs/pundits-blog/technology/318788-fcc-should-retain-net-neutrality-for-sake-of-consumers",
+    "title": "FCC should retain net neutrality for sake of consumers"
+  },
+  {
+    "url": "http://www.businessinsider.com.au/reddit-unbanned-russia-magic-mushrooms-germany-watchpeopledie-localised-censorship-2015-8",
+    "title": "Reddit is now censoring posts and communities on a country-by-country basis"
+  },
+  {
+    "url": "http://www.pcworld.com/article/3101396/windows/microsoft-faces-two-new-lawsuits-over-aggressive-windows-10-upgrade-tactics.html",
+    "title": "Microsoft faces two new lawsuits over aggressive Windows 10 upgrade tactics"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/10/ajit-pai-gets-new-term-on-fcc-despite-protest-of-anti-net-neutrality-plan/",
+    "title": "Ajit Pai gets new term on FCC despite protest of anti-net neutrality plan"
+  },
+  {
+    "url": "https://arstechnica.com/apple/2017/05/apple-has-a-record-250-billion-in-the-bank/",
+    "title": "Apple is about to report $250 billion in the bank, keeps 93 percent offshore"
+  },
+  {
+    "url": "http://bgr.com/2014/12/03/comcast-time-warner-cable-merger-opposition/",
+    "title": "Huge coalition forms to kill the Comcast-TWC merger for good"
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/the-switch/wp/2017/11/22/official-says-hes-been-stymied-by-the-fcc-in-investigation-of-fake-net-neutrality-foes/?noredirect=on&utm_term=.172775121c1b",
+    "title": "Investigation of fake net neutrality foes has been stymied by the FCC, New York attorney general says"
+  },
+  {
+    "url": "https://techcrunch.com/2018/09/08/equifax-one-year-later-unscathed/",
+    "title": "A year later, Equifax lost your data but faced little fallout"
+  },
+  {
+    "url": "https://www.bleepingcomputer.com/news/security/ccleaner-compromised-to-distribute-malware-for-almost-a-month/",
+    "title": "CCleaner Compromised to Distribute Malware for Almost a Month"
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/2018/02/23/amazon-google-and-apple-under-pressure-remove-nratv-their-streaming-services/368894002/",
+    "title": "Amazon, Google, Apple under pressure to remove NRA streaming channel"
+  },
+  {
+    "url": "https://www.theverge.com/2018/1/25/16932524/broadband-fcc-committee-san-jose-mayor",
+    "title": "San Jose mayor says he’s quitting FCC broadband committee because Big Telecom is running it."
+  },
+  {
+    "url": "http://www.govtech.com/security/A-Year-After-Data-Breach-Atlanta-Based-Equifax-Unbowed.html",
+    "title": "After a Year, Equifax Remains Largely Unfazed by Historic Breach -- Despite a breach that exposed the personal data of more than 147 million Americans, the company has yet to face a government-imposed financial punishment"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Trump-Could-Spell-Big-Trouble-for-Broadband-Net-Neutrality-138298",
+    "title": "Trump Could Spell Big Trouble for Broadband, Net Neutrality: 'Trump has made it clear he vehemently opposes net neutrality, despite repeatedly making it clear he's not entirely certain what net neutrality even is.'"
+  },
+  {
+    "url": "https://www.engadget.com/2017/03/15/chrome-57-throttle-background-tabs/",
+    "title": "Chrome 57 will throttle background tabs to save energy (Finally...)"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/08/fire-dept-rejects-verizons-customer-support-mistake-excuse-for-throttling/",
+    "title": "Fire dep’t rejects Verizon’s “customer support mistake” excuse for throttling"
+  },
+  {
+    "url": "http://www.businessinsider.com/google-engineer-benson-leung-reviewing-bad-usb-cables-on-amazon-until-he-forced-the-site-to-ban-them-2016-3?r=UK&IR=T",
+    "title": "A Google engineer spent months reviewing bad USB cables on Amazon until he forced the site to ban them"
+  },
+  {
+    "url": "https://electrek.co/2017/06/09/tesla-superchargers-solar-battery-grid-elon-musk/",
+    "title": "Tesla plans to disconnect ‘almost all’ Superchargers from the grid and go solar+battery"
+  },
+  {
+    "url": "http://www.nbcnews.com/meet-the-press/lindsey-graham-ive-never-sent-email-n319571",
+    "title": "U.S. Senator Lindsey Graham, who is currently on the Subcommittee on Privacy, Technology and the Law admits on Meet the Press that he has never sent an email in his life."
+  },
+  {
+    "url": "https://www.theverge.com/2018/8/15/17693834/uber-revenue-loss-earnings-q2-2018",
+    "title": "Uber loses $900 million in second quarter; urged by investors to sell off self-driving division"
+  },
+  {
+    "url": "https://techcrunch.com/2017/02/06/fbi-foia-fax-march-2017/",
+    "title": "FBI will stop taking FOIA (Freedom Of Information Act) Requests by email. Recommends Faxing or sending a letter."
+  },
+  {
+    "url": "http://bgr.com/2015/06/17/net-neutrality-lawsuit-twc-cns/",
+    "title": "Time Warner Cable is About to be Sued for Violating Net Neutrality Rules and Holding Traffic for Ransom"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180919/07473240669/court-orders-fcc-to-hand-over-data-bogus-net-neutrality-comments.shtml",
+    "title": "Court Orders FCC To Hand Over Data On Bogus Net Neutrality Comments"
+  },
+  {
+    "url": "http://exstreamist.com/the-most-common-reason-users-cancel-a-streaming-service-advertisements/?t=t",
+    "title": "Study: Netflix is the least-cancelled of all the major streaming services (Because it doesn't have advertisements)"
+  },
+  {
+    "url": "http://fortune.com/2017/04/01/trump-net-neutrality/",
+    "title": "Trump Sets Sights on Net Neutrality Rules Next, Spicer Says"
+  },
+  {
+    "url": "https://www.usatoday.com/story/tech/talkingtech/2018/12/29/did-apple-retail-prices-get-too-high-2018-consumers-say-way-yes/2432445002/",
+    "title": "Did Apple retail prices get too high in 2018? Consumers say way yes."
+  },
+  {
+    "url": "https://www.theverge.com/2018/11/12/18088846/comcast-nbcuniversal-american-cable-doj-antitrust-investigation-letter-trump-tweet",
+    "title": "Comcast should be investigated for antitrust violations, say small cable companies"
+  },
+  {
+    "url": "https://www.bbc.com/news/uk-46497526",
+    "title": "NHS told to ditch 'absurd' fax machines - The NHS will be banned from buying fax machines from next month - and has been told by the government to phase out the machines entirely by 31 March 2020."
+  },
+  {
+    "url": "http://www.bbc.com/news/technology-36619223",
+    "title": "Google says there was a large spike in searches for Irish passport applications as news broke"
+  },
+  {
+    "url": "http://www.businessinsider.com/google-maps-is-now-wheelchair-friendly-accessible-20-percent-time-employee-project-2016-12?op=1",
+    "title": "A group of Google employees spent their '20% time' making Google Maps wheelchair-friendly"
+  },
+  {
+    "url": "http://gadgets.ndtv.com/laptops/news/lenovo-in-the-news-again-for-installing-spyware-on-its-machines-743952",
+    "title": "Lenovo caught pre-installing spyware on its laptops yet again"
+  },
+  {
+    "url": "http://www.wired.com/2014/09/exercism/",
+    "title": "The Site That Teaches You to Code Well Enough to Get a Job"
+  },
+  {
+    "url": "http://www.theguardian.com/commentisfree/2015/apr/18/congress-cannot-be-taken-seriously-on-cybersecurity",
+    "title": "\"Members of Congress—most of whom can’t secure their own websites, and some of whom don’t even use email—are trying to force a dangerous 'cybersecurity' bill down the public’s throat. Everyone’s privacy is in the hands of people who, by all indications, have no idea what they’re talking about.\""
+  },
+  {
+    "url": "https://www.battleforthenet.com/sept10th/#infographic",
+    "title": "The Internet Slowdown was a huge success! Over 300,000 calls and 2,000,000 e-mails were sent to Congress. Here's an infographic on what happened."
+  },
+  {
+    "url": "http://www.theverge.com/2016/10/25/13410020/apple-annual-revenue-decline-first-2001",
+    "title": "Apple just had its first annual revenue decline since 2001"
+  },
+  {
+    "url": "https://www.androidheadlines.com/2018/07/republican-intros-bill-that-would-turn-net-neutrality-into-law.html",
+    "title": "Republican Intros Bill That Would Turn Net Neutrality Into Law"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/01/new-bill-could-finally-get-rid-of-paperless-voting-machines/",
+    "title": "New bill could finally get rid of paperless voting machines - The bill reads like a computer security expert’s wish list."
+  },
+  {
+    "url": "https://www.fastcompany.com/40551457/heres-how-to-plug-one-of-the-biggest-privacy-holes-in-the-internet",
+    "title": "Here’s How To Plug One Of The Biggest Privacy Holes In The Internet - An upgrade to DNS, the internet’s address book, would make it harder for ISPs to know where you surf, and for hackers to hijack your traffic."
+  },
+  {
+    "url": "https://www.ctvnews.ca/sci-tech/tech-writer-suggests-10-year-challenge-may-be-collecting-data-for-facial-recognition-algorithm-1.4259579",
+    "title": "Tech writer suggests '10 Year Challenge' may be collecting data for facial recognition algorithm"
+  },
+  {
+    "url": "https://arstechnica.com/staff/2017/02/op-ed-mark-zuckerbergs-manifesto-is-a-political-trainwreck/",
+    "title": "Mark Zuckerberg’s manifesto is a political trainwreck: Zuckerberg hopes to create what he calls a \"global community\" by essentially gerrymandering the Internet."
+  },
+  {
+    "url": "https://nakedsecurity.sophos.com/2017/07/05/illinois-poised-to-ban-geolocation-tracking-without-consent/",
+    "title": "Illinois poised to ban geolocation tracking without consent"
+  },
+  {
+    "url": "http://www.theverge.com/2016/9/13/12890050/adblock-plus-now-sells-ads",
+    "title": "Adblock Plus now sells ads"
+  },
+  {
+    "url": "http://uk.businessinsider.com/apple-paying-ireland-16-billion-dollars-back-taxes-2018-4",
+    "title": "Apple will start paying $16 billion in back taxes to Ireland"
+  },
+  {
+    "url": "http://www.nytimes.com/2015/08/16/technology/inside-amazon-wrestling-big-ideas-in-a-bruising-workplace.html",
+    "title": "Amazon employee on relentless working conditions - “Nearly every person I worked with, I saw cry at their desk.”"
+  },
+  {
+    "url": "http://www.wired.co.uk/article/bullshit-jobs-david-graeber-review",
+    "title": "Forget fears of automation, your job is probably bullshit anyway - A subversive new book argues that many of us are working in meaningless “bullshit jobs”. Let automation continue and liberate people through universal basic income"
+  },
+  {
+    "url": "http://motherboard.vice.com/read/court-cops-need-a-warrant-to-open-your-phone-even-just-to-look-at-the-screen",
+    "title": "Court: Cops Need a Warrant to Open Your Phone, Even Just to Look at the Screen"
+  },
+  {
+    "url": "http://thenextweb.com/insider/2016/08/22/comcast-hopes-you-dont-notice-its-twice-as-expensive-in-non-google-fiber-markets/",
+    "title": "Comcast hopes you don’t notice it’s twice as expensive in non-Google Fiber markets"
+  },
+  {
+    "url": "https://electrek.co/2016/11/10/tesla-made-more-money-last-quarter-than-the-entire-us-oil-industry-made-last-year/",
+    "title": "Tesla made more money last quarter than the entire US oil industry made last year"
+  },
+  {
+    "url": "http://www.theverge.com/2016/6/13/11920072/microsoft-linkedin-acquisition-2016",
+    "title": "Microsoft to acquire LinkedIn for $26.2 billion"
+  },
+  {
+    "url": "http://www.redditblog.com/2014/11/time-to-call-fcc-we-are-nearing-home.html?m=1",
+    "title": "If the Reddit admins don't want this on /r/blog, then let's embrace it here. Let's give calling the FCC another go. We are nearing the home stretch for net neutrality at the FCC."
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2018/07/24-people-have-now-been-sentenced-in-india-based-phone-scam-case/",
+    "title": "24 people have now been sentenced in India-based phone-scam case"
+  },
+  {
+    "url": "https://medium.com/@chris_urmson/the-view-from-the-front-seat-of-the-google-self-driving-car-chapter-2-8d5e2990101b",
+    "title": "Google: \"Our self-driving cars are being hit surprisingly often by other drivers who are distracted and not paying attention to the road.\""
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2017/06/attack-net-neutrality-attack-free-speech",
+    "title": "An Attack on Net Neutrality Is an Attack on Free Speech"
+  },
+  {
+    "url": "http://www.overclock3d.net/articles/misc_hardware/netflix_wants_to_make_neflix_global/1",
+    "title": "Netflix plans to create Netflix global, removing geo-blocking and allowing all customers access to all content. \"The key thing about piracy is that some fraction of it is because [users] couldn’t get the content. That part we can fix\""
+  },
+  {
+    "url": "http://arstechnica.com/tech-policy/2016/12/fcc-republicans-vow-to-gut-net-neutrality-rules-as-soon-as-possible/",
+    "title": "FCC Republicans vow to gut net neutrality rules “as soon as possible”"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/01/sen-franken-asks-att-to-prove-time-warner-merger-is-good-for-customers/",
+    "title": "Sen. Franken asks AT&T to prove Time Warner merger is good for customers"
+  },
+  {
+    "url": "https://www.digitaltrends.com/cool-tech/space-elon-musk-fcc-approval/",
+    "title": "Elon Musk receives FCC approval to launch over 7,500 satellites into space"
+  },
+  {
+    "url": "http://www.dailydot.com/technology/hola-vpn-security/?tw=dd",
+    "title": "Stop using the Hola VPN right now. The company behind Hola is turning your computer into a node on a botnet, and selling your network to anyone who is willing to pay."
+  },
+  {
+    "url": "https://www.thenation.com/article/net-neutrality-is-in-danger-tell-the-fcc-why-we-need-it/",
+    "title": "Net Neutrality Is in Danger. Tell the FCC Why We Need It"
+  },
+  {
+    "url": "https://arstechnica.com/?post_type=post&p=1126243",
+    "title": "Tom Wheeler defends Title II rules, accuses Pai of helping monopolists"
+  },
+  {
+    "url": "https://techcrunch.com/2017/04/04/apple-pushes-the-reset-button-on-the-mac-pro/",
+    "title": "In an extremely rare move, Apple admits its current mac pro design was a mistake. Reveals they are working on a fully modular Mac Pro, to be released next year."
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2018/jun/09/human-cost-kindle-amazon-china-foxconn-jeff-bezos",
+    "title": "Underpaid and exhausted: the human cost of your Kindle - In the Chinese city of Hengyang, we find a fatigued, disposable workforce assembling gadgets for Amazon, owned by the world’s richest man."
+  },
+  {
+    "url": "https://gizmodo.com/at-ts-estimated-payment-to-trumps-lawyer-rises-to-600-1825901783?IR=T",
+    "title": "AT&T's Estimated Payment to Trump's Lawyer Rises to $600,000 as Investigations Ramp Up"
+  },
+  {
+    "url": "https://www.androidpolice.com/2018/02/12/verizon-stop-honoring-fcc-restriction-not-sim-locking-phones-nothing-matters-anymore/",
+    "title": "Verizon to stop honoring FCC restriction on not SIM-locking phones because nothing matters anymore"
+  },
+  {
+    "url": "http://recode.net/2015/01/28/ftc-says-unlimited-data-with-throttling-doesnt-count-as-unlimited/",
+    "title": "FTC Says Unlimited Data With Throttling Doesn’t Count as Unlimited"
+  },
+  {
+    "url": "http://www.zdnet.com/article/amazon-the-least-transparent-tech-company/",
+    "title": "Amazon won't say if it hands your Echo data to the government - The retail, cloud, and device giant stands as the least transparent of transparent tech companies."
+  },
+  {
+    "url": "http://qz.com/628761/the-irs-is-using-a-system-that-was-hacked-to-protect-victims-of-a-hack-and-it-was-just-hacked/",
+    "title": "The IRS is using the same authentication system that was hacked last year to protect the victims of that hack--and it's just been hacked"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/05/senators-ask-fcc-why-reporter-was-manhandled-after-net-neutrality-vote/",
+    "title": "Senators ask FCC why reporter was “manhandled” after net neutrality vote"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2018/08/after-patent-office-rejection-it-time-google-abandon-its-attempt-patent-use-public",
+    "title": "Google is trying to patent use of a data compression algorithm that the real inventor had already dedicated to the public domain. This week, the U.S. Patent Office issued a non-final rejection of all claims in Google’s application."
+  },
+  {
+    "url": "https://techcrunch.com/2018/03/19/deletefacebook/",
+    "title": "#deletefacebook"
+  },
+  {
+    "url": "https://www.hongkongfp.com/2017/06/08/china-uncovers-massive-underground-network-apple-employees-selling-customers-personal-data/",
+    "title": "China uncovers massive underground network of Apple employees selling customers' personal data"
+  },
+  {
+    "url": "https://cleantechnica.com/2018/08/06/analysis-reveals-that-worlds-largest-battery-saves-south-australia-8-9-million-in-6-months/",
+    "title": "Analysis Reveals That World’s Largest Battery Saved South Australia $8.9 Million In 6 Months"
+  },
+  {
+    "url": "http://www.miaminewtimes.com/news/fcc-fines-miami-man-120-million-for-making-96-million-robocalls-in-three-months-9440277",
+    "title": "Miami Man Fined $120 Million for Making 96 Million Robocalls in Three Months"
+  },
+  {
+    "url": "https://thewire.in/90591/governments-shut-down-internet-50-times-2016/",
+    "title": "Governments around the world shut down the internet more than 50 times in 2016 – suppressing elections, slowing economies and limiting free speech"
+  },
+  {
+    "url": "https://www.forbes.com/sites/trevornace/2018/09/10/the-worlds-largest-ocean-cleanup-has-officially-begun/#4a34ac582738",
+    "title": "The World's Largest Ocean Cleanup Has Officially Begun"
+  },
+  {
+    "url": "http://www.businessinsider.com/google-sued-discriminating-white-asian-men-2018-3?r=UK&IR=T",
+    "title": "An ex-YouTube recruiter claims Google discriminated against white and Asian men, then deleted the evidence"
+  },
+  {
+    "url": "https://www.businessinsider.com/video-games-may-increase-your-brains-gray-matter-2018-12/?r=AU&IR=T",
+    "title": "Playing video games may increase your brain's gray matter and improve how it communicates"
+  },
+  {
+    "url": "https://www.seattletimes.com/business/bitcoin-backlash-as-miners-suck-up-electricity-stress-power-grids-in-central-washington/",
+    "title": "Bitcoin backlash as ‘miners’ suck up electricity, stress power grids in Central Washington"
+  },
+  {
+    "url": "https://gizmodo.com/report-equifax-lost-even-more-information-on-consumers-1822898461",
+    "title": "Report: Equifax lost even more information on consumers than it told the public."
+  },
+  {
+    "url": "http://www.independent.co.uk/news/people/elon-musk-universal-income-robots-ai-tesla-spacex-a7402556.html",
+    "title": "Elon Musk says people should receive a universal income once robots take their jobs: 'People will have time to do other things, more complex things, more interesting things'"
+  },
+  {
+    "url": "http://arstechnica.com/business/2016/03/isps-should-be-required-to-let-customers-cancel-online-lawmaker-says",
+    "title": "Proposed legislation in California would require Internet service providers to let customers cancel online, potentially ending the scourge of long, awkward cancellation phone calls."
+  },
+  {
+    "url": "http://www.wsj.com/articles/paris-attacks-plot-was-hatched-in-plain-sight-1448587309",
+    "title": "Paris attackers used real names, real IDs, and unencrypted, simple messaging to make plans."
+  },
+  {
+    "url": "http://www.broadcastingcable.com/news/fates-and-fortunes/wyden-slams-pai-senate-floor/168973",
+    "title": "Sen. Wyden Slams Pai on Senate Floor - Says FCC chair is on side of 'big cable'"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/04/03/fcc-commissioner-slams-her-own-agency-policies-custom-built-favor-sinclair-tribune",
+    "title": "FCC Commissioner Slams Her Own Agency for Policies 'Custom-Built' to Favor Sinclair-Tribune Merger"
+  },
+  {
+    "url": "https://www.newstatesman.com/science-tech/social-media/2018/05/facebook-s-answer-privacy-concerns-dating-site",
+    "title": "\"Facebook decided that the best thing to do after the Cambridge Analytica scandal was to ask its users to hand over access to their humiliating pick-up lines, their sexual fetishes, and, inevitably, their nudes.\""
+  },
+  {
+    "url": "http://www.statepress.com/article/2017/03/spopinion-why-ending-net-neutrality-would-be-disastrous",
+    "title": "Ending net neutrality would be disastrous for everyone"
+  },
+  {
+    "url": "https://www.androidheadlines.com/2018/07/fftf-calls-for-net-neutrality-reversal-due-to-fake-comments.html",
+    "title": "FFTF Calls For Net Neutrality Reversal Due To Fake Comments"
+  },
+  {
+    "url": "http://wgntv.com/2016/10/11/comcast-hit-with-fccs-biggest-cable-fine-ever/",
+    "title": "Comcast fined $2.3 million for mischarging customers"
+  },
+  {
+    "url": "https://gizmodo.com/new-york-attorney-general-subpoenas-industry-groups-lo-1829800862",
+    "title": "New York Attorney General Subpoenas Industry Groups, Lobbyists Over Fake Net Neutrality Comments"
+  },
+  {
+    "url": "https://arstechnica.com/apple/2017/01/apple-international-business-ireland-luxembourg/",
+    "title": "Apple will move its entire international iTunes business to Ireland. International HQ will move from one tax haven to another."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20160114/06532833339/56-would-drop-espn-heartbeat-if-it-meant-saving-8-month-cable.shtml",
+    "title": "56% Would Drop ESPN In A Heartbeat If It Meant Saving $8 A Month On Cable"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/shortcuts/2017/sep/19/apple-crumbles-cookies-but-there-is-more-to-come-in-the-online-advertising-arms-race",
+    "title": "Apple cuts cookies – but there is more to come in the online advertising arms race: Apple’s latest software update has enraged companies who have been using cookies to track users across the web"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170614/07270337586/wall-street-still-annoyed-that-competition-forced-wireless-carriers-to-bring-back-unlimited-data-plans.shtml",
+    "title": "Wall Street Still Annoyed That Competition Forced Wireless Carriers To Bring Back Unlimited Data Plans"
+  },
+  {
+    "url": "https://www.reddit.com/r/Vive/comments/4nxpnq/fuck_facebook_and_fuck_oculus/d480x6v?context=3",
+    "title": "Facebook finally caught buying out developers for Oculus Exclusivity, despite claims to the contrary"
+  },
+  {
+    "url": "https://www.androidauthority.com/verizon-att-selling-information-807684/",
+    "title": "Verizon and AT&T accused of selling your phone number and location to almost anyone"
+  },
+  {
+    "url": "https://www.polygon.com/2017/2/9/14548880/time-warner-lawsuit-new-york-league-of-legends-netflix",
+    "title": "Time Warner Cable sued by New York on behalf of League of Legends, Netflix customers"
+  },
+  {
+    "url": "http://www.bbc.com/future/story/20161207-the-first-pirate-politician-in-power",
+    "title": "The first pirate politician in power - many Icelandic voters have rallied around a radical, technology-focused left-wing party that champions political transparency, free health care and new measures to protect digital privacy."
+  },
+  {
+    "url": "http://www.redmondpie.com/firm-that-helped-fbi-break-into-san-bernardino-iphone-gets-hacked-tools-leaked-online/",
+    "title": "Firm That Helped FBI Break Into San Bernardino iPhone Gets Hacked, Tools Leaked Online"
+  },
+  {
+    "url": "http://www.businessinsider.com/tesla-lawsuit-oil-executive-impersonated-elon-musk-2016-9",
+    "title": "Tesla sues oil executive who impersonated Elon Musk to get info from the company."
+  },
+  {
+    "url": "https://www.extremetech.com/computing/245553-microsoft-now-puts-ads-windows-file-explorer",
+    "title": "Microsoft now puts ads in Windows 10 File Explorer, because of course"
+  },
+  {
+    "url": "http://motherboard.vice.com/read/orlando-shooting-response-shows-reddit-cant-be-the-front-page-of-the-internet?utm_source=vicefbus",
+    "title": "Orlando Shooting Response Shows Reddit Can't Be the ‘Front Page of the Internet'"
+  },
+  {
+    "url": "http://mashable.com/2015/03/02/google-confirms-wireless-carrier-service/",
+    "title": "Google confirms it wants to be a wireless carrier."
+  },
+  {
+    "url": "https://fossbytes.com/tenn-hacked-apple-servers-australia/",
+    "title": "A 16-Year-Old Hacked Apple Servers And Stored Data In Folder Named 'hacky hack hack'"
+  },
+  {
+    "url": "https://www.techtimes.com/articles/236834/20181227/fake-alexa-setup-app-ios-climbs-apples-store-charts.htm",
+    "title": "Fake Amazon Alexa Setup App Climbs Its Way To Apple's App Store Charts"
+  },
+  {
+    "url": "http://news.abs-cbn.com/overseas/08/05/18/bangladesh-shuts-down-mobile-internet-to-tackle-teen-protests",
+    "title": "Bangladesh shuts down mobile internet to tackle teen protests"
+  },
+  {
+    "url": "https://www.recode.net/2017/11/11/16619956/president-donald-trump-science-technology-open-jobs-federal-goverment-nominees",
+    "title": "One year after President Trump’s election, these 11 science and tech posts in government are still lacking leaders. Some of the jobs — like overseeing self-driving cars — have no nominees at all."
+  },
+  {
+    "url": "http://fortune.com/2018/01/19/uk-france-net-neutrality-us/",
+    "title": "The U.K. and France Are Thumbing Their Noses at the U.S. Over Net Neutrality Repeal - ‘the U.K. and France said Friday: “... we wish to restate our commitment and support for the principle of net neutrality, which promotes a free and open internet.”’"
+  },
+  {
+    "url": "http://www.theguardian.com/media/2014/sep/03/netflix-petitions-fcc-high-speed-internet-services",
+    "title": "Netflix pushes FCC to scrap rules blocking cities from building their own high-speed internet services"
+  },
+  {
+    "url": "http://electrek.co/2016/06/06/tesla-model-x-crash-not-at-fault/",
+    "title": "Tesla logs show that Model X driver hit the accelerator, Autopilot didn’t crash into building on its own"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/a33j5a/a-redditor-archived-nearly-2-million-gigabytes-of-porn-to-test-amazons-unlimited-cloud-storage",
+    "title": "A Redditor Archived Nearly 2 Million Gigabytes of Porn to Test Amazon’s ‘Unlimited’ Cloud Storage"
+  },
+  {
+    "url": "http://www.theguardian.com/commentisfree/2014/dec/24/sony-threat-free-speech-north-korea-the-interview",
+    "title": "Before praising Sony for \"free speech\" remember for the past two weeks they've attempted to censor Twitter, threatened journalists reporting on public info, and secretly planned to use state governments to block all sorts of websites."
+  },
+  {
+    "url": "http://nymag.com/selectall/2018/04/richard-stallman-rms-on-privacy-data-and-free-software.html",
+    "title": "‘No Company Is So Important Its Existence Justifies Setting Up a Police State’"
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2017/jul/07/elon-musks-big-battery-brings-reality-crashing-into-a-post-truth-world",
+    "title": "Elon Musk's big battery brings reality crashing into a post-truth world. For months, politicians and fossil fuel industry have lied about the viability of renewables. Now Tesla’s big battery in South Australia will prove them wrong."
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2018/may/11/facebook-class-action-lawsuit-collection-texts-call-logs",
+    "title": "Facebook hit with class action lawsuit over collection of texts and call logs - Plaintiffs claim social network’s ‘scraping’ of information including call recipients and duration violates privacy and competition law"
+  },
+  {
+    "url": "https://slate.com/technology/2018/06/ajit-pais-argument-for-repealing-net-neutrality-is-orwellian-and-wrong.html",
+    "title": "Ajit Pai Is Twisting the Meaning of the “Open Internet” - Don’t be fooled by the FCC chairman’s Orwellian argument justifying the repeal of net neutrality."
+  },
+  {
+    "url": "http://www.theguardian.com/commentisfree/2015/nov/17/intelligence-agencies-pounce-paris-attacks-pursue-spy-agenda",
+    "title": "\"Officials are wasting no time in attempting to exploit the tragedy in Paris to pass invasive anti-privacy laws and acquire extraordinary new powers that they have wanted for years. In the process, they are making incredibly dishonest arguments & are receiving virtually no pushback from the media.\""
+  },
+  {
+    "url": "https://qz.com/945261/how-to-get-a-personal-vpn-and-why-you-need-one-now/",
+    "title": "Set up a VPN in 10 minutes for free—and yes, Americans urgently need one, thanks to Congress"
+  },
+  {
+    "url": "https://www.recode.net/2018/2/12/16998750/facebooks-teen-users-decline-instagram-snap-emarketer",
+    "title": "Facebook lost around 2.8 million U.S. users under 25 last year. 2018 won’t be much better."
+  },
+  {
+    "url": "http://www.bbc.com/news/world-africa-38922819#share-tools",
+    "title": "The first African winner in Google's annual coding competition is a Cameroonian kid who had to travel 370km from home, because the government has cut off his hometown from the internet"
+  },
+  {
+    "url": "https://torrentfreak.com/pirate-bay-founder-finally-free-after-three-years-150928/",
+    "title": "Pirate Bay Founder Finally Free After Three Years"
+  },
+  {
+    "url": "https://www.recode.net/2019/1/10/18175869/susan-crawford-fiber-book-internet-access-comcast-verizon-google-peter-kafka-media-podcast",
+    "title": "America desperately needs fiber internet, and the tech giants won’t save us - Harvard’s Susan Crawford explains why we shouldn’t expect Google to fix slow internet speeds in the US."
+  },
+  {
+    "url": "https://www.theverge.com/2018/10/24/18020746/president-donald-trump-iphone-personal-calls-china-russia-spies-eavesdropping",
+    "title": "Trump reportedly still uses an unsecured iPhone, and China and Russia are listening in"
+  },
+  {
+    "url": "https://www.scribblrs.com/facebook-users-becoming-less-satisfied-new-research-shows/",
+    "title": "Facebook Users Becoming Less Satisfied and Using the Service Less; \"People are tired of being bombarded with political posts from their friends and the pages they follow\""
+  },
+  {
+    "url": "http://motherboard.vice.com/read/the-fcc-says-your-city-can-build-a-public-internet-even-if-your-state-says-no",
+    "title": "The FCC Says Your City Can Build a Public Internet, Even If Your State Says No"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/a3yadk/apple-sued-an-independent-iphone-repair-shop-owner-and-lost",
+    "title": "Apple Sued an Independent iPhone Repair Shop Owner from Norway and Lost"
+  },
+  {
+    "url": "http://www.spacex.com/webcast/",
+    "title": "SpaceX successfully lands Falcon 9 booster for the first time, paving the road for reusable rockets"
+  },
+  {
+    "url": "http://www.livetrucking.com/self-driving-semi-truck-just-made-first-cross-country-trip/",
+    "title": "A self-driving semi truck just made its first cross-country trip"
+  },
+  {
+    "url": "http://www.washingtonpost.com/blogs/the-switch/wp/2014/09/19/world-wide-web-inventor-lashes-out-at-internet-fast-lanes-its-bribery/?tid=rssfeed",
+    "title": "World Wide Web inventor lashes out at Internet fast lanes: ‘It’s bribery.’ \"Berners-Lee said that system is now in danger from ISPs who stand to amass too much power over what was intentionally built as a decentralized network — one where no single actor could dictate outcomes to everyone else.\""
+  },
+  {
+    "url": "http://www.washingtonpost.com/blogs/the-switch/wp/2014/11/18/john-hodgman-the-government-should-be-laying-down-broadband-like-eisenhower-laid-down-interstates/?tid=rssfeed",
+    "title": "John Hodgman: ‘The government should be laying down broadband like Eisenhower laid down interstates. And I believe preferential fast-laning for big companies will decrease competition and quality ...\""
+  },
+  {
+    "url": "https://www.thedailybeast.com/exclusive-lone-dnc-hacker-guccifer-20-slipped-up-and-revealed-he-was-a-russian-intelligence-officer",
+    "title": "‘Lone DNC Hacker’ Guccifer 2.0 Slipped Up and Revealed He Was a Russian Intelligence Officer"
+  },
+  {
+    "url": "https://www.theguardian.com/world/2016/nov/14/china-threatens-to-cut-sales-of-iphones-and-us-cars-if-naive-trump-pursues-trade-war?utm_source=dlvr.it&utm_medium=twitter",
+    "title": "China threatens to cut sales of iPhones and US cars if 'naive' Trump pursues trade war"
+  },
+  {
+    "url": "https://www.theverge.com/2018/3/28/17171470/playboy-leaves-facebook",
+    "title": "Playboy deletes its Facebook accounts"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/yw9qk7/macbook-pro-software-locks-prevent-independent-repair",
+    "title": "Apple's New Proprietary Software Locks Kill Independent Repair on New MacBook Pros - Failure to run Apple's proprietary diagnostic software after a repair \"will result in an inoperative system and an incomplete repair.\""
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170523/13491237437/if-net-neutrality-dies-comcast-can-just-block-protest-site-instead-sending-bogus-cease-and-desist.shtml",
+    "title": "f Net Neutrality Dies, Comcast Can Just Block A Protest Site Instead Of Sending A Bogus Cease-And-Desist"
+  },
+  {
+    "url": "https://www.zdnet.com/article/after-microsoft-complaints-indian-police-arrest-tech-support-scammers-at-26-call-centers/",
+    "title": "After Microsoft complaints, Indian police arrest tech support scammers at 26 call centers"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/06/18/apple-will-automatically-share-emergency-location-with-911-in-ios-12.html",
+    "title": "Apple will automatically share a user's location with emergency services when they call 911"
+  },
+  {
+    "url": "http://motherboard.vice.com/read/the-gop-is-trying-to-nuke-net-neutrality-with-a-budget-bill-sneak-attack",
+    "title": "The GOP Is Trying to Nuke Net Neutrality With a Budget Bill Sneak Attack"
+  },
+  {
+    "url": "http://news.sky.com/story/1412846/googles-record-spend-to-keep-net-neutral",
+    "title": "Google has spent a record amount on Washington lobbyists as it pushes to maintain net neutrality."
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2017/nov/13/sending-in-our-nude-photos-to-fight-revenge-porn-no-thanks-facebook",
+    "title": "Sending in our nude photos to fight revenge porn? No thanks, Facebook. Rather than trusting a private corporation, let’s just enforce existing laws supposed to protect us from harassment and abuse – in person or online"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/09/us-cell-carriers-still-selling-your-location-data/",
+    "title": "Despite promises to stop, US cell carriers are still selling your real-time phone location data"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/07/02/over-800-cryptocurrencies-are-now-dead-as-bitcoin-feels-pressure.html",
+    "title": "Over 800 cryptocurrencies are now dead as bitcoin is 70 percent off its record high"
+  },
+  {
+    "url": "https://www.courthousenews.com/democrats-close-to-forcing-vote-on-net-neutrality/",
+    "title": "Democrats Close to Forcing Vote on Net Neutrality"
+  },
+  {
+    "url": "http://www.vox.com/2016/6/9/11898512/multiple-sclerosis-stem-cell-chemo",
+    "title": "This isn’t hype: Canadian doctors just reversed severe MS using stem cells"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20150424/14443230784/president-obama-demands-critics-tell-him-whats-wrong-with-tpp-course-we-cant-do-that-because-he-wont-show-us-agreement.shtml",
+    "title": "President Obama Demands Critics Tell Him What's Wrong With TPP; Of Course We Can't Do That Because He Won't Show Us The Agreement"
+  },
+  {
+    "url": "https://www.nbcnews.com/think/opinion/mark-zuckerberg-wanted-facebook-change-world-it-has-not-better-ncna897701",
+    "title": "Mark Zuckerberg wanted Facebook to change the world. And it has — but not for the better: Facebook, Twitter and Google’s YouTube have become the digital arms dealers of the modern age."
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/at-t-funded-democrats-in-california-just-eviscerated-the-best-net-neutrality-bill-in-the-country-1e90defb5086",
+    "title": "AT&T funded democrats in California just “eviscerated” the best net neutrality bill in the country"
+  },
+  {
+    "url": "http://motorcitymuckraker.com/2015/10/09/more-than-10000-problems-fixed-through-improve-detroit-cell-phone-app/",
+    "title": "More than 10,000 problems fixed through ‘Improve Detroit’ cell phone app -- \"allows users to easily alert city hall to potholes, illegal dumping sites, abandoned cars, water main breaks, busted traffic signals and broken hydrants\""
+  },
+  {
+    "url": "https://techcrunch.com/2018/10/31/united-states-drops-internet-freedoms-fake-news-net-neutrality/",
+    "title": "U.S. declines in internet freedom rankings, thanks to net neutrality repeal and fake news"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Comcast-Sued-For-Misleading-Hidden-Fees-138136",
+    "title": "Comcast Sued For Misleading, Hidden Fees"
+  },
+  {
+    "url": "https://www.privateinternetaccess.com/blog/2017/05/today-fcc-votes-fate-net-neutrality/",
+    "title": "Today, the FCC votes on the fate of net neutrality"
+  },
+  {
+    "url": "http://torrentfreak.com/bittorrent-anonymous-and-impossible-to-shut-down-141218/",
+    "title": "Researchers Make BitTorrent Anonymous and Impossible to Shut Down"
+  },
+  {
+    "url": "https://www.businessinsider.com/apple-iphone-xs-and-xr-mainstream-consumers-2018-9",
+    "title": "Apple's $1,000 iPhones are turning it into a luxury brand — and it could lose a whole generation of customers"
+  },
+  {
+    "url": "http://www.businessinsider.com/google-merrill-lynch-and-the-right-to-be-forgotten-2014-7",
+    "title": "Google was required to delete a link to a factually accurate BBC article about Stan O'Neal, the former CEO of Merrill Lynch."
+  },
+  {
+    "url": "http://news.softpedia.com/news/Youtube-Says-Goodbye-to-Flash-HTML5-Is-Now-Default-471426.shtml",
+    "title": "YouTube Says Goodbye to Flash, HTML5 Is Now Default"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2014/07/act-immediately-stop-congresss-sneaky-move-shut-down-broadband-competition",
+    "title": "Act Immediately to Stop Congress’s Sneaky Move to Shut Down Broadband Competition (X-Post /r/news)"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/no-net-neutrality-is-not-officially-dead-today-b6f133075c13",
+    "title": "No, net neutrality is not “officially dead,” today. The FCC repeal has not yet gone into effect. The senate will vote soon on whether to block the repeal. Now’s the time to pay attention!"
+  },
+  {
+    "url": "http://finance.yahoo.com/news/more-software-engineers-over-age-195308179.html",
+    "title": "Google sued over refusing to employ engineers over 40 years of age"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/GOP-Pushing-Bill-That-Guts-FCC-Authority-Kills-Net-Neutrality-137060",
+    "title": "GOP Pushing Bill That Guts FCC Authority, Kills Net Neutrality"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180104/09234138930/colorado-cities-keep-voting-to-build-their-own-broadband-networks.shtml",
+    "title": "Colorado Cities Keep Voting To Build Their Own Broadband Networks"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/wj793y/ajit-pai-net-neutrality-repeal-not-official-yet",
+    "title": "Ajit Pai Is Intentionally Delaying His Net Neutrality Repeal and No One Knows Why"
+  },
+  {
+    "url": "http://www.theverge.com/2016/3/10/11196548/apple-accuses-department-of-justice-fbi-smearing-desperation",
+    "title": "Apple attorney: \"I can only conclude that the DoJ is so desperate at this point that it has thrown all decorum to the winds... Everyone should beware, because it seems like disagreeing with the Department of Justice means you must be evil and anti-American. Nothing could be further from the truth.\""
+  },
+  {
+    "url": "http://www.slate.com/articles/technology/bitwise/2015/02/lenovo_superfish_scandal_why_it_s_one_of_the_worst_consumer_computing_screw.html",
+    "title": "Lenovo committed one of the worst consumer betrayals ever made"
+  },
+  {
+    "url": "http://gizmodo.com/fcc-now-says-there-is-no-documented-analysis-of-the-cyb-1797073113",
+    "title": "FCC Now Says There Is No Documented 'Analysis' of the Cyberattack It Claims Crippled Its Website in May"
+  },
+  {
+    "url": "https://consumerist.com/2016/03/16/comcast-att-lobbyists-help-kill-community-broadband-expansion-in-tennessee/",
+    "title": "Comcast, AT&T Lobbyists Help Kill Community Broadband Expansion In Tennessee"
+  },
+  {
+    "url": "https://theintercept.com/2017/12/15/fcc-net-neutrality-public-broadband-seattle/",
+    "title": "Killing Net Neutrality Has Brought On a New Call For Public Broadband"
+  },
+  {
+    "url": "https://theintercept.com/2017/05/02/nypd-refuses-to-disclose-information-about-its-face-recognition-program-so-privacy-researchers-are-suing/",
+    "title": "NYPD Refuses to Disclose Information About Its Face Recognition Program, So Privacy Researchers Are Suing"
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/grade-point/wp/2016/06/15/college-courses-without-textbooks-these-schools-are-giving-it-a-shot/",
+    "title": "open-source materials in place of textbooks, an initiative that could save students as much as $1,300 a year. Such open educational resources—created using open licenses that let students download or print materials for free—have gained popularity as the price of print textbooks have skyrocketed"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2017/sep/27/pirate-bay-showtime-ads-websites-electricity-pay-bills-cryptocurrency-bitcoin?CMP=twt_gu",
+    "title": "Ads don't work so websites are using your electricity to pay the bills: Pirate Bay and Showtime turned to forcing unknowing visitors to mine cryptocurrency, using computers rather than eyeballs on ads to generate money"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/11/sorry-poor-people-the-fcc-is-coming-after-your-broadband-plans/",
+    "title": "Sorry, poor people: The FCC is coming after your broadband plans -- 70% of low-income wireless subscribers in Lifeline could have to find new ISPs"
+  },
+  {
+    "url": "https://fair.org/home/the-fcc-chair-is-outright-lying-to-reporters-and-congress/",
+    "title": "‘The FCC Chair Is Outright Lying to Reporters and Congress’"
+  },
+  {
+    "url": "https://www.commondreams.org/news/2018/06/04/sure-looks-zuckerberg-lied-congress-about-user-privacy-new-facebook-data-sharing",
+    "title": "'Sure Looks Like Zuckerberg Lied' to Congress About User Privacy, As New Facebook Data-Sharing Deals Come to Light"
+  },
+  {
+    "url": "https://www.theguardian.com/uk-news/2018/mar/23/leaked-cambridge-analyticas-blueprint-for-trump-victory?CMP=Share_iOSApp_Other",
+    "title": "Leaked: Cambridge Analytica's blueprint for Trump victory | UK news | The Guardian"
+  },
+  {
+    "url": "http://www.slate.com/blogs/future_tense/2015/04/10/florida_middle_schooler_arrested_charged_with_hacking_cybercrimes.html",
+    "title": "Eighth-Grader Arrested, Charged With Cybercrimes For Changing Teacher's Desktop Wallpaper"
+  },
+  {
+    "url": "http://hothardware.com/News/Enraged-Verizon-FiOS-Customer-Posts-Video-Seemingly-Proving-ISP-Throttles-Netflix/",
+    "title": "Enraged Verizon FiOS customer posts video seemingly proving ISP throttles Netflix; video streams 10x faster through a VPN than directly."
+  },
+  {
+    "url": "http://www.cbc.ca/news/business/tvaddons-piracy-rogers-bell-videotron-court-1.4231340",
+    "title": "Cable giants step up piracy battle by interrogating Montreal software developer and searching his home"
+  },
+  {
+    "url": "https://www.fastcompany.com/40510095/snubbing-fcc-states-are-writing-their-own-net-neutrality-laws",
+    "title": "Snubbing FCC, States Are Writing Their Own Net Neutrality Laws - California, New York, Washington, and likely more states are challenging both internet providers and the reach of the federal government."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180903/09561940575/after-nabbing-billions-tax-breaks-ats-promised-job-growth-magically-evaporates.shtml",
+    "title": "After Nabbing Billions In Tax Breaks, AT&T's Promised Job Growth Magically Evaporates"
+  },
+  {
+    "url": "http://nymag.com/intelligencer/2018/04/dan-mccomas-reddit-product-svp-and-imzy-founder-interview.html",
+    "title": "Former Reddit product head Dan McComas: 'I Fundamentally Believe That My Time at Reddit Made the World a Worse Place'"
+  },
+  {
+    "url": "http://arstechnica.com/tech-policy/2016/11/adblock-plus-wins-its-6th-court-case-brought-by-der-spiegel/?comments=1",
+    "title": "Adblock Plus wins its 6th court case trying to shut them down"
+  },
+  {
+    "url": "http://bgr.com/2014/10/15/hbo-online-streaming-service-launch/",
+    "title": "HBO will fulfill cord cutters’ dreams and launch a standalone streaming service next year"
+  },
+  {
+    "url": "http://www.nbcnews.com/tech/tech-news/fbi-can-t-force-apple-new-york-iphone-case-judge-n528446?cid=sm_tw&hootPostID=62e8ba65b2509e6191a213c775f8f628",
+    "title": "Apple Doesn't Have to Help FBI in New York iPhone Case, Judge Says"
+  },
+  {
+    "url": "https://www.inverse.com/article/34239-how-many-solar-panels-to-power-the-usa",
+    "title": "Here's Elon Musk's Plan to Power the USA on Solar Energy: \"you only need about 100 miles by 100 miles of solar panels to power the entire United States\""
+  },
+  {
+    "url": "https://www.cultofmac.com/585868/apple-bars-bloomberg-from-ipad-event-as-payback-for-spy-chip-story/",
+    "title": "Apple bars Bloomberg from iPad event as payback for spy chip story"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170413/11293537144/new-survey-most-millennials-both-pay-streaming-services-use-pirate-streams-when-content-isnt-legally-available.shtml",
+    "title": "New Survey: Most Millennials Both Pay For Streaming Services And Use Pirate Streams When Content Isn't Legally Available"
+  },
+  {
+    "url": "http://www.theverge.com/2016/2/23/11098592/bill-gates-fbi-apple-comments",
+    "title": "Bill Gates says he was 'disappointed' by reports he backs FBI in Apple fight"
+  },
+  {
+    "url": "https://www.pcmag.com/news/364132/california-law-bans-bots-from-pretending-to-be-human",
+    "title": "California Law Bans Bots From Pretending to Be Human - Effective July 1, it will be illegal for bots interacting with California consumers to pretend they're human if they're trying to sell goods, services, or to 'influence a vote in an election.'"
+  },
+  {
+    "url": "http://www.techradar.com/us/news/software/operating-systems/windows-xp-still-the-third-most-popular-os-two-years-after-end-of-life-1318572",
+    "title": "Windows XP is still the third most popular OS 2 years after end-of-life and 15 1/2 years after it was introduced."
+  },
+  {
+    "url": "http://www.ibtimes.co.uk/netflix-once-loved-talking-about-net-neutrality-so-why-has-it-suddenly-gone-quiet-1656260",
+    "title": "Netflix once loved talking about net neutrality - so why has it suddenly gone quiet?"
+  },
+  {
+    "url": "https://www.engadget.com/2017/01/09/report-fbi-arrests-volkswagen-executive-over-dieselgate/?sr_source=Twitter",
+    "title": "FBI arrests Volkswagen executive over Dieselgate"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170217/15584936738/federal-bill-introduced-to-add-warrant-requirement-to-stingray-deployment.shtml",
+    "title": "Federal Bill Introduced To Add A Warrant Requirement To Stingray Deployment"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Claims-That-Net-Neutrality-Hurt-Broadband-Investment-Are-Crap-140454",
+    "title": "Claims That Net Neutrality Hurt Broadband Investment Are Crap"
+  },
+  {
+    "url": "https://www.theverge.com/2017/6/12/15768920/police-body-camera-state-secret",
+    "title": "Police body camera footage is becoming a state secret - North Carolina, Louisiana, Kansas, and other states are writing laws to keep police videos out of public hands"
+  },
+  {
+    "url": "https://fight215.org/",
+    "title": "Fight 215: Call Congress now and urge them to end mass surveillance under the Patriot Act"
+  },
+  {
+    "url": "https://www.extremetech.com/computing/241587-microsoft-finally-admits-malware-style-get-windows-10-upgrade-campaign-went-far",
+    "title": "Microsoft finally admits that its malware-style Get Windows 10 upgrade campaign went too far"
+  },
+  {
+    "url": "https://www.engadget.com/2016/06/20/new-york-scalper-law-ticket-bots/",
+    "title": "New York criminalizes the use of ticket buying bots"
+  },
+  {
+    "url": "https://www.upi.com/Top_News/US/2018/09/16/New-Mexico-sues-Google-Twitter-for-illegally-collecting-data-on-children/9931537151359/",
+    "title": "New Mexico sues Google, Twitter for illegally collecting data on children"
+  },
+  {
+    "url": "https://electrek.co/2018/02/04/tesla-powerwall-solar-virtual-power-plant/",
+    "title": "Tesla is installing Powerwalls and solar power on 50,000 homes to create biggest virtual power plant in the world"
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2018/sep/13/scientific-publishing-rip-off-taxpayers-fund-research",
+    "title": "Scientific publishing is a rip-off. We fund the research – it should be free"
+  },
+  {
+    "url": "http://www.bit-tech.net/news/bits/2016/12/21/curia-rules-ip-act-illegal/1",
+    "title": "The Court of Justice of the European Union has ruled blanket communications data collection, as in the UK's IP Act, illegal"
+  },
+  {
+    "url": "https://techcrunch.com/2018/12/05/australia-rushes-its-dangerous-anti-encryption-bill-into-parliament/",
+    "title": "Australia rushes its ‘dangerous’ anti-encryption bill into parliament, despite massive opposition"
+  },
+  {
+    "url": "http://www.businessinsider.com/design-trumps-border-wall-hyperloop-2017-4",
+    "title": "A group of engineers just submitted this incredible proposal for Trump's border 'wall' that's actually a $15 billion hyperloop"
+  },
+  {
+    "url": "http://www.npr.org/blogs/alltechconsidered/2015/01/10/376166180/forget-wearable-tech-people-really-want-better-batteries",
+    "title": "Forget Wearable Tech. People Really Want Better Batteries."
+  },
+  {
+    "url": "https://www.wired.com/story/equifax-deserves-the-corporate-death-penalty/",
+    "title": "Equifax Deserves the Corporate Death Penalty"
+  },
+  {
+    "url": "https://qz.com/962487/states-are-moving-to-cut-college-costs-by-introducing-open-source-textbooks/",
+    "title": "States are moving to cut college costs by adopting open-source e-textbooks"
+  },
+  {
+    "url": "https://au.finance.yahoo.com/news/netflix-cofounder-apos-moviepass-now-035414536.html",
+    "title": "Netflix cofounder's MoviePass will now let you see one movie per day in theatres for just $10 a month"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20151209/06231533028/att-has-fooled-press-public-into-believing-building-massive-fiber-network-that-barely-exists.shtml",
+    "title": "AT&T Has Fooled The Press And Public Into Believing It's Building A Massive Fiber Network That Barely Exists"
+  },
+  {
+    "url": "https://gizmodo.com/at-t-employees-reportedly-encouraged-to-use-unethical-s-1827088406",
+    "title": "AT&T Employees Reportedly Encouraged to Use Unethical Sales Tactics to Drive Up DirecTV Now Subscriptions"
+  },
+  {
+    "url": "http://inthesetimes.com/article/20784/fcc-net-neutrality-open-internet-public-good-nationalize/",
+    "title": "It’s Time to Nationalize the Internet. To counter the FCC’s attack on net neutrality, we need to start treating the Internet like the public good it is."
+  },
+  {
+    "url": "http://www.engadget.com/2014/10/10/obama-net-neutrality",
+    "title": "President Obama wants the FCC to abandon plans for tiered 'net neutrality'"
+  },
+  {
+    "url": "https://www.theverge.com/2018/3/25/17162158/netflix-banned-from-competing-cannes-film-festival",
+    "title": "Netflix banned from competing at Cannes Film Festival - “because Netflix refuses to release its films in theaters, choosing instead to debut them on its streaming service”"
+  },
+  {
+    "url": "http://www.independent.co.uk/news/uk/politics/theresa-may-internet-regulated-london-bridge-terror-attack-google-facebook-whatsapp-borough-security-a7771896.html",
+    "title": "Theresa May says the internet must now be regulated following London Bridge terror attack"
+  },
+  {
+    "url": "http://www.latimes.com/opinion/op-ed/la-oe-rosenworcel-fcc-net-neutrality-repeal-20171122-story.html",
+    "title": "I'm on the FCC. Please stop us from killing net neutrality"
+  },
+  {
+    "url": "https://www.theverge.com/2018/3/20/17145200/brian-acton-delete-facebook-whatsapp",
+    "title": "The co-founder of WhatsApp just told everyone to delete Facebook"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-shell-m-a/shell-buying-spree-cranks-up-race-for-clean-energy-idUSKBN1FF1A8",
+    "title": "Shell buying spree cranks up race for clean energy - “spent over $400 million on a range of acquisitions in recent weeks, from solar power to electric car charging points, cranking up its drive to expand beyond its oil and gas business and reduce its carbon footprint.”"
+  },
+  {
+    "url": "https://www.hollywoodreporter.com/thr-esq/trump-administration-tells-supreme-court-wipe-decision-upholding-net-neutrality-1132149",
+    "title": "Trump Administration Tells Supreme Court to Wipe Out Decision Upholding Net Neutrality"
+  },
+  {
+    "url": "http://subtelforum.com/articles/google-faster-cable-system-is-ready-for-service-boosts-trans-pacific-capacity-and-connectivity/",
+    "title": "Google's FASTER is the first trans-Pacific submarine fiber optic cable system designed to deliver 60 Terabits per second (Tbps) of bandwidth using a six-fibre pair cable across the Pacific. It will go live tomorrow, and essentially doubles existing capacity along the route."
+  },
+  {
+    "url": "https://arstechnica.co.uk/gadgets/2017/02/amd-ryzen-price/",
+    "title": "AMD Ryzen pricing: $500 for 8-core 1800X CPU, undercutting Intel by $600"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/11/25/bill-gates-it-would-be-tragic-if-us-wont-lead-on-climate-innovation.html",
+    "title": "Bill Gates: It would be tragic if U.S. doesn't lead in innovation for cutting emissions"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170821/10485338053/state-supreme-court-says-digital-phones-cant-be-searched-without-warrant.shtml",
+    "title": "State Supreme Court Says Digital Phones Can't Be Searched Without A Warrant"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180410/17590439606/ftc-suddenly-remembers-warranty-void-if-removed-stickers-are-illegal-sends-out-stern-letters-to-manufacturers.shtml",
+    "title": "FTC Suddenly Remembers 'Warranty Void If Removed' Stickers Are Illegal, Sends Out Stern Letters To Manufacturers"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Dish-Ordered-to-Pay-Record-280-Million-for-Unwanted-Robocalls-139709",
+    "title": "Dish Ordered to Pay Record $280 Million for Unwanted Robocalls"
+  },
+  {
+    "url": "http://arstechnica.com/business/2016/03/comcast-failed-to-install-internet-for-10-months-then-demanded-60000-in-fees/",
+    "title": "Comcast failed to install Internet for 10 months then demanded $60,000 in fees"
+  },
+  {
+    "url": "http://www.esquire.com/blogs/news/comcast-astroturfing-net-neutrality",
+    "title": "This Is How Comcast Is Astroturfing the Net Neutrality Issue: \"Comcast is working with thinktanks like the American Enterprise Institute. AEI fellows are printing op-eds in support of killing Net neutrality throughout media—from WSJ to US News & World Report—without disclosing their ties to Comcast\""
+  },
+  {
+    "url": "https://www.sciencemag.org/news/2019/01/will-world-embrace-plan-s-radical-proposal-mandate-open-access-science-papers",
+    "title": "Will the world embrace Plan S, the radical proposal to mandate open access to science papers?"
+  },
+  {
+    "url": "https://www.inverse.com/article/35133-tesla-model-s-sets-new-record-for-distance-traveled-on-one-charge",
+    "title": "Tesla Model S Sets New Record For Distance Traveled On One Charge: 1078 km (669.83) miles with Tesla ModelS 100D"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20190110/13593541373/att-execs-think-really-funny-they-misled-consumers-about-5g-availability.shtml",
+    "title": "AT&T Execs Think It's Really Funny They Misled Consumers About 5G Availability"
+  },
+  {
+    "url": "http://forums.macrumors.com/threads/apples-new-thing-ipod.500/",
+    "title": "14 years ago Steve Jobs announced the iPod, and this is how people actually reacted..."
+  },
+  {
+    "url": "https://www.hln.be/nieuws/binnenland/belgie-wint-rechtszaak-tegen-facebook-omdat-het-privacy-niet-respecteert~a81e5c64",
+    "title": "Belgium wins trial against Facebook for violating privacy laws"
+  },
+  {
+    "url": "http://arstechnica.com/tech-policy/2016/03/paris-terrorist-attacks-burner-phones-not-encryption/",
+    "title": "Paris terrorists used burner phones, not encryption, to evade detection - \"Everywhere they went, the attackers left behind their throwaway phones.\""
+  },
+  {
+    "url": "https://www.cnbc.com/2017/09/26/equifax-ceo-retires-following-an-epic-data-breach-affecting-143-million-people.html",
+    "title": "Equifax CEO suddenly retires following an epic data breach affecting 143 million people"
+  },
+  {
+    "url": "https://www.admin.ch/gov/en/start/documentation/media-releases.msg-id-59636.html",
+    "title": "Switzerland has ruled on a single charger format for mobile telephones"
+  },
+  {
+    "url": "http://arstechnica.com/science/2016/09/feds-go-after-mylan-for-scamming-medicaid-out-of-millions-on-epipen-pricing/",
+    "title": "Feds go after Mylan for scamming Medicaid out of millions on EpiPen pricing"
+  },
+  {
+    "url": "http://www.cnbc.com/2016/11/03/google-android-hits-market-share-record-with-nearly-9-in-every-10-smartphones-using-it.html",
+    "title": "Google's Android hits market share record with nearly 9 in every 10 smartphones using it"
+  },
+  {
+    "url": "https://www.thisisinsider.com/amazon-warehouse-vickie-shannon-allen-homeless-injury-2018-7",
+    "title": "An Amazon staffer is posting YouTube videos of herself living in a warehouse parking lot after an accident at work."
+  },
+  {
+    "url": "https://apnews.com/b9a4ca1d8f0348f39cf9861e5929a555/Spotify-takes-down-Alex-Jones-podcasts-citing-'hate-content'",
+    "title": "Spotify takes down Alex Jones podcasts citing 'hate content.'"
+  },
+  {
+    "url": "https://www.independent.co.uk/life-style/gadgets-and-tech/news/apple-watch-update-latest-edition-watchos-5-expensive-out-of-date-obsolete-a8385291.html",
+    "title": "Apple Watch: $17,000 smartwatch is obsolete after latest update"
+  },
+  {
+    "url": "https://www.cbsnews.com/news/its-now-cheaper-to-build-a-new-wind-farm-than-to-keep-a-coal-plant-running/",
+    "title": "It's now cheaper to build a new wind farm than to keep a coal plant running"
+  },
+  {
+    "url": "https://www.businessinsider.com/facebook-instagram-snapchat-social-media-well-being-2018-11",
+    "title": "A new study finds that cutting your time on social media to 30 minutes a day reduces your risk of depression and loneliness"
+  },
+  {
+    "url": "https://gizmodo.com/at-ts-big-plan-for-hbo-is-to-fill-it-with-more-random-t-1827449321",
+    "title": "AT&T's Big Plan for HBO Is to Fill It With More Random Trash Like Netflix"
+  },
+  {
+    "url": "https://www.inverse.com/article/39711-elon-musk-falcon-heavy-tesla-roadsters-mars",
+    "title": "Elon Musk Makes It Official: Falcon Heavy is Taking Tesla Roadster to Mars"
+  },
+  {
+    "url": "http://www.sciencealert.com/costa-rica-powered-with-100-renewable-energy-for-75-days",
+    "title": "Costa Rica powered with 100% renewable energy for 75 straight days"
+  },
+  {
+    "url": "http://mentalfloss.com/uk/business/44942/japan-will-make-its-last-ever-vcr-this-month",
+    "title": "Japan Will Make Its Last Ever VCR This Month"
+  },
+  {
+    "url": "https://www.bbc.com/news/technology-44726296",
+    "title": "YouTuber in row over copyright infringement of his own song"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/7/18172355/att-fake-5g-logo-rolling-out-samsung-lg",
+    "title": "AT&T misleads customers by updating phones with fake 5G icon"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20161107/08205135980/att-mocks-google-fibers-struggles-ignores-it-caused-many-them.shtml",
+    "title": "AT&T Mocks Google Fiber's Struggles, Ignores It Caused Many Of Them"
+  },
+  {
+    "url": "https://qz.com/1152683/indian-it-layoffs-in-2017-top-56000-led-by-tcs-infosys-cognizant/",
+    "title": "56,000 layoffs and counting: India’s IT bloodbath this year may just be the start"
+  },
+  {
+    "url": "https://techcrunch.com/2018/03/23/elon-musk-deletes-own-spacex-and-tesla-facebook-pages-after-deletefacebook/",
+    "title": "Elon Musk deletes own, SpaceX and Tesla Facebook pages"
+  },
+  {
+    "url": "http://gothamist.com/2017/06/01/lrad_lawsuit_nypd.php",
+    "title": "The NYPD Claimed Its LRAD Sound Cannon Isn't A Weapon. A Judge Disagreed"
+  },
+  {
+    "url": "http://www.huffingtonpost.com/2015/04/06/edward-snowden-john-oliver-dick-pic_n_7008330.html",
+    "title": "Snowden: \"The good news is that there's no program named the 'dick pic' program. The bad news... they are still collecting everybody's information, including your dick pics\""
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/13/18178594/fcc-ftc-robocall-complaints-websites-government-shutdown",
+    "title": "Consumer protection websites are down due to the government shutdown"
+  },
+  {
+    "url": "https://www.technologyreview.com/s/602284/the-do-not-call-list-has-a-gaping-hole/",
+    "title": "The “Do Not Call” List Isn’t Working. Now the FCC is launching the “Robocall Strike Force.\""
+  },
+  {
+    "url": "http://thehill.com/policy/technology/368826-net-neutrality-advocates-look-to-states-after-fcc-repeal",
+    "title": "Net neutrality advocates look to states after FCC repeal: 'As of Friday, California, Washington, New York, Rhode Island, Nebraska and Massachusetts have all introduced net neutrality. North Carolina and Illinois are mulling similar legislation.'"
+  },
+  {
+    "url": "https://www.washingtonpost.com/news/the-switch/wp/2016/10/27/the-fcc-just-passed-sweeping-new-rules-to-protect-your-online-privacy/?tid=sm_tw",
+    "title": "The FCC Just Passed Sweeping New Rules to Protect Your Online Privacy"
+  },
+  {
+    "url": "http://www.grubstreet.com/2018/01/shoplifting-amazon-go-grocery-store.html",
+    "title": "One Person Already Accidentally Shoplifted at Amazon’s New Cashierless Grocery Store"
+  },
+  {
+    "url": "https://www.engadget.com/2016/11/22/tesla-runs-island-on-solar-power/",
+    "title": "Tesla runs an entire island on solar power"
+  },
+  {
+    "url": "http://www.mlive.com/news/index.ssf/2016/11/michigans_biggest_electric_pro.html",
+    "title": "Michigan's biggest electric provider phasing out coal, despite Trump's stance | \"I don't know anybody in the country who would build another coal plant,\" Anderson said."
+  },
+  {
+    "url": "http://bgr.com/2015/10/15/adobe-flash-player-security-vulnerability-warning/",
+    "title": "Adobe confirms major Flash vulnerability, and the only way to protect yourself is to uninstall Flash"
+  },
+  {
+    "url": "https://www.allflicks.net/netflix-has-twice-as-many-u-s-subscribers-as-comcast/",
+    "title": "Netflix Has Twice as Many U.S. Subscribers as Comcast"
+  },
+  {
+    "url": "http://motherboard.vice.com/read/valve-bans-game-publisher-after-it-sues-players-that-gave-it-bad-steam-reviews",
+    "title": "Valve Bans Game Publisher After It Sues Players That Gave It Bad Steam Reviews"
+  },
+  {
+    "url": "http://www.reuters.com/article/us-facebook-cambridge-analytica-apology/polls-show-facebook-losing-trust-as-firm-uses-ads-to-apologize-idUSKBN1H10AF",
+    "title": "Polls show Facebook losing trust as firm uses ads to apologize | Reuters"
+  },
+  {
+    "url": "http://www.wired.co.uk/news/archive/2015-08/07/kim-dotcom-exclusive-interview-mega-2",
+    "title": "Kim Dotcom: Mega 3.0 will succeed as a nonprofit \"Copyright extremism has to stop. Hollywood needs to adapt to the internet and not the other way around. They need to make their content available globally at the same time, at a fair price and for any device.\""
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20171106/09481638554/comcast-tries-to-stop-colorado-city-even-talking-about-building-own-broadband-network.shtml",
+    "title": "Comcast Tries To Stop Colorado City From Even Talking About Building Its Own Broadband Network"
+  },
+  {
+    "url": "https://www.eff.org/deeplinks/2017/09/just-how-unpopular-how-wrong-facts-how-misguided-fcc-proposal-rollback-network",
+    "title": "Just How Unpopular, How Wrong on the Facts, How Misguided Is the FCC Proposal to Rollback Network Neutrality and Broadband Privacy?"
+  },
+  {
+    "url": "https://www.opensecrets.org/orgs/recips.php?id=D000000461&type=P&state=&sort=A&cycle=2014",
+    "title": "Comcast has spent nearly $2,000,000 influencing politics in the first half of 2014."
+  },
+  {
+    "url": "http://forum.utorrent.com/topic/95041-warning-epicscale-riskware-silently-installed-with-latest-utorrent/",
+    "title": "Popular torrenting software µTorrent has included an automatic cryptocoin-miner in their latest update."
+  },
+  {
+    "url": "https://qz.com/1007227/netflix-nflx-now-has-more-us-subscribers-than-cable-tv/",
+    "title": "With more than 50 million US subscribers, Netflix has finally surpassed cable TV"
+  },
+  {
+    "url": "http://motherboard.vice.com/en_au/read/we-need-to-teach-kids-how-to-be-skeptical-of-the-internet",
+    "title": "We Need to Teach Kids How to Be Skeptical of the Internet - a Stanford study found \"80% of middle schoolers couldn't tell “sponsored content” from articles, over 80% of high schoolers accepted the validity of photographs without attempting to verify their authenticity\""
+  },
+  {
+    "url": "https://www.techdirt.com/blog/netneutrality/articles/20170710/10071737756/fcc-insists-it-cant-stop-impostors-lying-about-my-views-net-neutrality.shtml",
+    "title": "The FCC Insists It Can't Stop Impostors From Lying About My Views On Net Neutrality"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/mbpezp/fcc-smartphone-data-reclassification",
+    "title": "The FCC's next stunt: Reclassifying cell phone data service as 'broadband Internet'."
+  },
+  {
+    "url": "http://www.huffingtonpost.ca/2016/04/12/uber-transparency-report_n_9673770.html",
+    "title": "Uber Transparency Report Reveals It Shared Data On 13 Million Users With Government"
+  },
+  {
+    "url": "http://www.myce.com/news/hp-pre-programmed-failure-date-unofficial-non-hp-ink-cartridges-printers-80457/",
+    "title": "HP pre-programmed failure date of unofficial/ non-HP ink cartridges in its printers"
+  },
+  {
+    "url": "https://www.theguardian.com/world/2018/jan/28/fitness-tracking-app-gives-away-location-of-secret-us-army-bases",
+    "title": "Fitness tracking app gives away location of secret US army bases"
+  },
+  {
+    "url": "http://www.sciencemag.org/news/2018/05/trump-white-house-quietly-cancels-nasa-research-verifying-greenhouse-gas-cuts",
+    "title": "Trump White House quietly cancels NASA research verifying greenhouse gas cuts"
+  },
+  {
+    "url": "https://electrek.co/2017/10/05/elon-musk-tesla-rebuild-puerto-ricos-power-grid-batteries-solar/",
+    "title": "Elon Musk says Tesla could rebuild Puerto Rico’s power grid with batteries and solar"
+  },
+  {
+    "url": "https://theintercept.com/2016/04/28/new-study-shows-mass-surveillance-breeds-meekness-fear-and-self-censorship/",
+    "title": "\"After Snowden showed everyone how much the US tracks people's browsing, there was a 20% decrease in visits to Wikipedia pages about topics relating to terrorism.\""
+  },
+  {
+    "url": "http://www.engadget.com/2015/11/10/tim-cook-talks-encryption/",
+    "title": "Apple CEO: \"If you halt or weaken encryption, the people that you hurt are not the folks that want to do bad things. It's the good people. The other people know where to go.\""
+  },
+  {
+    "url": "https://medium.com/charged-tech/apple-just-told-the-world-it-has-no-idea-who-the-mac-is-for-722a2438389b#.8j5koelrj",
+    "title": "Apple just told the world it has no idea who the Mac is for"
+  },
+  {
+    "url": "http://www.nytimes.com/2015/11/28/us/politics/bill-gates-expected-to-create-billion-dollar-fund-for-clean-energy.html",
+    "title": "Bill Gates to create multibillion-dollar fund to pay for R&D of new clean-energy technologies. “If we create the right environment for innovation, we can accelerate the pace of progress, develop new solutions, and eventually provide everyone with reliable, affordable energy that is carbon free.”"
+  },
+  {
+    "url": "http://fortune.com/2018/12/21/comcast-customers-minnesota-ag-lawsuit/",
+    "title": "Comcast swindled customers with rate hikes, bogus equipment charges, lawsuit claims - “It’s hard to shop for cable television if a company plays hide-the-ball on its true prices, and people shouldn’t have to watch their bills for things they didn’t buy.”"
+  },
+  {
+    "url": "http://www.businessinsider.com/failing-to-protect-net-neutrality-would-crush-digital-startups-2017-7",
+    "title": "Why failing to protect net neutrality would crush the US's digital startups"
+  },
+  {
+    "url": "http://www.cnbc.com/2017/02/20/mark-cuban-robots-unemployment-and-we-need-to-prepare-for-it.html",
+    "title": "Mark Cuban: Robots will ‘cause unemployment and we need to prepare for it’"
+  },
+  {
+    "url": "https://nakedsecurity.sophos.com/2018/08/16/australians-who-wont-unlock-their-phones-could-face-10-years-in-jail/",
+    "title": "Australians who won’t unlock their phones could face 10 years in jail"
+  },
+  {
+    "url": "https://www.justice.gov/usao-ndca/pr/former-secret-service-agent-sentenced-scheme-related-silk-road-investigation",
+    "title": "Secret Service agent stole 1,600 Bitcoins from Silk Road wallet"
+  },
+  {
+    "url": "https://www.washingtonpost.com/world/national-security/the-nsas-top-talent-is-leaving-because-of-low-pay-and-battered-morale/2018/01/02/ff19f0c6-ec04-11e7-9f92-10a2203f6c8d_story.html?tid=pm_world_pop&utm_term=.637292c3a88f",
+    "title": "The NSA’s top talent is leaving because of low pay and flagging morale"
+  },
+  {
+    "url": "https://www.geek.com/tech/400-burger-per-hour-robot-will-put-teenagers-out-of-work-1703546/",
+    "title": "400 Burger Per Hour Robot Will Put Teenagers Out Of Work"
+  },
+  {
+    "url": "http://arstechnica.com/tech-policy/2014/08/senator-wants-all-us-cops-to-wear-video-cameras/",
+    "title": "Senator wants all US cops to wear video cameras | Ars Technica"
+  },
+  {
+    "url": "http://www.scribblelive.com/Event/Microsoft_launches_Windows_10/140927634",
+    "title": "Windows 10 will be a free upgrade from Windows 7 for a full year"
+  },
+  {
+    "url": "https://techcrunch.com/2018/12/10/equifax-breach-preventable-house-oversight-report/",
+    "title": "Equifax breach was ‘entirely preventable’ had it used basic security measures, says House report"
+  },
+  {
+    "url": "http://hustlecon.com/broke-artist-believed-in-sean-parker-makes-200-million-off-facebook-stock",
+    "title": "Artist who painted Facebook's first office and asked for stock instead of cash is now worth $200m"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2017-06-20/robots-are-eating-money-managers-lunch",
+    "title": "Robots Are Eating Money Managers’ Lunch - \"A wave of coders writing self-teaching algorithms has descended on the financial world, and it doesn’t look good for most of the money managers who’ve long been envied for their multimillion-­dollar bonuses.\""
+  },
+  {
+    "url": "http://bgr.com/2014/10/16/why-is-comcast-so-bad-24/",
+    "title": "An entire city tells Comcast it’s not wanted thanks to ‘deplorable and substandard’ customer service"
+  },
+  {
+    "url": "http://www.engadget.com/2016/01/08/you-say-advertising-i-say-block-that-malware/?utm_source=fark&utm_medium=website&utm_content=link",
+    "title": "Forbes.com asks users running adblockers to disable blocking to view stories on their site. Then promptly serves up pop-under malware to those who complied."
+  },
+  {
+    "url": "https://hardware.slashdot.org/story/16/06/11/1458246/apple-is-fighting-a-secret-war-to-keep-you-from-repairing-your-phone",
+    "title": "Apple Is Fighting A Secret War To Keep You From Repairing Your Phone"
+  },
+  {
+    "url": "http://europa.eu/rapid/press-release_IP-15-5265_en.htm",
+    "title": "European Commission welcomes agreement to end roaming charges and to guarantee an open Internet"
+  },
+  {
+    "url": "http://www.cnbc.com/2017/03/01/heres-the-business-bill-gates-would-start-with-elon-musk.html",
+    "title": "Bill Gates knows just what business he would start with Elon Musk - he would have the two of them take on energy alternatives. \"We need clean, reliable cheap energy — which we don't have\""
+  },
+  {
+    "url": "http://www.independent.co.uk/news/world/europe/france-coal-power-station-emmanuel-macron-davos-shut-2021-a8176796.html",
+    "title": "France to shut all coal-fired power stations by 2021, Macron declares"
+  },
+  {
+    "url": "http://newatlas.com/desktop-metal-3d-printing/50654/",
+    "title": "100x faster, 10x cheaper: 3D metal printing is about to go mainstream"
+  },
+  {
+    "url": "http://thenextweb.com/insider/2015/07/15/under-promise-over-deliver/",
+    "title": "Amazon Prime Day is on and customers are bummed out by the virtual ‘garage sale’"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/ne45jd/rand-paul-filibuster-fisa-702-senate",
+    "title": "5 Senators Are Filibustering an Attempt to Expand Warrantless Surveillance of Americans - 3 Democrats and 2 Republicans are filibustering the Senate vote on the reauthorization of FISA Section 702."
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Comcast-Says-It-Wants-to-Charge-Broadband-Users-More-For-Privacy-137567",
+    "title": "Comcast Says It Wants to Charge Broadband Users More For Privacy"
+  },
+  {
+    "url": "https://www.theverge.com/2018/10/30/18045410/facebook-bans-proud-boys-far-right-extremist-group-gavin-mcinnes",
+    "title": "Facebook has started banning accounts affiliated with far-right group the Proud Boys"
+  },
+  {
+    "url": "http://www.businessinsider.com/tesla-liberty-mutual-create-customize-insurance-package-2017-10?r=US&IR=T",
+    "title": "Tesla strikes another deal that shows it's about to turn the car insurance world upside down - InsureMyTesla shows how the insurance industry is bound for disruption as cars get safer with self-driving tech."
+  },
+  {
+    "url": "https://arstechnica.com/science/2018/03/amid-drug-price-increases-pfizer-ceo-gets-61-pay-raise-to-27-9-million/?amp=1",
+    "title": "Pfizer CEO gets 61% pay raise—to $27.9 million—as drug prices continue to climb"
+  },
+  {
+    "url": "https://www.utilitydive.com/news/colorado-could-save-25-billion-through-2040-by-replacing-coal-with-clean/545652/",
+    "title": "Colorado could save $2.5B through 2040 by replacing coal with clean energy: report"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20151207/21225233018/two-leading-presidential-candidates-clinton-trump-both-mocked-free-speech-internet.shtml",
+    "title": "The Two Leading Presidential Candidates -- Clinton And Trump -- Are Both Mocking Free Speech On The Internet"
+  },
+  {
+    "url": "http://www.cnn.com/2017/03/09/politics/fbi-investigation-continues-into-odd-computer-link-between-russian-bank-and-trump-organization/index.html",
+    "title": "Russian bank looked up the address to Trump corporate server 2,820 times, representing 80% of the lookups, according to records. 19% or the remaining 20 were from medical facility chain led by Dick DeVos, the husband of Betsy DeVos."
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20160424/07013134258/cable-industry-threatens-to-sue-if-fcc-tries-to-bring-competition-to-cable-set-top-boxes.shtml",
+    "title": "The Cable Industry Threatens To Sue If FCC Tries To Bring Competition To Cable Set Top Boxes"
+  },
+  {
+    "url": "https://www.theverge.com/2018/11/9/18079880/paypal-proud-boys-gavin-mcinnes-antifa",
+    "title": "PayPal is canceling accounts used by the Proud Boys, Gavin McInnes, and antifa groups - PayPal said today that it will cancel accounts used by far-right group the Proud Boys as well as multiple accounts from anti-fascist groups."
+  },
+  {
+    "url": "https://techcrunch.com/2016/08/13/spacex-succesfully-launches-another-satellite-brings-home-another-rocket/",
+    "title": "SpaceX succesfully launches another satellite, brings home another rocket"
+  },
+  {
+    "url": "http://www.businessinsider.com/mark-cuban-backed-startup-dave-has-landed-13-million-in-funding-2018-4",
+    "title": "Mark Cuban is trying to get rid of overdraft fees"
+  },
+  {
+    "url": "http://www.engadget.com/2016/05/17/ibm-research-phase-change-memory/",
+    "title": "IBM's optical storage is 50 times faster than flash and is now cheaper than RAM."
+  },
+  {
+    "url": "http://www.indystar.com/story/news/2015/01/19/police-radar-see-through-walls/22007615/",
+    "title": "New police radars can \"see\" inside homes; At least 50 U.S. law enforcement agencies quietly deployed radars that let them effectively see inside homes, with little notice to the courts or the public"
+  },
+  {
+    "url": "https://money.cnn.com/2018/07/19/technology/business/tesla-downgrade/index.html?utm_medium=social&utm_content=2018-07-21T21%3A02%3A06&utm_source=twmoney&utm_term=image",
+    "title": "24% of Tesla Model 3 orders have been canceled, analyst says"
+  },
+  {
+    "url": "http://www.theguardian.com/commentisfree/2015/apr/08/congress-must-end-mass-nsa-surveillance-with-next-patriot-act-vote",
+    "title": "\"In less than 60 days, Congress will be forced to decide if the NSA’s most notorious mass surveillance program lives or dies. And today, over 30 civil liberties organizations launched a nationwide call-in campaign urging them to kill it.\""
+  },
+  {
+    "url": "https://www.politico.com/story/2018/02/27/democrats-fcc-reverse-net-neutrality-426641",
+    "title": "Democrats introduce resolution to reverse FCC net neutrality repeal"
+  },
+  {
+    "url": "http://thehill.com/policy/technology/236769-house-effort-would-completely-dismantle-patriot-act",
+    "title": "House effort would completely dismantle Patriot Act"
+  },
+  {
+    "url": "https://medium.com/humane-tech/tech-and-the-fake-market-tactic-8bd386e3d382#.gxueb94j3",
+    "title": "In one generation, the Internet went from opening up new free markets to creating a series of Fake Markets that exploit society, without most media or politicians even noticing."
+  },
+  {
+    "url": "https://spreadprivacy.com/facebook-whatsapp/",
+    "title": "Most Americans aren't aware that Facebook owns WhatsApp"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20170513/10394837355/fcc-spent-last-week-trying-to-make-net-neutrality-supporters-seem-unreasonable-racist-unhinged.shtml",
+    "title": "The FCC Spent Last Week Trying To Make Net Neutrality Supporters Seem Unreasonable, Racist and Unhinged"
+  },
+  {
+    "url": "http://www.telegraph.co.uk/technology/news/11966036/Snapchat-just-reserved-the-rights-to-store-and-use-all-selfies-taken-with-the-device.html",
+    "title": "Snapchat just reserved the rights to store and use all selfies taken with the device"
+  },
+  {
+    "url": "https://www.businessinsider.com/fcc-ajit-pai-debunked-ddos-attack-senate-hearing-net-neutrality-john-oliver-2018-8",
+    "title": "Congress is set to grill the FCC's chairman for falsely claiming his agency was hit with a cyberattack — here's how it could affect the war over net neutrality"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2017/05/24/fcc_under_cable_company_control/",
+    "title": "FCC revised net neutrality rules reveal cable company control of process"
+  },
+  {
+    "url": "http://www.nytimes.com/2018/12/19/business/delete-facebook-account.amp.html",
+    "title": "NYTimes: How to Delete Facebook"
+  },
+  {
+    "url": "https://venturebeat.com/2017/11/17/facebook-removes-delete-post-option-from-the-desktop-web-version/",
+    "title": "Facebook removes ‘delete post’ option from the desktop web version"
+  },
+  {
+    "url": "http://uk.businessinsider.com/facebook-data-scandal-bigger-than-87-million-users-2018-4",
+    "title": "Second Cambridge Analytica whistleblower says 'sex compass' app gathered more Facebook data beyond the 87 million we already knew about"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-election-tech-advertising-lawsuit/washington-state-sues-facebook-google-over-election-ad-disclosure-idUSKCN1J030X",
+    "title": "Washington State Is Suing Facebook And Google For Violating Election Advertisement Laws"
+  },
+  {
+    "url": "http://www.businessinsider.com/russian-troll-farm-spent-millions-on-election-interference-2018-2",
+    "title": "A Russian troll factory had a $1.25 million monthly budget to interfere in the 2016 US election"
+  },
+  {
+    "url": "http://www.ibtimes.com/chicago-mayor-rahm-emanuel-received-more-100000-comcast-boosting-merger-1676264?utm_content=buffere9697&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer",
+    "title": "Chicago Mayor Rahm Emanuel Received More Than $100,000 from Comcast Before Boosting Merger"
+  },
+  {
+    "url": "http://motherboard.vice.com/en_ca/read/if-the-fbi-is-so-worried-about-car-hacking-why-is-it-fighting-encryption",
+    "title": "If the FBI Is So Worried About Car Hacking, Why Is It Fighting Encryption?"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2018-04-23/electric-buses-are-hurting-the-oil-industry",
+    "title": "Electric Buses Are Hurting the Oil Industry"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/ajit-pais-repeal-of-net-neutrality-officially-goes-into-effect-today-6e03a8991b95",
+    "title": "Ajit Pai’s repeal of net neutrality officially goes into effect today. But Congress can still reverse it. Contact your House Reps right now"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20180215/07195439242/game-studio-threatens-employees-jobs-if-they-dont-write-positive-reviews-own-game-then-steam-pulls-game-entirely.shtml",
+    "title": "Game Studio Threatens Employees' Jobs If They Don't Write Positive Reviews Of Own Game, Then Steam Pulls Game Entirely"
+  },
+  {
+    "url": "https://www.schneier.com/essays/archives/2014/02/its_time_to_break_up.html",
+    "title": "It's Time to Break Up the NSA"
+  },
+  {
+    "url": "https://arstechnica.com/?post_type=post&p=1191773",
+    "title": "Two-week-old Pixel 2 XL displays are already showing burn-in"
+  },
+  {
+    "url": "https://techcrunch.com/2016/09/18/dont-just-pardon-edward-snowden-give-the-man-a-medal/",
+    "title": "Don’t just pardon Edward Snowden; give the man a medal"
+  },
+  {
+    "url": "https://www.theverge.com/2018/1/30/16949550/bitcoin-graphics-cards-pc-prices-surge",
+    "title": "Bitcoin mania is hurting PC gamers by pushing up GPU prices"
+  },
+  {
+    "url": "http://www.dslreports.com/shownews/Chicago-to-Apply-9-Netflix-Tax-134367",
+    "title": "Chicago to Apply 9% 'Netflix Tax'"
+  },
+  {
+    "url": "https://www.theverge.com/2017/6/21/15816974/verizon-tumblr-net-neutrality-internet-politics-david-karp",
+    "title": "Verizon is killing Tumblr’s fight for net neutrality"
+  },
+  {
+    "url": "https://www.businessinsider.com/google-pixel-3-telemarketer-call-screen-2018-10",
+    "title": "Google's new phone software aims to end telemarketer calls for good"
+  },
+  {
+    "url": "http://qz.com/230603/youtube-like-netflix-is-now-publicly-shaming-internet-providers-for-slow-video/",
+    "title": "YouTube, following Netflix, is now publicly shaming internet providers for slow video"
+  },
+  {
+    "url": "https://cleantechnica.com/2017/02/02/garbage-trucks-buses-time-start-talking-big-electric-vehicles/",
+    "title": "From Garbage Trucks To Buses, It's Time To Start Talking About Big Electric Vehicles - \"While medium and heavy trucks account for only 4% of America’s +250 million vehicles, they represent 26% of American fuel use and 29% of vehicle CO2 emissions.\""
+  },
+  {
+    "url": "http://www.thedailybeast.com/articles/2016/06/15/a-twitter-bot-is-beating-trump-fans.html",
+    "title": "A Twitter Bot Is Beating Trump Fans: Scores of Trump supporters spent Tuesday fighting with an automated Twitter robot that spouts nonsense."
+  },
+  {
+    "url": "https://www.space.com/41599-nasa-moon-space-priorities-jim-bridenstine-update.html",
+    "title": "NASA Chief Wants to Send Humans to the Moon — 'To Stay'"
+  },
+  {
+    "url": "https://yro.slashdot.org/story/17/09/10/0128214/techcrunch-equifax-hack-checking-web-site-is-returning-random-results",
+    "title": "TechCrunch: Equifax Hack-Checking Web Site Is Returning Random Results"
+  },
+  {
+    "url": "https://krebsonsecurity.com/2017/12/kansas-man-killed-in-swatting-attack/",
+    "title": "Kansas Man Killed In ‘SWATting’ Attack; Attacker was same individual who called in fake net-neutrality bomb"
+  },
+  {
+    "url": "http://www.latimes.com/business/hiltzik/la-fi-hiltzik-lifelock-equifax-20170918-story.html",
+    "title": "Lifelock offers to protect you from the Equifax breach — by selling you services provided by Equifax."
+  },
+  {
+    "url": "http://www.gamespot.com/articles/hbo-go-blocked-on-ps4-by-comcast-just-like-on-ps3/1100-6425719/",
+    "title": "HBO Go Blocked on PS4 by Comcast, Just Like on PS3"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/ev5mm7/at-the-behest-of-t-mobile-the-fcc-is-undoing-rules-that-make-it-easier-for-small-isps-to-compete-with-big-telecom",
+    "title": "At the Behest of T-Mobile, the FCC Is Undoing Rules That Make it Easier for Small ISPs to Compete With Big Telecom"
+  },
+  {
+    "url": "https://www.commondreams.org/views/2018/11/18/biggest-threat-free-speech-no-one-talking-about",
+    "title": "The Biggest Threat to Free Speech No One Is Talking About: It's not being mean to reporters, \"The biggest freedom-of-the-press issue is that Trump is working with Comcast and AT&T and Verizon to end net neutrality.\""
+  },
+  {
+    "url": "http://www.theverge.com/2016/9/27/13071330/facebook-whatsapp-user-data-germany-privacy",
+    "title": "Germany orders Facebook to stop collecting data on WhatsApp users"
+  },
+  {
+    "url": "http://www.independent.co.uk/life-style/gadgets-and-tech/un-declares-online-freedom-to-be-a-human-right-that-must-be-protected-a7120186.html",
+    "title": "UN declares online freedom to be a human right that must be protected"
+  },
+  {
+    "url": "http://www.cbc.ca/news/business/bell-customer-wins-court-battle-over-contract-1.4635118",
+    "title": "Customer takes Bell to court and wins, as judge agrees telecom giant can't promise a price, then change it"
+  },
+  {
+    "url": "http://www.businessinsider.com/china-bullet-train-speed-map-photos-tour-2018-5/?r=US&IR=T",
+    "title": "I rode China's superfast bullet train that could go from New York to Chicago in 4.5 hours — and it shows how far behind the US really is"
+  },
+  {
+    "url": "https://www.thedailybeast.com/how-trump-will-turn-americas-open-internet-into-an-ugly-version-of-chinas",
+    "title": "How Trump Will Turn America’s Open Internet Into an Ugly Version of China’s"
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2018/dec/21/quit-facebook-privacy-scandal-private-messages",
+    "title": "Is 2019 the year you should finally quit Facebook? Deleting your Facebook account isn’t a bad New Year resolution – the company has proven yet again it violated public trust"
+  },
+  {
+    "url": "https://www.forbes.com/sites/laurencebradford/2018/06/19/why-we-need-to-talk-about-burnout-in-the-tech-industry/#27e4d6a11406",
+    "title": "57% of tech industry employees are suffering from job burnout"
+  },
+  {
+    "url": "http://hn.premii.com/#/article/13778543",
+    "title": "94-year-old Lithium-Ion Battery Inventor Introduces Solid State Battery"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/11/21/amazon-exposed-customer-names-and-emails-in-a-technical-error.html",
+    "title": "Amazon exposed customer names and emails in a 'technical error'"
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2018/nov/20/facebook-google-antitrust-laws-gilded-age",
+    "title": "Break up Facebook (and while we're at it, Google, Apple and Amazon) - Big tech has ushered in a second Gilded Age. We must relearn the lessons of the first, writes the former US labor secretary"
+  },
+  {
+    "url": "https://qz.com/878790/a-lawyer-rewrote-instagrams-terms-of-service-for-kids-now-you-can-understand-all-of-the-private-data-you-and-your-teen-are-giving-up-to-social-media/",
+    "title": "A lawyer rewrote Instagram's terms of service for kids. Now you can understand all of the private data you and your teen are giving up to social media"
+  },
+  {
+    "url": "http://time.com/5328463/uganda-social-media-tax/",
+    "title": "Uganda Just Rolled Out a 5-Cent Daily Tax to Access Social Media"
+  },
+  {
+    "url": "https://gizmodo.com/trumphotels-org-purchased-by-pranksters-to-promote-amer-1827098727",
+    "title": "TrumpHotels.org Purchased by Pranksters to Promote America's Concentration Camps"
+  },
+  {
+    "url": "http://money.cnn.com/2016/04/26/news/companies/mitsubishi-cheating-fuel-tests-25-years/index.html",
+    "title": "Mitsubishi: We've been cheating on fuel tests for 25 years"
+  },
+  {
+    "url": "https://medium.com/@fightfortheftr/this-fourth-of-july-us-veterans-are-calling-on-congress-to-restore-net-neutrality-acb89ce767b7",
+    "title": "This Fourth of July, US veterans are calling on Congress to restore net neutrality"
+  },
+  {
+    "url": "https://www.techdirt.com/articles/20160410/06272034141/as-isps-push-harder-usage-caps-house-pushes-bill-preventing-fcc-doing-anything-about-it.shtml",
+    "title": "As ISPs Push Harder On Usage Caps, House Pushes Bill Preventing The FCC From Doing Anything About It"
+  },
+  {
+    "url": "http://www.rcrwireless.com/20170601/carriers/att-throttling-blocking-allowed-under-title-II-tag6?",
+    "title": "AT&T -- Throttling, “filtered service” allowed under Title II: '... AT&T executive said that court intepretations of Title II regulations appear to allow ISPs to slow down or block certain content or traffic types — so long as they are upfront with customers about it.'"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2017/10/former-fcc-chief-asks-fcc-why-the-silence-about-trumps-media-threats/",
+    "title": "Tom Wheeler to Ajit Pai: “Why the silence” about Trump’s media threats?"
+  },
+  {
+    "url": "https://gizmodo.com/aclu-wants-release-of-secret-court-order-demanding-face-1830732015",
+    "title": "ACLU Wants Release of Secret Court Order Demanding Facebook Build Surveillance Backdoor"
+  },
+  {
+    "url": "https://qz.com/279940/meet-profile-engine-the-spammy-facebook-crawler-hated-by-people-who-want-to-be-forgotten/",
+    "title": "From 2007-2010 Facebook allowed a website called ProfileEngine to scrape user data, allowing them to steal the details of over 400 million user profiles, all still accessible on their website."
+  },
+  {
+    "url": "http://www.mobilecomputingtoday.co.uk/339/att-continues-throttle-internet-speeds-opposing-ftc-actions-fccs-rules/",
+    "title": "AT&T continues to throttle internet speeds opposing FTC actions and the FCC’s rules"
+  },
+  {
+    "url": "https://theintercept.com/2015/06/20/wikileaks-jacob-appelbaum-google-investigation/",
+    "title": "The Obama administration fought a legal battle against Google to secretly obtain the email records of a researcher and journalist associated with WikiLeaks"
+  },
+  {
+    "url": "https://www.ft.com/content/b42f40c2-a6df-11e6-8b69-02899e8bd9d1",
+    "title": "Silicon Valley frets over foreign worker crackdown. Trump has warned H-1B visas are being used to bring cheap labour to the US"
+  },
+  {
+    "url": "https://www.cnbc.com/2018/12/01/social-media-detox-christina-farr-quits-instagram-facebook.html",
+    "title": "I quit Instagram and Facebook and it made me a lot happier — and that's a big problem for social media companies"
+  },
+  {
+    "url": "https://www.engadget.com/amp/2019/01/08/verizon-t-mobile-burn-att-fake-5g/",
+    "title": "AT&T gets burned by rivals over its fake 5G network"
+  },
+  {
+    "url": "https://thehackernews.com/2018/10/apple-macbook-microphone.html",
+    "title": "Apple's New MacBook Disconnects Microphone \"Physically\" When Lid is Closed"
+  },
+  {
+    "url": "http://nintendoeverything.com/nintendo-president-satoru-iwata-has-passed-away/",
+    "title": "Nintendo president Satoru Iwata has passed away"
+  },
 
-
-    {"url":"https://find.xyz/map/product-management-search-engine","title":"Product-building articles by PMs at major tech companies"},
-    {"url":"https://cloud.google.com/blog/products/databases/announcing-cloud-firestore-general-availability-and-updates/","title":"Google Cloud Firestore NoSQL database is in GA"},
-    {"url":"https://www.cbc.ca/news/canada/calgary/carstairs-westview-co-op-grocery-car-key-fob-1.4999558","title":"Something mysterious is blocking car key fobs from working in an Alberta town"},
-    {"url":"https://www.greghendershott.com/2018/05/extramaze-llc-using-racket-postgresql-aws-but-no-ads-or-js.html","title":"Extramaze: Using Racket, PostgreSQL, AWS, but no ads or JavaScript (2018)"},
-    {"url":"https://mwi.usma.edu/stealing-enemys-urban-advantage-battle-sadr-city/","title":"Stealing the Enemy's Urban Advantage: The Battle of Sadr City"},
-    {"url":"https://www.troyhunt.com/everything-you-ever-wanted-to-know/","title":"Everything you ever wanted to know about building a secure password reset (2012)"},
-    {"url":"https://slatestarcodex.com/2019/01/31/book-review-zero-to-one/","title":"Scott Alexander Reviews Thiel's Zero to One"},
-    {"url":"https://www.myuv.com/","title":"UltraViolet DRM will close on July 31, 2019"},
-    {"url":"https://motherboard.vice.com/en_us/article/mbzvxv/criminals-hackers-ss7-uk-banks-metro-bank","title":"Criminals Are Tapping into the Phone Network Backbone to Empty Bank Accounts"},
-    {"url":"https://media.ccc.de/v/35c3-9800-how_to_teach_programming_to_your_loved_ones","title":"How to teach programming to your loved ones [video]"},
-    {"url":"https://news.ycombinator.com/item?id=19048108","title":"Ask HN: Top three questions for a startup before accepting a job offer?"},
-    {"url":"https://blog.kentcdodds.com/write-tests-not-too-many-mostly-integration-5e8c7fff591c","title":"Write tests. Not too many. Mostly integration (2017)"},
-    {"url":"https://bytes.grubhub.com/lombok-makes-java-cool-again-171102bdcc52","title":"Lombok makes Java cool again"},
-    {"url":"https://news.ycombinator.com/item?id=19038132","title":"Ask HN: How to RTFM?"},
-    {"url":"https://lwn.net/Articles/776688/","title":"A proposed API for full-memory encryption"},
-    {"url":"https://peeke.nl/simulating-blobs-of-fluid","title":"Simulating blobs of fluid"},
-    {"url":"http://www.methodsandtools.com/archive/softwarearchitecturelearning.php","title":"How Software Architecture Learns (2011)"},
-    {"url":"https://www.codingnagger.com/2019/01/31/slow-ci/","title":"Slow CI: real problem or easy excuse for developers?"},
-    {"url":"https://arxiv.org/abs/1901.08338","title":"Can We Prove Time Protection?"},
-    {"url":"https://www.wired.com/story/mastermind-excerpt/","title":"Meth, Murder, and Pirates: The Coder Who Became a Crime Boss"},
-    {"url":"https://relationshiphero.com/careers?role=coach","title":"Relationship Hero (YC S17) Is Hiring Full-Time Coaches – Remote Only"},
-    {"url":"https://www.spiria.com/en/blog/desktop-software/hypothetical-c-easy-type-creation/","title":"Hypothetical C++: easy type creation"},
-    {"url":"https://css-tricks.com/lodge/svg/","title":"Everything You Need to Know About SVG"},
-    {"url":"https://nationalinterest.org/blog/the-buzz/fact-the-kgb-shipped-sidewinder-missile-by-mail-moscow-21673","title":"A KGB agent shipped a Sidewinder missile by mail to Moscow (2017)"},
-    {"url":"https://hamy.io/post/0010/how-i-lost-my-data-trying-to-back-it-up/","title":"I lost my data trying to back it up"},
-    {"url":"https://www.faucet-pipeline.org/","title":"Faucet-pipeline – a framework-independent, pluggable asset pipeline"},
-    {"url":"http://news.mit.edu/2019/converting-wi-fi-signals-electricity-0128","title":"Converting Wi-Fi signals to electricity with new 2-D materials"},
-    {"url":"https://www.gq.com/story/cal-newport-digital-minimalism","title":"Cal Newport on Why We'll Look Back at Our Smartphones Like Cigarettes"},
-    {"url":"https://blog.racket-lang.org/2019/01/racket-v7-2.html","title":"Racket v7.2"},
-    {"url":"https://blogs.technet.microsoft.com/srd/2019/01/28/fuzzing-para-virtualized-devices-in-hyper-v/","title":"Fuzzing para-virtualized devices in Hyper-V"},
-    {"url":"https://news.ycombinator.com/item?id=19046852","title":"Ask HN: Why is it easier to get a raise with a new job?"},
-    {"url":"https://fusionauth.io/blog/2019/01/31/revoking-jwts","title":"Revoking JWTs (JSON Web Tokens)"},
-    {"url":"https://www.youtube.com/watch?time_continue=2&v=u7sRrC2Jpp4","title":"Table-Saw Kickback on Camera (2012) [video]"},
-    {"url":"https://www.washingtonpost.com/entertainment/books/a-peek-inside-edward-goreys-modern-gothic-world/2018/11/20/29028b50-e83f-11e8-bbdb-72fdbf9d4fed_story.html","title":"A peek inside Edward Gorey’s modern Gothic world"},
-    {"url":"http://www.bbc.com/travel/story/20190129-did-wine-cause-a-full-scale-revolution-in-armenia","title":"Did wine cause a full-scale revolution in Armenia?"},
-    {"url":"https://www.citusdata.com/blog/2018/12/14/watching-star-wars-in-postgres/","title":"\\watch ing Star Wars in Postgres"},
-    {"url":"https://numeracy.co/blog/life-of-a-sql-query","title":"Life of a Sql Query"},
-    {"url":"https://www.nytimes.com/2016/02/28/magazine/what-google-learned-from-its-quest-to-build-the-perfect-team.html","title":"What Google Learned From Its Quest to Build the Perfect Team (2016)"},
-    {"url":"https://www.wsj.com/articles/u-s-changes-visa-process-for-high-skilled-workers-11548879868","title":"U.S. Changes Visa Process for High-Skilled Workers"},
-    {"url":"https://www.theguardian.com/technology/2019/jan/31/how-facebook-robbed-us-of-our-sense-of-self","title":"Facebook robbed us of our sense of self"},
-    {"url":"https://geneticliteracyproject.org/2019/01/29/how-germs-and-ancient-migration-help-explain-our-world-of-haves-and-have-nots/","title":"Germs and ancient migrations help explain our world of 'haves' and 'have nots'"},
-    {"url":"https://insights.dice.com/2019/01/29/tech-salaries-stagnant-low-unemployment-dice-salary-survey/?CMPID=EM_RE_UP_JS_AD_DA_CP_A_&utm_source=Responsys&utm_medium=Email&utm_content=&utm_campaign=Advisory_DiceAdvisor_A","title":"Tech Salaries Stagnant Despite Low Unemployment: Survey"},
-    {"url":"https://www.weforum.org/agenda/2018/02/south-korea-and-sweden-are-the-most-innovative-countries-in-the-world/","title":"South Korea and Sweden are the most innovative countries in the world"},
-    {"url":"https://news.ycombinator.com/item?id=19047093","title":"Ask HN: What’s your go-to investment for protecting cash from inflation?"},
-    {"url":"https://write.as/blog/ending-our-medium-integration","title":"Ending our Medium integration"},
-    {"url":"https://www.statisticsdonewrong.com/","title":"Statistics Done Wrong"},
-    {"url":"https://www.nytimes.com/2019/01/31/opinion/ai-bias-healthcare.html","title":"Opinion: A.I. Could Worsen Health Disparities"},
-    {"url":"https://arxiv.org/abs/1807.08416","title":"Some Fundamental Theorems in Mathematics"},
-    {"url":"https://arturdryomov.online/posts/superior-testing-stop-stopping/","title":"Superior Testing: Stop Stopping"},
-    {"url":"https://reich.hms.harvard.edu/five-corrections-new-york-times","title":"Five Corrections to The New York Times"},
-    {"url":"https://techcrunch.com/2019/01/30/facebook-earnings-q4-2018/","title":"Facebook shares shoot up after strong Q4 earnings despite data breach"},
-    {"url":"https://lidarmag.com/2019/01/27/elon-musk-is-right-lidar-is-a-crutch/","title":"Lidar Is a Crutch"},
-    {"url":"https://www.theguardian.com/technology/2019/jan/31/apple-facebook-campus-permissions-revoked-teens-access-data-iphone-app","title":"Apple leaves Facebook offices in disarray after revoking app permissions"},
-    {"url":"https://thepointsguy.com/news/boeing-787-suffers-rare-dual-engine-failure-on-landing/","title":"Boeing 787 Suffers Rare Dual Engine Failure on Landing"},
-    {"url":"https://www.nytimes.com/2019/01/31/business/locast-streaming-free-network-tv.html","title":"Locast, a Free App Streaming Network TV, Would Love to Get Sued"},
-    {"url":"https://www.theatlantic.com/magazine/archive/2019/03/how-humans-tamed-themselves/580447/","title":"A New Theory Proposes That Humans Tamed Themselves"},
-    {"url":"https://jarredsumner.com/codeblog/","title":"Why isn't the internet more fun and weird?"},
-    {"url":"https://vimist.github.io/2019/01/30/Steganographic-Packets.html","title":"Steganographic Packets"},
-    {"url":"https://www.bbc.co.uk/news/stories-47033704","title":"Why some Japanese pensioners want to go to jail"},
-    {"url":"https://support.google.com/plus/answer/9195133","title":"Shutting down Google+ for consumer (personal) accounts on April 2, 2019"},
-    {"url":"https://www.reuters.com/investigates/special-report/usa-spying-karma/","title":"'Karma': A hack used by the UAE to break into iPhones of foes"},
-    {"url":"https://www.nytimes.com/2019/01/30/health/facebook-psychology-health.html","title":"This is Your Brain Off Facebook - study offers glimpse of unplugging"},
-    {"url":"https://www.theatlantic.com/international/archive/2019/01/colombia-welcomes-millions-venezuelans-maduro-guaido/581647/","title":"Colombia’s Plan to Welcome Millions of Venezuelan Migrants"},
-    {"url":"http://nautil.us/issue/68/context/what-impossible-meant-to-feynman","title":"What Impossible Meant to Feynman"},
-    {"url":"https://lemire.me/blog/2019/01/31/my-blog-cant-keep-up-500-errors-all-over/","title":"My blog can’t keep up: 500 errors all over"},
-    {"url":"http://bactra.org/notebooks/godels-theorem.html","title":"Gödel's Theorem"},
-    {"url":"http://eurydice13.com/2019/01/how-to-prepare-for-and-run-a-design-thinking-gamestorming-creative-workshop-and-what-to-do-with-the-outputs-too/","title":"Preparing for and runing a Design Thinking, Gamestorming and Creative workshop"},
-    {"url":"https://techcrunch.com/2019/01/30/googles-also-peddling-a-data-collector-through-apples-back-door/","title":"Google’s also peddling a data collector through Apple’s back door"},
-    {"url":"https://www.nytimes.com/interactive/2019/01/31/us/public-defender-case-loads.html","title":"One Lawyer, One Day, 194 Felony Cases"},
-    {"url":"https://www.wsj.com/articles/elon-musks-surprise-pick-for-tesla-cfo-is-a-relative-unknown-11548935508","title":"Elon Musk’s Surprise Pick for Tesla CFO Is a Relative Unknown"},
-    {"url":"https://jalopnik.com/chicago-is-so-ridiculously-cold-that-the-railroad-track-1832177510/","title":"It’s so cold in Chicago, crews had to set fire to commuter rail tracks"},
-    {"url":"https://www.npr.org/sections/thetwo-way/2012/02/06/146490064/remembering-roger-boisjoly-he-tried-to-stop-shuttle-challenger-launch","title":"Remembering Roger Boisjoly: He Tried to Stop Shuttle Challenger Launch"},
-    {"url":"https://www.bloomberg.com/news/articles/2019-01-30/apple-shares-rally-as-company-outlines-life-beyond-the-iphone","title":"Apple's Business Beyond the iPhone"},
-    {"url":"https://github.com/RSS-Bridge/rss-bridge","title":"RSS-Bridge: the RSS feed for websites missing it"},
-    {"url":"https://8bitworkshop.com/","title":"8bit Workshop"},
-    {"url":"https://www.reuters.com/article/us-southkorea-economy-pets/like-a-son-but-cheaper-harried-south-koreans-pamper-pets-instead-of-having-kids-idUSKCN1PI029","title":"Harried South Koreans pamper pets instead of having kids"},
-    {"url":"https://www.vice.com/en_ca/article/yv574m/ive-owned-the-moon-since-1980","title":"Dennis M. Hope Has Owned the Moon Since 1980 Because He Says So"},
-    {"url":"https://en.wikipedia.org/wiki/Scramble_for_Africa","title":"Scramble for Africa"},
-    {"url":"https://www.stef.be/bassoontracker/","title":"Amiga Music Tracker in JavaScript"},
-    {"url":"https://techcrunch.com/2019/01/30/rigetti-launches-the-public-beta-of-its-quantum-cloud-services/","title":"Rigetti launches the public beta of its Quantum Cloud Services"},
-    {"url":"https://techcrunch.com/2019/01/30/state-bank-india-data-leak/","title":"India’s largest bank SBI leaked account data on millions of customers"},
-    {"url":"https://www.amusingplanet.com/2019/01/bookwheel-16th-century-forerunner-to.html","title":"Bookwheel, the 16th Century Forerunner to the EBook Reader"},
-    {"url":"https://m.signalvnoise.com/yesterdays-mass-login-attack-on-basecamp-is-another-reminder-to-protect-yourself/","title":"Basecamp handled a security breach yesterday"},
-    {"url":"https://news.ycombinator.com/item?id=19045141","title":"Ask HN: Is there room for a new ‘curated’ search engine?"},
-    {"url":"https://culturehustle.com/products/black-3-0-beta-evaluation-batch-blackest-black-acrylic-paint-20ml","title":"BLACK 3.0 BETA blackest black acrylic paint"},
-    {"url":"https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html","title":"Lock-Free Rust: Crossbeam in 2019"},
-    {"url":"https://artamonoviv.ru/wp-content/uploads/2016/08/Coloured_Petri_Nets_modeling_and_validation_of_concurrent_systems__2009.pdf","title":"Coloured Petri Nets: Modelling and Validation of Concurrent Systems (2009) [pdf]"},
-    {"url":"https://www.cs.uaf.edu/users/chappell/public_html/class/2018_spr/cs331/docs/types_primer.html","title":"A Primer on Type Systems"},
-    {"url":"https://en.wikipedia.org/wiki/Bloom%27s_taxonomy","title":"Bloom's Taxonomy"},
-    {"url":"https://blog.bugsnag.com/server-side-rendering-and-authenticated-content/","title":"Server-side rendering: how to serve authenticated content"},
-    {"url":"https://www.nature.com/articles/d41586-019-00236-4","title":"The first synthetic element"},
-    {"url":"https://www.theverge.com/2019/1/31/18204559/apple-facebook-feud-market-research-platform-power","title":"Apple’s power over Facebook ought to worry the rest of us"},
-    {"url":"https://www.reuters.com/article/us-iran-usa-sanctions-eu/germany-france-britain-to-launch-mechanism-for-trade-with-iran-idUSKCN1PP0K3","title":"Skirting U.S. sanctions, Europeans launch trade mechanism for Iran"},
-    {"url":"https://lemire.me/blog/2019/01/30/what-is-the-space-overhead-of-base64-encoding/","title":"What is the space overhead of Base64 encoding?"},
-    {"url":"https://theintercept.com/2019/01/30/prison-voice-prints-databases-securus/","title":"Prisons Are Quietly Building Databases of Incarcerated People’s Voice Prints"},
-    {"url":"https://codewithoutrules.com/2019/01/31/does-company-have-worklife-balance/","title":"Do they have work/life balance? Investigating potential employers with GitHub"},
-    {"url":"https://openchirp.io/","title":"OpenChird – An Open Source Platform for IoT with Support for LoRaWAN"},
-    {"url":"https://blog.kyber.network/wbtc-is-now-live-on-ethereum-4b4e2d1ef76f","title":"Wrapped Bitcoin (WBTC) Is Now Live on Ethereum"},
-    {"url":"https://k-bx.github.io/articles/drinker.html","title":"Struggling with My Drinker's Problem"},
-    {"url":"https://ebzzry.io/en/script-lisp/","title":"Scripting in Common Lisp"},
-    {"url":"https://spreadprivacy.com/privacy-simplified/","title":"Use DuckDuckGo to improve your privacy online (2018)"},
-    {"url":"http://www.openculture.com/2018/07/jean-paul-sartre-bad-mescaline-trip-hallucinated-years-followed-crabs.html","title":"Jean-Paul Sartre Had a Bad Mescaline Trip (2018)"},
-    {"url":"https://www.atlasobscura.com/articles/what-is-sigma-derby","title":"Time Running Out for Beloved Mechanical Horse-Race Game in Vegas"},
-    {"url":"https://github.com/hughpyle/ASR33/blob/master/asciiart/README.md","title":"Show HN: ASCII Art with Overstrike"},
-    {"url":"https://motherboard.vice.com/en_us/article/wjm5kw/nintendo-makes-it-clear-that-piracy-is-the-only-way-to-preserve-video-game-history","title":"Nintendo Makes It Clear That Piracy Is Only Way to Preserve Video Game History"},
-    {"url":"https://www.nytimes.com/2019/01/30/business/foxconn-wisconsin-manufacturing.html","title":"Foxconn Is Reconsidering Plan for Manufacturing in Wisconsin"},
-    {"url":"https://www.theverge.com/2019/1/29/18202398/apple-facetime-bug-warned-eavesdropping","title":"Apple was warned about the FaceTime eavesdropping bug last week"},
-    {"url":"https://evilmartians.com/chronicles/anonymous-web-authentication-with-stellar-blockchain","title":"Anonymous web authentication with Stellar blockchain"},
-    {"url":"https://status.office365.com/","title":"Office 365 global authentication outage"},
-    {"url":"https://www.wsj.com/articles/new-york-insurers-can-evaluate-your-social-media-useif-they-can-prove-why-its-needed-11548856802","title":"NY Insurers Can Evaluate Social Media Use If They Can Prove Why It’s Needed"},
-    {"url":"https://code.fb.com/ml-applications/random-encoders/","title":"No training required: Exploring random encoders for sentence classification"},
-    {"url":"https://towardsdatascience.com/the-unsung-heroes-of-modern-software-development-561fc4cb6850","title":"The Unsung Heroes of Modern Software Development"},
-    {"url":"https://alpinelinux.org/posts/Alpine-3.9.0-released.html","title":"Alpine Linux 3.9.0 Released"},
-    {"url":"https://eng.uber.com/aresdb/","title":"AresDB: Uber’s GPU-Powered Open-Source, Real-Time Analytics Engine"},
-    {"url":"https://limitedresults.com/2019/01/pwn-the-lifx-mini-white/","title":"Pwn the LIFX Mini white"},
-    {"url":"https://blogs.scientificamerican.com/observations/the-topography-of-disease/#googDisableSync","title":"The Topography of Disease"},
-    {"url":"https://www.saiglobal.com/en-au/news_and_resources/industry_news/google_feels_the_brunt_of_gdpr_enforcement/","title":"Google Feels the Brunt of GDPR Enforcement"},
-    {"url":"https://www.interviewcake.com/article/java/data-structures-coding-interview","title":"Data Structures for coding interviews"},
-    {"url":"http://olafurw.com/2019-01-27-programmer-advice/","title":"Advice to new programmers"},
-    {"url":"https://www.centauri-dreams.org/2019/01/29/future-ai-the-explorer-and-the-philosopher/","title":"Future AI: The Explorer and the Philosopher"},
-    {"url":"https://mashable.com/article/facebook-employees-react-teen-spying-app-blind/#X5hGityLeaqd","title":"'Fuck ethics. Money is everything' FB employees react to scandal on gossip app"},
-    {"url":"https://github.com/CurtisLusmore/ghp","title":"Show HN: Serve Static GitHub Pages Locally"},
-    {"url":"https://blog.fuzzing-project.org/65-When-your-Memory-Allocator-hides-Security-Bugs.html","title":"When a Memory Allocator Hides Security Bugs"},
-    {"url":"http://bostonreview.net/science-nature/tom-rutledge-man-who-invented-information-theory","title":"The Man Who Invented Information Theory (2017)"},
-    {"url":"https://news.ycombinator.com/item?id=19037467","title":"Launch HN: DevFlight (YC W19) – Helping open-source maintainers make money"},
-    {"url":"https://evolt.org/node/564","title":"Napster: A New Killer Internet App (1999)"},
-    {"url":"https://www.theverge.com/2019/1/30/18203551/apple-facebook-blocked-internal-ios-apps","title":"Apple blocks Facebook from running its internal iOS apps"},
-    {"url":"https://theory.stanford.edu/~aiken/publications/trs/FLProject.pdf","title":"The FL Project: The Design of a Function Language (1989) [pdf]"},
-    {"url":"https://www.newyorker.com/tech/annals-of-technology/how-scripto-the-app-that-stephen-colbert-helped-build-became-a-fixture-of-late-night-comedy-news","title":"The Scripto App Became a Fixture of Late-Night Comedy News (2018)"},
-    {"url":"https://www.anandtech.com/show/13748/the-intel-xeon-w-3175x-review-28-unlocked-cores-2999-usd","title":"The Intel Xeon W-3175X Review: 28 Unlocked Cores, $2999"},
-    {"url":"https://motherboard.vice.com/en_us/article/yw8vm7/android-security-locking-out-law-enforcement-unintended-side-effect","title":"Head of Android Security: Locking Out Law Enforcement Is Unintended Side Effect"},
-    {"url":"https://research.eligrey.com/status/1090696844944932864","title":"Google is discontinuing their free weather API"},
-    {"url":"https://beta.aifiddle.io/","title":"Show HN: Deep Learning GUI to Create, Train and Visualize Models in a Browser"},
-    {"url":"https://www.wowa.me/","title":"Royalty Free No Copyright Music for All Your Projects"},
-    {"url":"https://jerrington.me/posts/2019-01-29-self-hosted-ngrok.html","title":"Roll Your Own Ngrok with Nginx, Letsencrypt, and SSH Reverse Tunnelling"},
-    {"url":"https://github.com/rvhuang/pathfinding-lab","title":"Pathfinding Laboratory"},
-    {"url":"https://paleotronic.com/2019/01/30/arthur-c-clarke-communications-in-the-second-century-of-the-telephone-1977/","title":"Arthur C. Clarke: Communications in the Second Century of the Telephone (1977)"},
-    {"url":"http://varnish-cache.org/docs/trunk/phk/notes.html","title":"Notes from the Architect (2006)"},
-    {"url":"https://www.wired.com/story/google-chrome-kill-url-first-steps/","title":"Google Takes Its First Steps Toward Killing the URL"},
-    {"url":"https://www.sciencedaily.com/releases/2019/01/190128125314.htm","title":"'Metallic wood' has the strength of titanium and the density of water"},
-    {"url":"https://dmitryfrank.com/articles/how_i_ended_up_writing_my_own_kernel","title":"How I ended up writing a new real-time kernel (2015)"},
-    {"url":"https://bugs.webkit.org/show_bug.cgi?id=194028","title":"Add limits to amount of JavaScript that can be loaded by a website"},
-    {"url":"https://github.com/victorqribeiro/photoEditor","title":"Show HN: A Image Editor in JavaScript Canvas"},
-    {"url":"https://daily.jstor.org/when-was-first-handshake/","title":"When Was the First Handshake?"},
-    {"url":"https://techcrunch.com/2019/01/30/google-for-consumers-will-shut-down-on-april-2nd/","title":"Google+ for consumers will shut down on April 2nd"},
-    {"url":"https://www.opendemocracy.net/brexitinc/paul-hilder/they-were-planning-on-stealing-election-explosive-new-tapes-reveal-cambridg","title":"New tapes reveal Cambridge Analytica CEO’s boasts of voter suppression"},
-    {"url":"https://exclusive-design.vasilis.nl/","title":"Exclusive Design"},
-    {"url":"https://github.com/Microsoft/project-rome","title":"Microsoft Project Rome 1.0.0"},
-    {"url":"https://blog.torproject.org/tors-open-research-topics-2018-edition","title":"Tor's Open Research Topics (2018)"},
-    {"url":"https://eli.thegreenplace.net/2019/on-concurrency-in-go-http-servers/","title":"On Concurrency in Go HTTP Servers"},
-    {"url":"https://blog.statebox.org/why-visual-programming-doesnt-suck-2c1ece2a414e","title":"Visual Programming Doesn’t Suck"},
-    {"url":"https://tylerayoung.com/2019/01/29/benchmarks-of-cache-friendly-data-structures-in-c/","title":"Benchmarks of Cache-Friendly Data Structures in C++"},
-    {"url":"http://ir.tesla.com/static-files/0b913415-467d-4c0d-be4c-9225c2cb0ae0","title":"Tesla Q4 2018 Earnings Letter"},
-    {"url":"https://www.fastcompany.com/90299216/japan-will-try-to-hack-its-citizens-routers-and-webcams-in-the-name-of-cybersecurity","title":"Japan to hack its citizens’ routers and webcams in name of cybersecurity"},
-    {"url":"https://www.washingtonpost.com/technology/2019/01/29/report-americans-got-billion-robocalls-last-year-up-percent/","title":"Americans got 26.3B robocalls last year, up 46 percent from 2017"},
-    {"url":"https://jack-vanlightly.com/blog/2019/1/27/building-a-simple-distributed-system-formal-verification","title":"Building a “Simple” Distributed System – Formal Verification"},
-    {"url":"https://youngdynasty.net/posts/writing-mac-apps-in-go/","title":"Writing Apps in Go and Swift"},
-    {"url":"https://blog.racket-lang.org/2019/01/racket-on-chez-status.html","title":"Racket-On-Chez Status: January 2019"},
-    {"url":"https://www.theverge.com/facebook/2019/1/30/18203349/facebook-research-app-apple-shutdown","title":"Facebook will shut down its controversial market research app for iOS"},
-    {"url":"https://www.nytimes.com/2019/01/30/arts/fyre-festival-billy-mcfarland-elizabeth-holmes-anna-delvey.html","title":"Our Never Ending 'Scam Season'"},
-    {"url":"https://erfur.github.io/down_the_rabbit_hole_pt1/","title":"Down the Rabbit Hole – Part I: A Journey into the UEFI Land"},
-    {"url":"https://www.nytimes.com/interactive/2019/01/29/magazine/china-globalization-kazakhstan.html","title":"Can China Turn the Middle of Nowhere into the Center of the World Economy?"},
-    {"url":"https://www.workingwa.org/instacart-eighty-cents","title":"Instacart paying 80 cents an hour because worker received a large tip"},
-    {"url":"https://puri.sm/posts/librem-5-hardware-update/","title":"Librem 5 Hardware Update"},
-    {"url":"https://www.nytimes.com/2019/01/25/arts/music/verdi-papers-italy.html","title":"5,000 Pages of Verdi’s Drafts, Long Hidden, Will Be Made Public"},
-    {"url":"https://github.com/joewalnes/websocketd","title":"Turn any program that uses stdin/stdout into a WebSocket server"},
-    {"url":"http://www.cgl.uwaterloo.ca/csk/projects/mazes/","title":"Maze Design (2005)"},
-    {"url":"https://www.bbc.com/news/world-us-canada-47066652","title":"Mystery illness sees Canada halve its Cuba embassy staff"},
-    {"url":"https://www.youtube.com/watch?v=hnM252gU-g4","title":"Using Logic Programming to Recover C++ Classes and Methods from Executables"},
-    {"url":"https://www.artsy.net/article/artsy-editorial-nasa-art-shape-vision-future","title":"Nasa Used Art to Shape Our Vision of the Future"},
-    {"url":"https://github.com/bxcodec/faker","title":"Show HN: Faker – Struct Data Fake Generator in Go"},
-    {"url":"https://www.sfchronicle.com/business/article/H-1B-visa-lottery-changing-to-favor-those-with-13574410.php","title":"H-1B visa lottery changing to favor those with advanced degrees"},
-    {"url":"https://functionalcs.github.io/curriculum/","title":"A Self-Learning, Modern Computer Science Curriculum"},
-    {"url":"https://www.wired.com/story/collection-leak-usernames-passwords-billions/","title":"Hackers Are Passing Around a Megaleak of 2.2B Records"},
-    {"url":"https://news.ycombinator.com/item?id=19031711","title":"Ask HN: Why can’t I block all incoming calls that aren’t in my contact list?"},
-    {"url":"https://www.cyberscoop.com/mobile-zero-days-lookout-shmoocon-2019-android-barracuda-ios-stonefish/","title":"FinFisher offered to sell nation-states a zero-click iOS compromise"},
-    {"url":"https://9to5mac.com/2019/01/30/jizhong-chen-charged-theft-project-titan-trade-secrets/","title":"Apple employee accused stealing ‘Titan’ trade secrets for a Chinese competitor"},
-    {"url":"https://www.jpl.nasa.gov/news/news.php?feature=7322","title":"Huge Cavity in Antarctic Glacier Signals Rapid Decay"},
-    {"url":"https://techcrunch.com/2019/01/29/facebook-project-atlas/","title":"Facebook has been paying people to install a “Research” VPN"},
-    {"url":"https://blockstack.org/","title":"Building decentralized blockchain webpages"},
-    {"url":"http://naplab.ee.columbia.edu/reconstruction.html","title":"Reconstructing intelligible speech from the human auditory cortex"},
-    {"url":"http://www.righto.com/2019/01/inside-apollo-guidance-computers-core.html","title":"Inside the Apollo Guidance Computer's Core Memory"},
-    {"url":"https://postmake.io/open","title":"Show HN: Open startups with their revenue, metrics, and stories"},
-    {"url":"https://gravitational.com/blog/kubernetes-kustomize-kep-kerfuffle/","title":"The Kubernetes Kustomize KEP Kerfuffle"},
-    {"url":"https://www.mozilla.org/en-US/firefox/65.0/releasenotes/","title":"Firefox 65.0 released"},
-    {"url":"https://www.theregister.co.uk/2019/01/30/azure_sql_delete/","title":"Microsoft accidentally deletes customer DBs"},
-    {"url":"https://news.ycombinator.com/item?id=19038580","title":"Ask HN: Discipline but no focus, how to fix?"},
-    {"url":"https://genius.engineering/you-have-to-hear-it-to-believe-it-how-audio-messaging-improved-our-conversion-rate-more-than-50/","title":"An audio message improved our conversion rate by more than 50%"},
-    {"url":"https://www.seattletimes.com/business/real-estate/ceos-of-seattle-areas-biggest-companies-we-need-more-housing-for-the-middle-class/","title":"CEOs of Seattle area’s biggest companies: We need more middle-class housing"},
-    {"url":"https://news.ycombinator.com/item?id=19025885","title":"Ask HN: How much time to devote to learning algorithms vs. creating software?"},
-    {"url":"https://arxiv.org/abs/1401.1219","title":"Consciousness as a State of Matter (2015)"},
-    {"url":"https://www.bloomberg.com/opinion/articles/2019-01-29/hollywood-stars-didn-t-pay-90-percent-tax-they-created-loopholes","title":"The Golden Age of Hollywood Tax Avoidance"},
-    {"url":"https://www.latimes.com/business/la-fi-pge-bankruptcy-filing-20190129-story.html","title":"PG&E files for bankruptcy"},
-    {"url":"https://www.macleans.ca/thai-cave-rescue-heroes/","title":"The heroes of the Thai cave rescue"},
-    {"url":"https://medium.com/@gajus/lessons-learned-scaling-postgresql-database-to-1-2bn-records-month-edc5449b3067","title":"Lessons learned scaling a PostgreSQL database to 1.2bn records/month"},
-    {"url":"https://techcrunch.com/2019/01/30/apples-facetime-bug-will-be-investigated-by-new-yorks-attorney-general/","title":"Apple’s FaceTime Bug Will Be Investigated by New York’s Attorney General"},
-    {"url":"https://onlinelibrary.wiley.com/doi/full/10.1002/aur.2064","title":"Predictors of mental health in employed adults with autism spectrum disorder"},
-    {"url":"http://www.inference.org.uk/itprnn/book.pdf","title":"Information Theory, Inference, and Learning Algorithms (2005) [pdf]"},
-    {"url":"https://www.cnbc.com/2019/01/29/walgreens-cvs-test-teeth-straightening-cleaning-in-some-stores.html","title":"Walgreens, CVS test teeth straightening, cleanings in some stores"},
-    {"url":"https://www.sciencealert.com/mind-altering-cat-parasite-linked-to-schizophrenia-in-largest-study-yet","title":"Scientists find link between infection with Toxoplasma gondii and schizophrenia"},
-    {"url":"https://towardsdatascience.com/applying-ai-to-horse-racing-e3632a7e7c92","title":"My journey applying AI to horse racing"},
-    {"url":"https://www.newsweek.com/theyre-selling-unicorns-israel-cancer-cure-claim-debunked-experts-1311656","title":"'THEY'RE SELLING UNICORNS:' ISRAEL CANCER CURE CLAIM DEBUNKED BY EXPERTS"},
-    {"url":"https://github.com/fabiospampinato/notable#readme","title":"Show HN: Notable – The markdown-based note-taking app that doesn't suck"},
-    {"url":"https://www.justice.gov/opa/pr/justice-department-announces-court-authorized-efforts-map-and-disrupt-botnet-used-north","title":"Justice Department Announces Court-Authorized Efforts to Map and Disrupt Botnet"},
-    {"url":"https://news.ycombinator.com/item?id=19043182","title":"Use a special phrase to mark paywalled articles on HN"},
-    {"url":"https://www.nytimes.com/2019/01/29/opinion/artificial-intelligence-surveillance.html","title":"Warning Everything Is Going Deep: ‘The Age of Surveillance Capitalism’"},
-    {"url":"https://blog.freedombone.net/dark-messenger","title":"Dark Messenger: Mobile XMPP Over TOR"},
-    {"url":"https://tech.townsourced.com/post/boltdb-vs-badger/","title":"BoltDB vs. Badger: A Comparison of Go Key-Value Databases"},
-    {"url":"https://www.cs.uaf.edu/users/chappell/public_html/misc/freesp.html","title":"Freedom of speech memo, President of the university of Alaska, March 2001"},
-    {"url":"https://haydenjames.io/linux-networking-commands-scripts/","title":"I Tried to List All Linux Networking Commands and Scripts"},
-    {"url":"https://www.forbes.com/sites/jasonevangelho/2019/01/30/the-new-pinebook-pro-will-challenge-google-chromebooks-for-199/","title":"New Pinebook Pro Will Challenge Google Chromebooks for $199"},
-    {"url":"https://www.businessinsider.com/lyft-juno-sue-new-york-city-minimum-wage-law-for-drivers-2019-1","title":"Lyft and Juno are suing New York City after new minimum wage requirements"},
-    {"url":"https://arstechnica.com/gadgets/2019/01/the-roomba-lawnmower-is-finally-happening/","title":"The Roomba lawnmower is finally happening"},
-    {"url":"https://techcrunch.com/2019/01/30/nyc-council-questions-tax-breaks-and-economic-impact-of-amazon-hq2/","title":"NYC Council questions tax breaks and economic impact of Amazon HQ2"},
-    {"url":"https://torrentfreak.com/youtube-strikes-now-being-used-as-scammers-extortion-tool/","title":"YouTube Strikes Now Being Used as Scammers’ Extortion Tool"},
-    {"url":"https://hashnode.com/post/docker-tutorial-for-beginners-cjrj2hg5001s2ufs1nker9he2","title":"Docker tutorial for beginners"},
-    {"url":"https://medium.com/@louisbarclay/become-ceo-of-this-sexy-startup-for-just-1-a-month-6f3db6828410","title":"Become CEO of this sexy startup for just $1 a month"},
-    {"url":"https://www.inc.com/christine-lagorio/steve-blank-lean-startup-founders-project.html","title":"A Screaming Boss Helped Steve Blank Develop His Brilliant Startup Philosophy"},
-    {"url":"https://www.newyorker.com/science/elements/a-study-on-driverless-car-ethics-offers-a-troubling-look-into-our-values","title":"A Study on Driverless-Car Ethics"},
-    {"url":"https://www.theverge.com/2019/1/29/18202602/san-francisco-facial-recognition-ban-proposal","title":"San Francisco proposal would ban government facial recognition use in the city"},
-    {"url":"https://news.ycombinator.com/item?id=19026014","title":"Ask HN: Are there any online lawyer services?"},
-    {"url":"https://thenextweb.com/apple/2019/01/31/after-facebook-google-apologizes-for-running-a-user-data-collection-program-on-ios/","title":"After Facebook, Google apologizes for running a user data collection program"},
-    {"url":"https://www.reuters.com/article/us-foxconn-wisconsin-exclusive/exclusive-foxconn-reconsidering-plans-to-make-lcd-panels-at-wisconsin-plant-idUSKCN1PO0FV","title":"Foxconn reconsidering plans to make LCD panels at Wisconsin plant"},
-    {"url":"https://twitter.com/oliviaabland/status/1090281095805980672","title":"I had a job interview for a position at a company called Web Applications UK"},
-    {"url":"https://uk.reuters.com/article/uk-usa-spying-raven-specialreport/special-report-inside-the-uaes-secret-hacking-team-of-u-s-mercenaries-idUKKCN1PO1A6","title":"The UAE’s hacking team of U.S. mercenaries"},
-    {"url":"https://medium.com/@lukeberner/7e3f455b71a1","title":"I abused 2FA to maintain persistence after a password change"},
-    {"url":"https://nwn.blogs.com/nwn/2019/01/nylon-pinkney-sl-comics-flickr.html","title":"When your UX is so bad your userbase ridicules it in a whole series of comics"},
-    {"url":"https://github.com/LedgerHQ/ledger-live-mobile","title":"Ledger Live: A mobile companion app for Ledger hardware wallets"},
-    {"url":"https://news.ycombinator.com/item?id=19034707","title":"Ask HN: How do you come up with side projects?"},
-    {"url":"https://mashable.com/article/facebook-employees-react-teen-spying-app-blind/","title":"'Fuck ethics. Money is everything': Facebook employees react to scandal"},
-    {"url":"https://www.theverge.com/2019/1/30/18204186/facebook-q4-2018-earnings-user-growth-revenue-increase-privacy-scandals","title":"Facebook keeps growing despite scandals and privacy outrage"},
-    {"url":"https://www.dailymail.co.uk/health/article-6648545/Mind-altering-parasite-spread-CATS-lead-schizophrenia.html","title":"Mind-altering parasite spread by cats 'may lead to schizophreni'"},
-    {"url":"https://www.freep.com/story/weather/2019/01/30/consumers-energy-dte-usage-polar-vortex/2724017002/","title":"Michigan electric, gas capacity down significantly during polar vortex"},
-    {"url":"https://www.sciencemuseum.org.uk/about-us/press-office/3d-scan-reveals-intricate-detail-iconic-locomotive","title":"3D scan reveals intricate detail of iconic 1829 locomotive"},
-    {"url":"https://blog.floydhub.com/instagram-street-art/","title":"On Building an Instagram Street Art Dataset and Detection Model"},
-    {"url":"https://medium.com/automation-generation/hft-like-trading-algorithm-in-300-lines-of-code-you-can-run-now-983bede4f13a","title":"Show HN: HFT-Like Trading Algo in 300 Lines of Python"},
-    {"url":"https://www.businessinsider.com/facebook-q4-2018-earnings-2019-1","title":"FB soars after hours after beating top and bottom line for Q4 earnings"},
-    {"url":"https://techcrunch.com/2019/01/30/apple-bans-facebook-vpn/","title":"Apple bans Facebook’s Research app that paid users for data"},
-    {"url":"https://www.microsoft.com/en-us/Investor/earnings/FY-2019-Q2/press-release-webcast","title":"Microsoft announces record earnings on strong cloud growth"},
-    {"url":"https://mashable.com/article/facebook-will-stop-disclosing-metrics-for-main-app/#wrBjaaQghaqs","title":"Facebook doesn't want to talk about how many people use its app anymore"},
-    {"url":"https://nummberr.com/","title":"Show HN: Nummberr a random number generator PWA"},
-    {"url":"https://betterhumans.coach.me/how-to-walk-100-000-steps-in-one-day-5087adbd4569","title":"How to Walk 100,000 Steps in One Day"},
-    {"url":"https://openimagedenoise.github.io/","title":"Intel Open Image Denoise: High-Performance Denoising Library for Ray Tracing"},
-    {"url":"https://medium.com/@christianalfoni/reducing-the-pain-of-developing-apps-cd10b2e6a83c","title":"Reducing the pain of developing apps"},
-    {"url":"https://news.ycombinator.com/item?id=19042334","title":"Ask HN: Which large tech company will best prepare me to be a startup founder?"},
-    {"url":"https://quid.works/","title":"Show HN: Quid – try micropayments instead of ads or subscriptions"},
-    {"url":"https://towardsdatascience.com/learn-how-to-listen-edaea38fb276","title":"Learn How to Listen – One of the hardest parts of being a data scientist"},
-    {"url":"https://news.ycombinator.com/item?id=19040843","title":"Ask HN: What are your rules-of-thumb for personal finance and saving?"},
-    {"url":"https://www.reuters.com/article/idUSKCN1PO0FV","title":"Foxconn reconsidering plans to make LCD panels at Wisconsin plant"},
-    {"url":"https://developers.google.com/web/updates/2019/01/nic72","title":"New in Chrome 72"},
-    {"url":"https://www.da-platform.com/blog/match_recognize-where-flink-sql-and-complex-event-processing-meet","title":"MATCH_RECOGNIZE: Where Flink Sql and Complex Event Processing Meet"},
-    {"url":"https://fusionauth.io/blog/2019/01/29/white-paper-developers-guide-gdpr","title":"Developers guide to GDPR"},
-    {"url":"http://blog.felipe.rs/2019/01/29/demystifying-join-algorithms/","title":"Demystifying JOIN Algorithms"},
-    {"url":"https://techcrunch.com/2019/01/30/elon-musk-wants-teslas-to-automatically-call-a-tow-truck-when-something-breaks/","title":"Elon Musk wants Teslas to automatically call a tow truck when something breaks"},
-    {"url":"http://paulrubenstein.co.uk/variational-autoencoders-are-not-autoencoders/","title":"Variational Autoencoders are not autoencoders"},
-    {"url":"https://arstechnica.com/gaming/2019/01/an-ai-crushed-two-human-pros-at-starcraft-but-it-wasnt-a-fair-fight/","title":"An AI crushed two human pros at StarCraft–but it wasn’t a fair fight"},
-    {"url":"https://medium.com/@karl.pickett/benchmarking-a-toy-c-task-vs-a-go-goroutine-is-there-any-difference-248f73f7f7b7","title":"Benchmarking 1M C# tasks vs. Go goroutines"},
-    {"url":"https://news.ycombinator.com/item?id=19028449","title":"Launch HN: Scribe 2.0 (YC W17) – Configurable, Actionable Alerts on Slack"},
-    {"url":"https://www.reuters.com/article/us-foxconn-wisconsin-exclusive-idUSKCN1PO0FV","title":"Foxconn reconsidering plans to make LCD panels at Wisconsin plant"},
-    {"url":"https://news.ycombinator.com/item?id=19032802","title":"Ask HN: Is there any social network you trust?"},
-    {"url":"https://habr.com/en/post/437912/","title":"A small notebook for a system administrator"},
-    {"url":"https://www.research.ibm.com/artificial-intelligence/trusted-ai/diversity-in-faces/","title":"Diversity in Faces: A Dataset of Annotations of 1M Human Facial images"},
-    {"url":"https://hothardware.com/news/amd-lisa-su-q4-7nm-strength-epyc-double-performance","title":"AMD Talks Datacenter Share Gains as EPYC's 2X Uplift per Socket Drives Revenue"},
-    {"url":"https://tails.boum.org/news/version_3.12/index.en.html","title":"Tails 3.12 is out"},
-    {"url":"https://outage.report/gmail","title":"Gmail Services Global Outage"},
-    {"url":"https://github.com/komeiji-satori/Dress","title":"Dress: learn how to GitHub by posting your cosplay"},
-    {"url":"https://en.wikipedia.org/wiki/The_Blazing_World","title":"The Blazing World"},
-    {"url":"https://markets.businessinsider.com/news/stocks/facebook-chaos-after-apple-blocks-internal-iphone-apps-report-2019-1-1027910304","title":"Chaos has reportedly erupted inside Facebook as Apple revoked FB's certificate"},
-    {"url":"https://www.businessinsider.com/facebook-chaos-after-apple-blocks-internal-iphone-apps-report-2019-1","title":"Facebook employees unable to open internal apps"},
-    {"url":"https://news.ycombinator.com/item?id=19040139","title":"Ask HN: How to practise Algo/DS for interviews that are every 2-3 years?"},
-    {"url":"https://github.com/Microsoft/vscode/wiki/Roadmap","title":"VS Code Roadmap 2019"},
-    {"url":"https://www.propublica.org/article/facebook-blocks-ad-transparency-tools","title":"Facebook Moves to Block Ad Transparency Tools"},
-    {"url":"https://twitter.com/zcorpan/status/1090719253379104779","title":"Mozilla developer fixes Chromium bug caused by Google breaking the spec"},
-    {"url":"https://iai.tv/articles/the-history-and-politics-of-boredom-auid-1208","title":"The History and Politics of Boredom"},
-    {"url":"https://www.wired.com/story/facebook-hires-privacy-critics/","title":"Facebook Hires Up Three of Its Biggest Privacy Critics"},
-    {"url":"https://fermatslibrary.com/s/the-value-of-science","title":"The Value of Science (1955)"},
-    {"url":"https://www.mercurynews.com/2019/01/29/go-into-debt-to-pay-rent-startup-pays-your-rent-with-high-interest-loans/","title":"California startup lets you finance your rent with high-interest loans"},
-    {"url":"https://blog.ycombinator.com/yc-120/","title":"YC 120"},
-    {"url":"https://abc7chicago.com/weather/watch-live-steam-rises-off-lake-michigan-in-chicago-as-temps-plunge/5113047/","title":"Steam rises off Lake Michigan in Chicago as temps plunge to –23 degrees"},
-    {"url":"http://bit-player.org/2019/a-room-with-a-view","title":"A Room with a View"},
-    {"url":"https://www.theregister.co.uk/2019/01/29/microsoft_internet_explorer_10/","title":"Microsoft decides IE 10 has had its fun: Termination set for Jan 2020"},
-    {"url":"https://www.cnn.com/videos/weather/2019/01/30/chicago-train-tracks-fire-newsource-orig.cnn","title":"Why Chicago train tracks are being set on fire"},
-    {"url":"https://www.theregister.co.uk/2019/01/30/programming_bugs/","title":"Boffins debunk study showing some languages can be more buggy than others"},
-    {"url":"https://www.reddit.com/r/business/comments/aliemz/chaos_has_reportedly_erupted_inside_facebook_as/","title":"Apple blocks Facebook from running its internal iOS apps"},
-    {"url":"https://www.theverge.com/2019/1/30/18204350/google-screenwise-app-ios-apple-violation","title":"Google disables app that monitored iPhone usage in violation of Apple’s rules"},
-    {"url":"https://www.theguardian.com/commentisfree/2019/jan/30/facebook-is-predicting-if-youll-kill-yourself-thats-wrong","title":"Facebook is predicting if you'll kill yourself. That's wrong"},
-    {"url":"https://news.ycombinator.com/item?id=19040873","title":"Ask HN: Recommedation on system design book?"},
-    {"url":"https://lemire.me/blog/2019/01/29/rethinking-hammings-questions/","title":"Rethinking Hamming’s questions"},
-    {"url":"https://googleprojectzero.blogspot.com/2019/01/voucherswap-exploiting-mig-reference.html?m=1","title":"Voucher_swap: Exploiting MIG reference counting in iOS 12"},
-    {"url":"https://phys.org/news/2019-01-all-in-one-transparent-transistors.html","title":"All-in-one transparent transistors"},
-    {"url":"http://www.cultofmac.com/603708/chinese-spy-allegedly-caught-stealing-self-driving-car-secrets-from-apple/","title":"Chinese spy allegedly caught stealing self-driving car secrets from Apple"},
-    {"url":"http://ttendency.cs.ucl.ac.uk/projects/type_study/documents/type_study.pdf","title":"To Type or Not to Type: Quantifying Detectable Bugs in JavaScript [pdf]"},
-    {"url":"https://www.cnbc.com/2019/01/30/facebooks-sheryl-sandberg-defends-research-app-says-users-opted-in.html","title":"Sheryl Sandberg defends Facebook data-collecting app: Users 'knew’"},
-    {"url":"https://news.ycombinator.com/item?id=19024575","title":"Ask HN: Highest paying remote companies?"},
-    {"url":"https://gizmodo.com/i-cut-google-out-of-my-life-it-screwed-up-everything-1830565500","title":"Goodbye Big Five: Google"},
-    {"url":"http://nymag.com/intelligencer/2019/01/buzzfeed-top-traffic-quizzes-teen.html","title":"Buzzfeed paid the teen who made its top quizzes in free swag"},
-    {"url":"https://github.com/nature40/pimod","title":"Show HN: Pimod – Reconfigure Raspberry Pi Images with Docker-Like Configuration"},
-    {"url":"http://web.stanford.edu/class/cs181/","title":"Stanford Course: Computers, Ethics, and Public Policy"},
-    {"url":"https://news.ycombinator.com/item?id=19039016","title":"Ask HN: What are the most fun areas of programming?"},
-    {"url":"https://www.zdnet.com/article/amazon-gets-harrison-ford-to-reveal-the-grim-future-of-alexa/","title":"Amazon gets Harrison Ford to reveal the grim future of Alexa"},
-    {"url":"https://news.ycombinator.com/item?id=19028764","title":"Ask HN: If my company bills me out at $165/hr what should my salary be?"},
-    {"url":"https://shkspr.mobi/blog/2019/01/i-robot-the-3-laws-considered-harmful/","title":"“I, Robot” – the 3 laws considered harmful"},
-    {"url":"https://sanfrancisco.cbslocal.com/2019/01/29/east-bay-biochemist-sells-gene-editing-kit-for-the-masses/","title":"East Bay Biochemist Sells ‘Gene-Editing Kit’ for the Masses"},
-    {"url":"https://www.nbcbayarea.com/news/local/Another-Apple-Engineer-Accused-of-Stealing-Autonomous-Vehicle-Trade-Secrets-505055701.html","title":"Another Apple Engineer Accused of Stealing Autonomous Vehicle Trade Secrets"},
-    {"url":"https://www.wsj.com/articles/teenager-and-his-mom-tried-to-warn-apple-of-facetime-bug-11548783393","title":"Teenager and His Mom Tried to Warn Apple of FaceTime Bug"},
-    {"url":"https://www.wired.com/story/facebook-research-app-lessons/","title":"By defying Apple's rules, Facebook shows it never learns"},
-    {"url":"https://blogs.msdn.microsoft.com/dotnet/2019/01/29/announcing-net-core-3-preview-2/","title":"Announcing .NET Core 3 Preview 2"},
-    {"url":"https://www.businessinsider.com/instagram-tv-service-igtv-recommended-potential-child-abuse-2018-9","title":"Instagram's new TV service recommended videos of potential child abuse"},
-    {"url":"https://www.anandtech.com/show/13909/ces-2019-amd-ceo-dr-lisa-su","title":"CES 2019 Question and Answer Session with AMD CEO, Dr. Lisa Su"},
-    {"url":"http://www.remotepresence.io/","title":"Show HN: Remote Presence – faking your presence on Slack"},
-    {"url":"https://nakedsecurity.sophos.com/2016/11/24/how-your-speakers-could-be-turned-into-eavesdropping-microphones/","title":"Your Speakers Could Be Turned into Eavesdropping Microphones (2016)"},
-    {"url":"https://www.cnbc.com/2019/01/29/facebook-hires-nate-cardozo-eff-privacy-critic-for-whatsapp-privacy.html","title":"Facebook hires one of its biggest privacy critics to oversee WhatsApp privacy"},
-    {"url":"https://news.ycombinator.com/item?id=19032180","title":"Ask HN: What are your go-to checklists?"},
-    {"url":"https://events.linuxfoundation.org/wp-content/uploads/2017/11/When-eBPF-Meets-FUSE-Improving-Performance-of-User-File-Systems-Ashish-Bijlani-Georgia-Tech.pdf","title":"EBPF and FUSE = Faster FUSE File Systems [pdf]"},
-    {"url":"https://twitter.com/alexeheath/status/1090618327502897152","title":"Apple revoked Facebook’s iOS developer certificate"},
-    {"url":"https://news.ycombinator.com/item?id=19036698","title":"If iframes are evil, why do top websites allow ad networks to embed with them?"},
-    {"url":"https://medium.com/sandbox-vr/were-building-the-holodeck-with-andreessen-horowitz-79e2cb18046","title":"We’re Building the Holodeck with Andreessen Horowitz"},
-    {"url":"https://www.nydailynews.com/news/politics/ny-pol-amazon-city-council-union-workers-20190130-story.html","title":"Amazon will oppose unionization bids in New York City"},
-    {"url":"https://www.businessinsider.com/us-indictment-against-huawei-t-mobile-reads-spy-movie-2019-1","title":"Huawei's attempts to copycat a T-Mobile robot read like a comical spy movie"},
-    {"url":"https://arstechnica.com/tech-policy/2019/01/lawyer-sues-apple-claims-facetime-bug-allowed-recording-of-deposition/","title":"Lawyer sues Apple, claims FaceTime bug “allowed” recording of deposition"},
-    {"url":"https://siepr.stanford.edu/news/drop-facebook","title":"Tuning Out: What Happens When You Drop Facebook?"},
-    {"url":"http://www.informit.com/articles/article.aspx?p=2213858&WT.mc_id=Author_Knuth_20Questions","title":"Twenty Questions for Donald Knuth (2014)"},
-    {"url":"https://camelcamelcamel.com/","title":"CamelCamelCamel is down for a week, 3 failed hard drives and $45k"},
-    {"url":"https://www.apple.com/business/resources/docs/iOS_Security_Overview.pdf","title":"Apple iOS Security Overview: Secure by Design [pdf]"},
-    {"url":"https://aeon.co/ideas/believing-without-evidence-is-always-morally-wrong","title":"Believing without evidence is always morally wrong"},
-    {"url":"https://medium.com/@lenoreestrada/munchery-how-a-venture-backed-startup-swindled-a-group-of-women-and-minority-owned-companies-out-e64ee610511b","title":"Munchery swindled a group of women and minority owned companies out of over $50k"},
-    {"url":"https://rythere.com/best-most-beautiful-places-visit-france/","title":"Most Beautiful Places to Visit in France 2019 France Travel"},
-    {"url":"https://www.johnwdefeo.com/articles/future-of-white-hat-seo","title":"What If Google Doesn't Reward White Hat SEO?"},
-    {"url":"https://www.groovehq.com/blog/rebirth-of-groove/?r","title":"The Rebirth of Groove"},
-    {"url":"https://www.theverge.com/2019/1/29/18187178/pentagon-research-documents-invisibility-cloaking-wormholes-warp-drive-department-of-defense","title":"Pentagon compiled research into invisibility cloaking, wormholes, and warp drive"},
-    {"url":"https://medium.com/@DavidKPiano/the-facetime-bug-and-the-dangers-of-implicit-state-machines-a5f0f61bdaa2","title":"The FaceTime Bug and the Dangers of Implicit State Machines"},
-    {"url":"https://venturebeat.com/2019/01/30/fbi-charges-second-apple-employee-with-stealing-autonomous-car-secrets/","title":"FBI Charges Second Apple Employee with Stealing Autonomous Car Secrets"},
-    {"url":"https://www.nytimes.com/2019/01/29/books/review/roger-mcnamee-zucked.html","title":"An Anti-Facebook Manifesto, by an Early Facebook Investor"},
-    {"url":"https://www.theregister.co.uk/2018/06/18/bjarne_stroustrup_c_plus_plus/","title":"Bjarne Stroustrup warns of dangerous future plans for his C++ (2018)"},
-    {"url":"https://www.nytimes.com/2019/01/29/opinion/zuckerberg-facebook-ads.html","title":"Mark Zuckerberg’s Delusion of Consumer Consent"},
-    {"url":"https://www.engadget.com/2019/01/30/lyft-reportedly-suing-over-nyc-minimum-wage-law/","title":"Lyft Will Reportedly Sue Over New York's Minimum Pay for Drivers Law"},
-    {"url":"https://www.businessinsider.com/facebook-employees-angry-after-apple-blocks-its-internal-ios-apps-2019-1","title":"Facebook employees 'angry' after Apple blocks its internal iOS apps"},
-    {"url":"https://leavemealone.xyz/","title":"Show HN: Leave Me Alone – A privacy focused email unsubscription service"},
-    {"url":"https://edition.cnn.com/2019/01/28/health/hiv-status-data-leak-singapore-intl/index.html","title":"HIV status of over 14,000 people leaked online, Singapore authorities say"},
-    {"url":"https://www.apple.com/investor/earnings-call/","title":"Apple Financial Results – Q1 2019 Conference Call LIVE"},
-    {"url":"https://news.yahoo.com/inside-key-hawaii-intelligence-outpost-listening-pacific-174040136.html","title":"Inside a key Hawaii intelligence outpost listening in on the Pacific"},
-    {"url":"https://www.consumerreports.org/food-safety/arsenic-and-lead-are-in-your-fruit-juice-what-you-need-to-know/","title":"Arsenic and Lead Are in Your Fruit Juice"},
-    {"url":"https://threader.app/thread/1090410029256081408","title":"A thread by Stanford Computer Science lecturer regarding Facebook spying methods"},
-    {"url":"https://www.foxnews.com/tech/americans-hit-with-26-3-billion-robocalls-last-year-causing-some-to-not-answer-their-phone","title":"Robocalls reach ridiculous level, as people are afraid to answer their phones"},
-    {"url":"https://www.muckrock.com/news/archives/2019/jan/30/doe-enron-data/","title":"Terabytes of Enron data have quietly gone missing from the Department of Energy"},
-    {"url":"https://consortiumnews.com/2018/07/19/inside-wikileaks-working-with-the-publisher-that-changed-the-world/","title":"WikiLeaks: Working with the Publisher That Changed the World"},
-    {"url":"https://news.ycombinator.com/item?id=19028201","title":"Ask HN: How to ask your employer to let you own your personal projects"},
-    {"url":"https://news.ycombinator.com/item?id=19025488","title":"Ask HN: Which new programming language are you planning to pick up in 2019?"},
-    {"url":"https://m.signalvnoise.com/paying-tribute-to-the-web-with-view-source/","title":"DHH: Paying Tribute to the Web with View Source"},
-    {"url":"https://www.theguardian.com/sport/2019/jan/29/golden-globe-race-jean-luc-van-den-heede-solo-yacht","title":"73-year-old sailor wins round-the-world solo-race without modern instruments"},
-    {"url":"https://www.sciencedaily.com/releases/2019/01/190122084401.htm","title":"Artificial intelligence can cut time needed to process abnormal chest X-rays"},
-    {"url":"https://medium.com/react-in-depth/why-react-suspense-will-be-a-game-changer-37b40fea71ec","title":"Why React Suspense Will Be a Game Changer"},
-    {"url":"https://www.fastcompany.com/90299141/how-facebook-is-paying-teens-to-harvest-their-data-after-an-app-store-ban-project-atlas","title":"How Facebook is quietly paying teens to gather their data after an App Store ban"},
-    {"url":"https://www.nbcnews.com/tech/security/how-teenage-fortnite-player-found-apple-s-facetime-bug-why-n963961","title":"A teenager found Apple's FaceTime bug – and why it was so hard to report it"},
-    {"url":"https://www.youtube.com/watch?v=yM4Rb0DTyKU","title":"Designing a circular knitting machine from scratch [video]"},
-    {"url":"https://twitter.com/LouisDhauwe/status/1088729484054933504","title":"If your radar is being ignored, just join the team and fix it yourself"},
-    {"url":"https://pushdata.io/blog/1","title":"The case for vanilla front-end development"},
-    {"url":"https://theoutline.com/post/4143/telegram-is-the-hot-new-source-for-illegal-downloads?zd=3&zi=xew4vxww","title":"Telegram is the hot new source for pirated content (2018)"},
-    {"url":"https://www.youtube.com/watch?v=Lj1a8rdX6DU","title":"What Engineers Found When They Tore Apart Tesla's Model 3"},
-    {"url":"https://news.ycombinator.com/item?id=19031470","title":"Ask HN: Steps to forming a company?"},
-    {"url":"https://www.zdnet.com/article/japanese-government-plans-to-hack-into-citizens-iot-devices/","title":"Japanese government plans to hack into citizens' IoT devices"},
-    {"url":"https://hbr.org/1995/09/the-power-of-talk-who-gets-heard-and-why","title":"The Power of Talk: Who Gets Heard and Why (1995)"},
-    {"url":"https://hackernoon.com/building-a-remote-friendly-company-an-interview-with-webflow-ceo-vlad-magdalin-3597d55df44c","title":"Building a Remote-Friendly Company at Webflow (YC S13)"},
-    {"url":"https://www.politico.eu/article/corruption-europe-shortfalls-fuelling-global-democracy-crisis/","title":"Anti-corruption shortfalls fuelling ‘global democracy crisis’"},
-    {"url":"https://en.wikipedia.org/wiki/The_Cuckoo%27s_Egg","title":"The Cuckoo's Egg"},
-    {"url":"https://mathvault.ca/10-commandments/","title":"[Illustrated Guide] the 10 Commandments of Higher Mathematical Learning"},
-    {"url":"https://heartbeat.fritz.ai/how-tensorflow-lite-optimizes-neural-networks-for-mobile-machine-learning-e6ffa7f8ee12","title":"TensorFlow Lite adds GPU support for Android making ML models run 4-7X faster"},
-    {"url":"https://www.sciencedaily.com/releases/2019/01/190129081919.htm","title":"Engineers translate brain signals directly into speech"},
-    {"url":"https://nypost.com/2019/01/27/american-stooges-for-venezuelas-dictator/","title":"American stooges for Venezuela’s dictator"},
-    {"url":"https://medium.com/@carlosedp/building-a-hybrid-x86-64-and-arm-kubernetes-cluster-e7f94ff6e51d","title":"Building a Hybrid x86–64 and ARM Kubernetes Cluster"},
-    {"url":"http://blog.robertelder.org/computer-science-for-engineers/","title":"An Overview of Computer Science Concepts for Engineers"},
-    {"url":"https://medium.com/tensorflow/what-are-symbolic-and-imperative-apis-in-tensorflow-2-0-dfccecb01021","title":"What Are Symbolic and Imperative APIs in TensorFlow 2.0?"},
-    {"url":"https://medium.com/@lukeberner/how-i-abused-2fa-to-maintain-persistence-after-a-password-change-google-microsoft-instagram-7e3f455b71a1","title":"I abused 2FA to maintain persistence after a password change"},
-    {"url":"https://www.theatlantic.com/ideas/archive/2019/01/will-we-ever-have-flying-cars/581473/","title":"Why Flying Cars Are an Impossible Dream"},
-    {"url":"https://www.theguardian.com/news/2019/jan/22/the-new-elites-phoney-crusade-to-save-the-world-without-changing-anything","title":"The new elite’s phoney crusade to save the world – without changing anything"},
-    {"url":"https://www.nbcnews.com/politics/2020-election/elizabeth-warren-s-plan-tax-super-rich-has-been-tried-n963971?cid=eml_nbn_20190129","title":"Plan to tax the super-rich has been tried before. Here's what happened"},
-    {"url":"https://aeon.co/ideas/foodie-localism-loves-farming-in-theory-but-not-in-practice","title":"Foodie Localism Loves Farming in Theory but Not in Practice"},
-    {"url":"https://www.iflscience.com/plants-and-animals/namibian-desert-lions-spotted-hunting-and-eating-marine-creatures/","title":"Namibian Desert Lions Spotted Hunting and Eating Marine Creatures"},
-    {"url":"https://www.thesun.co.uk/tech/8303195/alexander-the-great-was-alive-while-body-was-prepared-for-burial-after-rare-disease-left-him-paralysed/","title":"Alexander the Great ‘was ALIVE while his body was prepared for burial’"},
-    {"url":"https://news.ycombinator.com/item?id=19026746","title":"Ask HN: Best File Naming Convention?"},
-    {"url":"https://news.ycombinator.com/item?id=19026552","title":"Ask HN: What was your experience moving from Xamarin to native iOS/Android"},
-    {"url":"https://www.theguardian.com/cities/2019/jan/28/no-one-likes-being-a-tourist-the-rise-of-the-anti-tour","title":"'No one likes being a tourist': the rise of the anti-tour"},
-    {"url":"https://medium.com/@jinkangcen/i-know-why-google-cloud-is-falling-behind-9f7357c3abc3","title":"I know why Google Cloud is falling behind"},
-    {"url":"https://medium.com/@steven.appdrag/social-brand-destruction-a-survivors-account-1d988225611c","title":"Social brand destruction: A survivor’s account"},
-    {"url":"https://www.theverge.com/2019/1/29/18202880/facebook-research-enterprise-root-certificate-onavo-techcrunch","title":"Facebook has been paying teens $20 a month for total access to their phones"},
-    {"url":"https://twitter.com/MissEllieMae/status/1090217105797074944","title":"“Just stop talking about philanthropy, and start talking about taxes.”"},
-    {"url":"https://blog.scalyr.com/2018/08/custom-regex-parser/","title":"Built for Speed: Custom Parser for Regex at Scale"},
-    {"url":"https://webplatform.news/issues/2019-01-29","title":"Rails 6 just committed to shipping source maps by default in production"},
-    {"url":"https://www.wired.com/story/nest-cameras-pew-die-pie-north-korea-passwords/","title":"Nest Cams Hijacked in the Name of PewDiePie and North Korea Pranks"},
-    {"url":"https://medium.com/merantix/journey-from-academic-paper-to-industry-usage-cf57fe598f31","title":"What building Conditional Imitation Learning taught about reproducing a paper"},
-    {"url":"https://mashable.com/article/apple-warned-of-facetime-bug/","title":"Apple was warned of the FaceTime bug over a week ago"},
-    {"url":"https://hashrocket.com/blog/posts/sql-inner-join-vs-outer-join","title":"Sql: Inner Join vs. Outer Join"},
-    {"url":"https://www.macrumors.com/2019/01/28/apple-disables-group-facetime-due-to-bug/","title":"Apple Disables Group FaceTime as Temporary Workaround to Major Privacy Bug"},
-    {"url":"https://www.theguardian.com/world/2019/jan/28/fate-of-castles-in-the-air-in-turkeys-151m-ghost-town","title":"Fate of castles in the air in Turkey’s £151m ghost town"},
-    {"url":"https://waitbutwhy.com/2014/06/taming-mammoth-let-peoples-opinions-run-life.html","title":"Taming the Mammoth: Why You Should Stop Caring What Other People Think (2014)"},
-    {"url":"https://www.youtube.com/watch?v=x4La5hrqWXM","title":"US Intel Community Westling with Deep Fake and Other Technologies"},
-    {"url":"https://www.nationalgeographic.com/animals/2019/01/blue-eyes-mutation-coyotes-spreading-in-california/","title":"Mutant blue-eyed coyotes spreading through California"},
-    {"url":"https://www.fastcompany.com/90297443/this-guy-holds-the-guinness-world-record-for-collecting-spreadsheets","title":"Meet the Guy Who Holds the Guinness World Record for Collecting Spreadsheets"},
-    {"url":"https://www.jpost.com/HEALTH-SCIENCE/A-cure-for-cancer-Israeli-scientists-say-they-think-they-found-one-578939","title":"Israeli scientists say they found a cure for cancer"},
-    {"url":"https://twitter.com/lambda_conf/status/1089461074070523904","title":"Book of Monads, first edition"},
-    {"url":"https://adcontrarian.blogspot.com/2019/01/why-online-ads-havent-built-brands.html","title":"Why online ads haven't built brands"},
-    {"url":"https://www.zdnet.com/article/google-oracle-java-win-will-kill-software-development-so-supreme-court-must-rule/","title":"Google: Oracle Java win will kill software development, so SCOTUS must rule"},
-    {"url":"https://www.buzzfeed.com/heidiblake/poison-in-the-system","title":"Evidence of Kremlin assassination plot that British authorities sidelined"},
-    {"url":"https://www.reddit.com/r/cscareerquestions/comments/al2p6q/7_months_into_fang_company_want_out/efad55p/","title":"Amazon has forced attrition rates (someone has to go every year)"},
-    {"url":"https://www.recode.net/2019/1/30/18203231/apple-says-its-banning-facebooks-research-that-collected-users-personal-information","title":"Apple to ban Facebook’s research app that collects users’ personal information"},
-    {"url":"https://www.salon.com/2019/01/30/a-gold-standard-study-finds-deleting-facebook-is-great-for-your-mental-health/","title":"A “gold standard” study finds deleting Facebook is great for your mental health"},
-    {"url":"https://firebase.googleblog.com/2019/01/cloud-firestore-in-general-availability.htm","title":"Google Cloud Firestore Is Now Generally Available"},
-    {"url":"http://time.com/5190977/how-oat-milk-could-change-the-way-you-drink-coffee/","title":"Oat Milk Could Change the Way You Drink Coffee (2018)"},
-    {"url":"https://www.usgamer.net/articles/facebook-unsealed-documents-whales-mobile-games","title":"Facebook Referred to Kids as Young as Five as “Whales” for Its Monetized Games"},
-    {"url":"https://nickjanetakis.com/blog/i-tried-linux-as-my-main-dev-environment-but-was-forced-back-to-windows","title":"I Tried Linux as My Main Dev Environment but Was Forced Back to Windows"},
-    {"url":"https://www.reuters.com/investigates/special-report/usa-spying-raven/","title":"Ex-NSA cyberspies reveal how they helped hack foes of UAE"},
-    {"url":"https://www.nytimes.com/2019/01/29/technology/facetime-glitch-apple.html","title":"Apple Was Slow to Act on FaceTime Bug That Allows Spying on iPhones"},
-    {"url":"https://www.wired.com/story/a-childs-puzzle-helped-uncover-how-magnets-really-work/","title":"A Child’s Puzzle Helped Uncover How Magnets Work"},
-    {"url":"https://news.nationalgeographic.com/2018/05/nasa-emdrive-impossible-physics-independent-tests-magnetic-space-science/","title":"The first independent tests of the EmDrive suggest a mundane explanation (2018)"},
-    {"url":"https://www.nytimes.com/2019/01/28/world/black-cube-nso-citizen-lab-intelligence.html","title":"The Case of the Bumbling Spy: A Watchdog Group Gets Him on Camera"},
-    {"url":"https://seekingalpha.com/news/3427520-apple-banning-facebooks-info-sucking-research-app","title":"Apple banning Facebook's info-sucking research app"}
+  {
+    "url": "https://find.xyz/map/product-management-search-engine",
+    "title": "Product-building articles by PMs at major tech companies"
+  },
+  {
+    "url": "https://cloud.google.com/blog/products/databases/announcing-cloud-firestore-general-availability-and-updates/",
+    "title": "Google Cloud Firestore NoSQL database is in GA"
+  },
+  {
+    "url": "https://www.cbc.ca/news/canada/calgary/carstairs-westview-co-op-grocery-car-key-fob-1.4999558",
+    "title": "Something mysterious is blocking car key fobs from working in an Alberta town"
+  },
+  {
+    "url": "https://www.greghendershott.com/2018/05/extramaze-llc-using-racket-postgresql-aws-but-no-ads-or-js.html",
+    "title": "Extramaze: Using Racket, PostgreSQL, AWS, but no ads or JavaScript (2018)"
+  },
+  {
+    "url": "https://mwi.usma.edu/stealing-enemys-urban-advantage-battle-sadr-city/",
+    "title": "Stealing the Enemy's Urban Advantage: The Battle of Sadr City"
+  },
+  {
+    "url": "https://www.troyhunt.com/everything-you-ever-wanted-to-know/",
+    "title": "Everything you ever wanted to know about building a secure password reset (2012)"
+  },
+  {
+    "url": "https://slatestarcodex.com/2019/01/31/book-review-zero-to-one/",
+    "title": "Scott Alexander Reviews Thiel's Zero to One"
+  },
+  {
+    "url": "https://www.myuv.com/",
+    "title": "UltraViolet DRM will close on July 31, 2019"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/mbzvxv/criminals-hackers-ss7-uk-banks-metro-bank",
+    "title": "Criminals Are Tapping into the Phone Network Backbone to Empty Bank Accounts"
+  },
+  {
+    "url": "https://media.ccc.de/v/35c3-9800-how_to_teach_programming_to_your_loved_ones",
+    "title": "How to teach programming to your loved ones [video]"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19048108",
+    "title": "Ask HN: Top three questions for a startup before accepting a job offer?"
+  },
+  {
+    "url": "https://blog.kentcdodds.com/write-tests-not-too-many-mostly-integration-5e8c7fff591c",
+    "title": "Write tests. Not too many. Mostly integration (2017)"
+  },
+  {
+    "url": "https://bytes.grubhub.com/lombok-makes-java-cool-again-171102bdcc52",
+    "title": "Lombok makes Java cool again"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19038132",
+    "title": "Ask HN: How to RTFM?"
+  },
+  {
+    "url": "https://lwn.net/Articles/776688/",
+    "title": "A proposed API for full-memory encryption"
+  },
+  {
+    "url": "https://peeke.nl/simulating-blobs-of-fluid",
+    "title": "Simulating blobs of fluid"
+  },
+  {
+    "url": "http://www.methodsandtools.com/archive/softwarearchitecturelearning.php",
+    "title": "How Software Architecture Learns (2011)"
+  },
+  {
+    "url": "https://www.codingnagger.com/2019/01/31/slow-ci/",
+    "title": "Slow CI: real problem or easy excuse for developers?"
+  },
+  {
+    "url": "https://arxiv.org/abs/1901.08338",
+    "title": "Can We Prove Time Protection?"
+  },
+  {
+    "url": "https://www.wired.com/story/mastermind-excerpt/",
+    "title": "Meth, Murder, and Pirates: The Coder Who Became a Crime Boss"
+  },
+  {
+    "url": "https://relationshiphero.com/careers?role=coach",
+    "title": "Relationship Hero (YC S17) Is Hiring Full-Time Coaches – Remote Only"
+  },
+  {
+    "url": "https://www.spiria.com/en/blog/desktop-software/hypothetical-c-easy-type-creation/",
+    "title": "Hypothetical C++: easy type creation"
+  },
+  {
+    "url": "https://css-tricks.com/lodge/svg/",
+    "title": "Everything You Need to Know About SVG"
+  },
+  {
+    "url": "https://nationalinterest.org/blog/the-buzz/fact-the-kgb-shipped-sidewinder-missile-by-mail-moscow-21673",
+    "title": "A KGB agent shipped a Sidewinder missile by mail to Moscow (2017)"
+  },
+  {
+    "url": "https://hamy.io/post/0010/how-i-lost-my-data-trying-to-back-it-up/",
+    "title": "I lost my data trying to back it up"
+  },
+  {
+    "url": "https://www.faucet-pipeline.org/",
+    "title": "Faucet-pipeline – a framework-independent, pluggable asset pipeline"
+  },
+  {
+    "url": "http://news.mit.edu/2019/converting-wi-fi-signals-electricity-0128",
+    "title": "Converting Wi-Fi signals to electricity with new 2-D materials"
+  },
+  {
+    "url": "https://www.gq.com/story/cal-newport-digital-minimalism",
+    "title": "Cal Newport on Why We'll Look Back at Our Smartphones Like Cigarettes"
+  },
+  {
+    "url": "https://blog.racket-lang.org/2019/01/racket-v7-2.html",
+    "title": "Racket v7.2"
+  },
+  {
+    "url": "https://blogs.technet.microsoft.com/srd/2019/01/28/fuzzing-para-virtualized-devices-in-hyper-v/",
+    "title": "Fuzzing para-virtualized devices in Hyper-V"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19046852",
+    "title": "Ask HN: Why is it easier to get a raise with a new job?"
+  },
+  {
+    "url": "https://fusionauth.io/blog/2019/01/31/revoking-jwts",
+    "title": "Revoking JWTs (JSON Web Tokens)"
+  },
+  {
+    "url": "https://www.youtube.com/watch?time_continue=2&v=u7sRrC2Jpp4",
+    "title": "Table-Saw Kickback on Camera (2012) [video]"
+  },
+  {
+    "url": "https://www.washingtonpost.com/entertainment/books/a-peek-inside-edward-goreys-modern-gothic-world/2018/11/20/29028b50-e83f-11e8-bbdb-72fdbf9d4fed_story.html",
+    "title": "A peek inside Edward Gorey’s modern Gothic world"
+  },
+  {
+    "url": "http://www.bbc.com/travel/story/20190129-did-wine-cause-a-full-scale-revolution-in-armenia",
+    "title": "Did wine cause a full-scale revolution in Armenia?"
+  },
+  {
+    "url": "https://www.citusdata.com/blog/2018/12/14/watching-star-wars-in-postgres/",
+    "title": "\\watch ing Star Wars in Postgres"
+  },
+  {
+    "url": "https://numeracy.co/blog/life-of-a-sql-query",
+    "title": "Life of a Sql Query"
+  },
+  {
+    "url": "https://www.nytimes.com/2016/02/28/magazine/what-google-learned-from-its-quest-to-build-the-perfect-team.html",
+    "title": "What Google Learned From Its Quest to Build the Perfect Team (2016)"
+  },
+  {
+    "url": "https://www.wsj.com/articles/u-s-changes-visa-process-for-high-skilled-workers-11548879868",
+    "title": "U.S. Changes Visa Process for High-Skilled Workers"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2019/jan/31/how-facebook-robbed-us-of-our-sense-of-self",
+    "title": "Facebook robbed us of our sense of self"
+  },
+  {
+    "url": "https://geneticliteracyproject.org/2019/01/29/how-germs-and-ancient-migration-help-explain-our-world-of-haves-and-have-nots/",
+    "title": "Germs and ancient migrations help explain our world of 'haves' and 'have nots'"
+  },
+  {
+    "url": "https://insights.dice.com/2019/01/29/tech-salaries-stagnant-low-unemployment-dice-salary-survey/?CMPID=EM_RE_UP_JS_AD_DA_CP_A_&utm_source=Responsys&utm_medium=Email&utm_content=&utm_campaign=Advisory_DiceAdvisor_A",
+    "title": "Tech Salaries Stagnant Despite Low Unemployment: Survey"
+  },
+  {
+    "url": "https://www.weforum.org/agenda/2018/02/south-korea-and-sweden-are-the-most-innovative-countries-in-the-world/",
+    "title": "South Korea and Sweden are the most innovative countries in the world"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19047093",
+    "title": "Ask HN: What’s your go-to investment for protecting cash from inflation?"
+  },
+  {
+    "url": "https://write.as/blog/ending-our-medium-integration",
+    "title": "Ending our Medium integration"
+  },
+  {
+    "url": "https://www.statisticsdonewrong.com/",
+    "title": "Statistics Done Wrong"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/31/opinion/ai-bias-healthcare.html",
+    "title": "Opinion: A.I. Could Worsen Health Disparities"
+  },
+  {
+    "url": "https://arxiv.org/abs/1807.08416",
+    "title": "Some Fundamental Theorems in Mathematics"
+  },
+  {
+    "url": "https://arturdryomov.online/posts/superior-testing-stop-stopping/",
+    "title": "Superior Testing: Stop Stopping"
+  },
+  {
+    "url": "https://reich.hms.harvard.edu/five-corrections-new-york-times",
+    "title": "Five Corrections to The New York Times"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/facebook-earnings-q4-2018/",
+    "title": "Facebook shares shoot up after strong Q4 earnings despite data breach"
+  },
+  {
+    "url": "https://lidarmag.com/2019/01/27/elon-musk-is-right-lidar-is-a-crutch/",
+    "title": "Lidar Is a Crutch"
+  },
+  {
+    "url": "https://www.theguardian.com/technology/2019/jan/31/apple-facebook-campus-permissions-revoked-teens-access-data-iphone-app",
+    "title": "Apple leaves Facebook offices in disarray after revoking app permissions"
+  },
+  {
+    "url": "https://thepointsguy.com/news/boeing-787-suffers-rare-dual-engine-failure-on-landing/",
+    "title": "Boeing 787 Suffers Rare Dual Engine Failure on Landing"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/31/business/locast-streaming-free-network-tv.html",
+    "title": "Locast, a Free App Streaming Network TV, Would Love to Get Sued"
+  },
+  {
+    "url": "https://www.theatlantic.com/magazine/archive/2019/03/how-humans-tamed-themselves/580447/",
+    "title": "A New Theory Proposes That Humans Tamed Themselves"
+  },
+  {
+    "url": "https://jarredsumner.com/codeblog/",
+    "title": "Why isn't the internet more fun and weird?"
+  },
+  {
+    "url": "https://vimist.github.io/2019/01/30/Steganographic-Packets.html",
+    "title": "Steganographic Packets"
+  },
+  {
+    "url": "https://www.bbc.co.uk/news/stories-47033704",
+    "title": "Why some Japanese pensioners want to go to jail"
+  },
+  {
+    "url": "https://support.google.com/plus/answer/9195133",
+    "title": "Shutting down Google+ for consumer (personal) accounts on April 2, 2019"
+  },
+  {
+    "url": "https://www.reuters.com/investigates/special-report/usa-spying-karma/",
+    "title": "'Karma': A hack used by the UAE to break into iPhones of foes"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/30/health/facebook-psychology-health.html",
+    "title": "This is Your Brain Off Facebook - study offers glimpse of unplugging"
+  },
+  {
+    "url": "https://www.theatlantic.com/international/archive/2019/01/colombia-welcomes-millions-venezuelans-maduro-guaido/581647/",
+    "title": "Colombia’s Plan to Welcome Millions of Venezuelan Migrants"
+  },
+  {
+    "url": "http://nautil.us/issue/68/context/what-impossible-meant-to-feynman",
+    "title": "What Impossible Meant to Feynman"
+  },
+  {
+    "url": "https://lemire.me/blog/2019/01/31/my-blog-cant-keep-up-500-errors-all-over/",
+    "title": "My blog can’t keep up: 500 errors all over"
+  },
+  {
+    "url": "http://bactra.org/notebooks/godels-theorem.html",
+    "title": "Gödel's Theorem"
+  },
+  {
+    "url": "http://eurydice13.com/2019/01/how-to-prepare-for-and-run-a-design-thinking-gamestorming-creative-workshop-and-what-to-do-with-the-outputs-too/",
+    "title": "Preparing for and runing a Design Thinking, Gamestorming and Creative workshop"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/googles-also-peddling-a-data-collector-through-apples-back-door/",
+    "title": "Google’s also peddling a data collector through Apple’s back door"
+  },
+  {
+    "url": "https://www.nytimes.com/interactive/2019/01/31/us/public-defender-case-loads.html",
+    "title": "One Lawyer, One Day, 194 Felony Cases"
+  },
+  {
+    "url": "https://www.wsj.com/articles/elon-musks-surprise-pick-for-tesla-cfo-is-a-relative-unknown-11548935508",
+    "title": "Elon Musk’s Surprise Pick for Tesla CFO Is a Relative Unknown"
+  },
+  {
+    "url": "https://jalopnik.com/chicago-is-so-ridiculously-cold-that-the-railroad-track-1832177510/",
+    "title": "It’s so cold in Chicago, crews had to set fire to commuter rail tracks"
+  },
+  {
+    "url": "https://www.npr.org/sections/thetwo-way/2012/02/06/146490064/remembering-roger-boisjoly-he-tried-to-stop-shuttle-challenger-launch",
+    "title": "Remembering Roger Boisjoly: He Tried to Stop Shuttle Challenger Launch"
+  },
+  {
+    "url": "https://www.bloomberg.com/news/articles/2019-01-30/apple-shares-rally-as-company-outlines-life-beyond-the-iphone",
+    "title": "Apple's Business Beyond the iPhone"
+  },
+  {
+    "url": "https://github.com/RSS-Bridge/rss-bridge",
+    "title": "RSS-Bridge: the RSS feed for websites missing it"
+  },
+  { "url": "https://8bitworkshop.com/", "title": "8bit Workshop" },
+  {
+    "url": "https://www.reuters.com/article/us-southkorea-economy-pets/like-a-son-but-cheaper-harried-south-koreans-pamper-pets-instead-of-having-kids-idUSKCN1PI029",
+    "title": "Harried South Koreans pamper pets instead of having kids"
+  },
+  {
+    "url": "https://www.vice.com/en_ca/article/yv574m/ive-owned-the-moon-since-1980",
+    "title": "Dennis M. Hope Has Owned the Moon Since 1980 Because He Says So"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Scramble_for_Africa",
+    "title": "Scramble for Africa"
+  },
+  {
+    "url": "https://www.stef.be/bassoontracker/",
+    "title": "Amiga Music Tracker in JavaScript"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/rigetti-launches-the-public-beta-of-its-quantum-cloud-services/",
+    "title": "Rigetti launches the public beta of its Quantum Cloud Services"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/state-bank-india-data-leak/",
+    "title": "India’s largest bank SBI leaked account data on millions of customers"
+  },
+  {
+    "url": "https://www.amusingplanet.com/2019/01/bookwheel-16th-century-forerunner-to.html",
+    "title": "Bookwheel, the 16th Century Forerunner to the EBook Reader"
+  },
+  {
+    "url": "https://m.signalvnoise.com/yesterdays-mass-login-attack-on-basecamp-is-another-reminder-to-protect-yourself/",
+    "title": "Basecamp handled a security breach yesterday"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19045141",
+    "title": "Ask HN: Is there room for a new ‘curated’ search engine?"
+  },
+  {
+    "url": "https://culturehustle.com/products/black-3-0-beta-evaluation-batch-blackest-black-acrylic-paint-20ml",
+    "title": "BLACK 3.0 BETA blackest black acrylic paint"
+  },
+  {
+    "url": "https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html",
+    "title": "Lock-Free Rust: Crossbeam in 2019"
+  },
+  {
+    "url": "https://artamonoviv.ru/wp-content/uploads/2016/08/Coloured_Petri_Nets_modeling_and_validation_of_concurrent_systems__2009.pdf",
+    "title": "Coloured Petri Nets: Modelling and Validation of Concurrent Systems (2009) [pdf]"
+  },
+  {
+    "url": "https://www.cs.uaf.edu/users/chappell/public_html/class/2018_spr/cs331/docs/types_primer.html",
+    "title": "A Primer on Type Systems"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Bloom%27s_taxonomy",
+    "title": "Bloom's Taxonomy"
+  },
+  {
+    "url": "https://blog.bugsnag.com/server-side-rendering-and-authenticated-content/",
+    "title": "Server-side rendering: how to serve authenticated content"
+  },
+  {
+    "url": "https://www.nature.com/articles/d41586-019-00236-4",
+    "title": "The first synthetic element"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/31/18204559/apple-facebook-feud-market-research-platform-power",
+    "title": "Apple’s power over Facebook ought to worry the rest of us"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-iran-usa-sanctions-eu/germany-france-britain-to-launch-mechanism-for-trade-with-iran-idUSKCN1PP0K3",
+    "title": "Skirting U.S. sanctions, Europeans launch trade mechanism for Iran"
+  },
+  {
+    "url": "https://lemire.me/blog/2019/01/30/what-is-the-space-overhead-of-base64-encoding/",
+    "title": "What is the space overhead of Base64 encoding?"
+  },
+  {
+    "url": "https://theintercept.com/2019/01/30/prison-voice-prints-databases-securus/",
+    "title": "Prisons Are Quietly Building Databases of Incarcerated People’s Voice Prints"
+  },
+  {
+    "url": "https://codewithoutrules.com/2019/01/31/does-company-have-worklife-balance/",
+    "title": "Do they have work/life balance? Investigating potential employers with GitHub"
+  },
+  {
+    "url": "https://openchirp.io/",
+    "title": "OpenChird – An Open Source Platform for IoT with Support for LoRaWAN"
+  },
+  {
+    "url": "https://blog.kyber.network/wbtc-is-now-live-on-ethereum-4b4e2d1ef76f",
+    "title": "Wrapped Bitcoin (WBTC) Is Now Live on Ethereum"
+  },
+  {
+    "url": "https://k-bx.github.io/articles/drinker.html",
+    "title": "Struggling with My Drinker's Problem"
+  },
+  {
+    "url": "https://ebzzry.io/en/script-lisp/",
+    "title": "Scripting in Common Lisp"
+  },
+  {
+    "url": "https://spreadprivacy.com/privacy-simplified/",
+    "title": "Use DuckDuckGo to improve your privacy online (2018)"
+  },
+  {
+    "url": "http://www.openculture.com/2018/07/jean-paul-sartre-bad-mescaline-trip-hallucinated-years-followed-crabs.html",
+    "title": "Jean-Paul Sartre Had a Bad Mescaline Trip (2018)"
+  },
+  {
+    "url": "https://www.atlasobscura.com/articles/what-is-sigma-derby",
+    "title": "Time Running Out for Beloved Mechanical Horse-Race Game in Vegas"
+  },
+  {
+    "url": "https://github.com/hughpyle/ASR33/blob/master/asciiart/README.md",
+    "title": "Show HN: ASCII Art with Overstrike"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/wjm5kw/nintendo-makes-it-clear-that-piracy-is-the-only-way-to-preserve-video-game-history",
+    "title": "Nintendo Makes It Clear That Piracy Is Only Way to Preserve Video Game History"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/30/business/foxconn-wisconsin-manufacturing.html",
+    "title": "Foxconn Is Reconsidering Plan for Manufacturing in Wisconsin"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/29/18202398/apple-facetime-bug-warned-eavesdropping",
+    "title": "Apple was warned about the FaceTime eavesdropping bug last week"
+  },
+  {
+    "url": "https://evilmartians.com/chronicles/anonymous-web-authentication-with-stellar-blockchain",
+    "title": "Anonymous web authentication with Stellar blockchain"
+  },
+  {
+    "url": "https://status.office365.com/",
+    "title": "Office 365 global authentication outage"
+  },
+  {
+    "url": "https://www.wsj.com/articles/new-york-insurers-can-evaluate-your-social-media-useif-they-can-prove-why-its-needed-11548856802",
+    "title": "NY Insurers Can Evaluate Social Media Use If They Can Prove Why It’s Needed"
+  },
+  {
+    "url": "https://code.fb.com/ml-applications/random-encoders/",
+    "title": "No training required: Exploring random encoders for sentence classification"
+  },
+  {
+    "url": "https://towardsdatascience.com/the-unsung-heroes-of-modern-software-development-561fc4cb6850",
+    "title": "The Unsung Heroes of Modern Software Development"
+  },
+  {
+    "url": "https://alpinelinux.org/posts/Alpine-3.9.0-released.html",
+    "title": "Alpine Linux 3.9.0 Released"
+  },
+  {
+    "url": "https://eng.uber.com/aresdb/",
+    "title": "AresDB: Uber’s GPU-Powered Open-Source, Real-Time Analytics Engine"
+  },
+  {
+    "url": "https://limitedresults.com/2019/01/pwn-the-lifx-mini-white/",
+    "title": "Pwn the LIFX Mini white"
+  },
+  {
+    "url": "https://blogs.scientificamerican.com/observations/the-topography-of-disease/#googDisableSync",
+    "title": "The Topography of Disease"
+  },
+  {
+    "url": "https://www.saiglobal.com/en-au/news_and_resources/industry_news/google_feels_the_brunt_of_gdpr_enforcement/",
+    "title": "Google Feels the Brunt of GDPR Enforcement"
+  },
+  {
+    "url": "https://www.interviewcake.com/article/java/data-structures-coding-interview",
+    "title": "Data Structures for coding interviews"
+  },
+  {
+    "url": "http://olafurw.com/2019-01-27-programmer-advice/",
+    "title": "Advice to new programmers"
+  },
+  {
+    "url": "https://www.centauri-dreams.org/2019/01/29/future-ai-the-explorer-and-the-philosopher/",
+    "title": "Future AI: The Explorer and the Philosopher"
+  },
+  {
+    "url": "https://mashable.com/article/facebook-employees-react-teen-spying-app-blind/#X5hGityLeaqd",
+    "title": "'Fuck ethics. Money is everything' FB employees react to scandal on gossip app"
+  },
+  {
+    "url": "https://github.com/CurtisLusmore/ghp",
+    "title": "Show HN: Serve Static GitHub Pages Locally"
+  },
+  {
+    "url": "https://blog.fuzzing-project.org/65-When-your-Memory-Allocator-hides-Security-Bugs.html",
+    "title": "When a Memory Allocator Hides Security Bugs"
+  },
+  {
+    "url": "http://bostonreview.net/science-nature/tom-rutledge-man-who-invented-information-theory",
+    "title": "The Man Who Invented Information Theory (2017)"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19037467",
+    "title": "Launch HN: DevFlight (YC W19) – Helping open-source maintainers make money"
+  },
+  {
+    "url": "https://evolt.org/node/564",
+    "title": "Napster: A New Killer Internet App (1999)"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/30/18203551/apple-facebook-blocked-internal-ios-apps",
+    "title": "Apple blocks Facebook from running its internal iOS apps"
+  },
+  {
+    "url": "https://theory.stanford.edu/~aiken/publications/trs/FLProject.pdf",
+    "title": "The FL Project: The Design of a Function Language (1989) [pdf]"
+  },
+  {
+    "url": "https://www.newyorker.com/tech/annals-of-technology/how-scripto-the-app-that-stephen-colbert-helped-build-became-a-fixture-of-late-night-comedy-news",
+    "title": "The Scripto App Became a Fixture of Late-Night Comedy News (2018)"
+  },
+  {
+    "url": "https://www.anandtech.com/show/13748/the-intel-xeon-w-3175x-review-28-unlocked-cores-2999-usd",
+    "title": "The Intel Xeon W-3175X Review: 28 Unlocked Cores, $2999"
+  },
+  {
+    "url": "https://motherboard.vice.com/en_us/article/yw8vm7/android-security-locking-out-law-enforcement-unintended-side-effect",
+    "title": "Head of Android Security: Locking Out Law Enforcement Is Unintended Side Effect"
+  },
+  {
+    "url": "https://research.eligrey.com/status/1090696844944932864",
+    "title": "Google is discontinuing their free weather API"
+  },
+  {
+    "url": "https://beta.aifiddle.io/",
+    "title": "Show HN: Deep Learning GUI to Create, Train and Visualize Models in a Browser"
+  },
+  {
+    "url": "https://www.wowa.me/",
+    "title": "Royalty Free No Copyright Music for All Your Projects"
+  },
+  {
+    "url": "https://jerrington.me/posts/2019-01-29-self-hosted-ngrok.html",
+    "title": "Roll Your Own Ngrok with Nginx, Letsencrypt, and SSH Reverse Tunnelling"
+  },
+  {
+    "url": "https://github.com/rvhuang/pathfinding-lab",
+    "title": "Pathfinding Laboratory"
+  },
+  {
+    "url": "https://paleotronic.com/2019/01/30/arthur-c-clarke-communications-in-the-second-century-of-the-telephone-1977/",
+    "title": "Arthur C. Clarke: Communications in the Second Century of the Telephone (1977)"
+  },
+  {
+    "url": "http://varnish-cache.org/docs/trunk/phk/notes.html",
+    "title": "Notes from the Architect (2006)"
+  },
+  {
+    "url": "https://www.wired.com/story/google-chrome-kill-url-first-steps/",
+    "title": "Google Takes Its First Steps Toward Killing the URL"
+  },
+  {
+    "url": "https://www.sciencedaily.com/releases/2019/01/190128125314.htm",
+    "title": "'Metallic wood' has the strength of titanium and the density of water"
+  },
+  {
+    "url": "https://dmitryfrank.com/articles/how_i_ended_up_writing_my_own_kernel",
+    "title": "How I ended up writing a new real-time kernel (2015)"
+  },
+  {
+    "url": "https://bugs.webkit.org/show_bug.cgi?id=194028",
+    "title": "Add limits to amount of JavaScript that can be loaded by a website"
+  },
+  {
+    "url": "https://github.com/victorqribeiro/photoEditor",
+    "title": "Show HN: A Image Editor in JavaScript Canvas"
+  },
+  {
+    "url": "https://daily.jstor.org/when-was-first-handshake/",
+    "title": "When Was the First Handshake?"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/google-for-consumers-will-shut-down-on-april-2nd/",
+    "title": "Google+ for consumers will shut down on April 2nd"
+  },
+  {
+    "url": "https://www.opendemocracy.net/brexitinc/paul-hilder/they-were-planning-on-stealing-election-explosive-new-tapes-reveal-cambridg",
+    "title": "New tapes reveal Cambridge Analytica CEO’s boasts of voter suppression"
+  },
+  {
+    "url": "https://exclusive-design.vasilis.nl/",
+    "title": "Exclusive Design"
+  },
+  {
+    "url": "https://github.com/Microsoft/project-rome",
+    "title": "Microsoft Project Rome 1.0.0"
+  },
+  {
+    "url": "https://blog.torproject.org/tors-open-research-topics-2018-edition",
+    "title": "Tor's Open Research Topics (2018)"
+  },
+  {
+    "url": "https://eli.thegreenplace.net/2019/on-concurrency-in-go-http-servers/",
+    "title": "On Concurrency in Go HTTP Servers"
+  },
+  {
+    "url": "https://blog.statebox.org/why-visual-programming-doesnt-suck-2c1ece2a414e",
+    "title": "Visual Programming Doesn’t Suck"
+  },
+  {
+    "url": "https://tylerayoung.com/2019/01/29/benchmarks-of-cache-friendly-data-structures-in-c/",
+    "title": "Benchmarks of Cache-Friendly Data Structures in C++"
+  },
+  {
+    "url": "http://ir.tesla.com/static-files/0b913415-467d-4c0d-be4c-9225c2cb0ae0",
+    "title": "Tesla Q4 2018 Earnings Letter"
+  },
+  {
+    "url": "https://www.fastcompany.com/90299216/japan-will-try-to-hack-its-citizens-routers-and-webcams-in-the-name-of-cybersecurity",
+    "title": "Japan to hack its citizens’ routers and webcams in name of cybersecurity"
+  },
+  {
+    "url": "https://www.washingtonpost.com/technology/2019/01/29/report-americans-got-billion-robocalls-last-year-up-percent/",
+    "title": "Americans got 26.3B robocalls last year, up 46 percent from 2017"
+  },
+  {
+    "url": "https://jack-vanlightly.com/blog/2019/1/27/building-a-simple-distributed-system-formal-verification",
+    "title": "Building a “Simple” Distributed System – Formal Verification"
+  },
+  {
+    "url": "https://youngdynasty.net/posts/writing-mac-apps-in-go/",
+    "title": "Writing Apps in Go and Swift"
+  },
+  {
+    "url": "https://blog.racket-lang.org/2019/01/racket-on-chez-status.html",
+    "title": "Racket-On-Chez Status: January 2019"
+  },
+  {
+    "url": "https://www.theverge.com/facebook/2019/1/30/18203349/facebook-research-app-apple-shutdown",
+    "title": "Facebook will shut down its controversial market research app for iOS"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/30/arts/fyre-festival-billy-mcfarland-elizabeth-holmes-anna-delvey.html",
+    "title": "Our Never Ending 'Scam Season'"
+  },
+  {
+    "url": "https://erfur.github.io/down_the_rabbit_hole_pt1/",
+    "title": "Down the Rabbit Hole – Part I: A Journey into the UEFI Land"
+  },
+  {
+    "url": "https://www.nytimes.com/interactive/2019/01/29/magazine/china-globalization-kazakhstan.html",
+    "title": "Can China Turn the Middle of Nowhere into the Center of the World Economy?"
+  },
+  {
+    "url": "https://www.workingwa.org/instacart-eighty-cents",
+    "title": "Instacart paying 80 cents an hour because worker received a large tip"
+  },
+  {
+    "url": "https://puri.sm/posts/librem-5-hardware-update/",
+    "title": "Librem 5 Hardware Update"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/25/arts/music/verdi-papers-italy.html",
+    "title": "5,000 Pages of Verdi’s Drafts, Long Hidden, Will Be Made Public"
+  },
+  {
+    "url": "https://github.com/joewalnes/websocketd",
+    "title": "Turn any program that uses stdin/stdout into a WebSocket server"
+  },
+  {
+    "url": "http://www.cgl.uwaterloo.ca/csk/projects/mazes/",
+    "title": "Maze Design (2005)"
+  },
+  {
+    "url": "https://www.bbc.com/news/world-us-canada-47066652",
+    "title": "Mystery illness sees Canada halve its Cuba embassy staff"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=hnM252gU-g4",
+    "title": "Using Logic Programming to Recover C++ Classes and Methods from Executables"
+  },
+  {
+    "url": "https://www.artsy.net/article/artsy-editorial-nasa-art-shape-vision-future",
+    "title": "Nasa Used Art to Shape Our Vision of the Future"
+  },
+  {
+    "url": "https://github.com/bxcodec/faker",
+    "title": "Show HN: Faker – Struct Data Fake Generator in Go"
+  },
+  {
+    "url": "https://www.sfchronicle.com/business/article/H-1B-visa-lottery-changing-to-favor-those-with-13574410.php",
+    "title": "H-1B visa lottery changing to favor those with advanced degrees"
+  },
+  {
+    "url": "https://functionalcs.github.io/curriculum/",
+    "title": "A Self-Learning, Modern Computer Science Curriculum"
+  },
+  {
+    "url": "https://www.wired.com/story/collection-leak-usernames-passwords-billions/",
+    "title": "Hackers Are Passing Around a Megaleak of 2.2B Records"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19031711",
+    "title": "Ask HN: Why can’t I block all incoming calls that aren’t in my contact list?"
+  },
+  {
+    "url": "https://www.cyberscoop.com/mobile-zero-days-lookout-shmoocon-2019-android-barracuda-ios-stonefish/",
+    "title": "FinFisher offered to sell nation-states a zero-click iOS compromise"
+  },
+  {
+    "url": "https://9to5mac.com/2019/01/30/jizhong-chen-charged-theft-project-titan-trade-secrets/",
+    "title": "Apple employee accused stealing ‘Titan’ trade secrets for a Chinese competitor"
+  },
+  {
+    "url": "https://www.jpl.nasa.gov/news/news.php?feature=7322",
+    "title": "Huge Cavity in Antarctic Glacier Signals Rapid Decay"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/29/facebook-project-atlas/",
+    "title": "Facebook has been paying people to install a “Research” VPN"
+  },
+  {
+    "url": "https://blockstack.org/",
+    "title": "Building decentralized blockchain webpages"
+  },
+  {
+    "url": "http://naplab.ee.columbia.edu/reconstruction.html",
+    "title": "Reconstructing intelligible speech from the human auditory cortex"
+  },
+  {
+    "url": "http://www.righto.com/2019/01/inside-apollo-guidance-computers-core.html",
+    "title": "Inside the Apollo Guidance Computer's Core Memory"
+  },
+  {
+    "url": "https://postmake.io/open",
+    "title": "Show HN: Open startups with their revenue, metrics, and stories"
+  },
+  {
+    "url": "https://gravitational.com/blog/kubernetes-kustomize-kep-kerfuffle/",
+    "title": "The Kubernetes Kustomize KEP Kerfuffle"
+  },
+  {
+    "url": "https://www.mozilla.org/en-US/firefox/65.0/releasenotes/",
+    "title": "Firefox 65.0 released"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2019/01/30/azure_sql_delete/",
+    "title": "Microsoft accidentally deletes customer DBs"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19038580",
+    "title": "Ask HN: Discipline but no focus, how to fix?"
+  },
+  {
+    "url": "https://genius.engineering/you-have-to-hear-it-to-believe-it-how-audio-messaging-improved-our-conversion-rate-more-than-50/",
+    "title": "An audio message improved our conversion rate by more than 50%"
+  },
+  {
+    "url": "https://www.seattletimes.com/business/real-estate/ceos-of-seattle-areas-biggest-companies-we-need-more-housing-for-the-middle-class/",
+    "title": "CEOs of Seattle area’s biggest companies: We need more middle-class housing"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19025885",
+    "title": "Ask HN: How much time to devote to learning algorithms vs. creating software?"
+  },
+  {
+    "url": "https://arxiv.org/abs/1401.1219",
+    "title": "Consciousness as a State of Matter (2015)"
+  },
+  {
+    "url": "https://www.bloomberg.com/opinion/articles/2019-01-29/hollywood-stars-didn-t-pay-90-percent-tax-they-created-loopholes",
+    "title": "The Golden Age of Hollywood Tax Avoidance"
+  },
+  {
+    "url": "https://www.latimes.com/business/la-fi-pge-bankruptcy-filing-20190129-story.html",
+    "title": "PG&E files for bankruptcy"
+  },
+  {
+    "url": "https://www.macleans.ca/thai-cave-rescue-heroes/",
+    "title": "The heroes of the Thai cave rescue"
+  },
+  {
+    "url": "https://medium.com/@gajus/lessons-learned-scaling-postgresql-database-to-1-2bn-records-month-edc5449b3067",
+    "title": "Lessons learned scaling a PostgreSQL database to 1.2bn records/month"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/apples-facetime-bug-will-be-investigated-by-new-yorks-attorney-general/",
+    "title": "Apple’s FaceTime Bug Will Be Investigated by New York’s Attorney General"
+  },
+  {
+    "url": "https://onlinelibrary.wiley.com/doi/full/10.1002/aur.2064",
+    "title": "Predictors of mental health in employed adults with autism spectrum disorder"
+  },
+  {
+    "url": "http://www.inference.org.uk/itprnn/book.pdf",
+    "title": "Information Theory, Inference, and Learning Algorithms (2005) [pdf]"
+  },
+  {
+    "url": "https://www.cnbc.com/2019/01/29/walgreens-cvs-test-teeth-straightening-cleaning-in-some-stores.html",
+    "title": "Walgreens, CVS test teeth straightening, cleanings in some stores"
+  },
+  {
+    "url": "https://www.sciencealert.com/mind-altering-cat-parasite-linked-to-schizophrenia-in-largest-study-yet",
+    "title": "Scientists find link between infection with Toxoplasma gondii and schizophrenia"
+  },
+  {
+    "url": "https://towardsdatascience.com/applying-ai-to-horse-racing-e3632a7e7c92",
+    "title": "My journey applying AI to horse racing"
+  },
+  {
+    "url": "https://www.newsweek.com/theyre-selling-unicorns-israel-cancer-cure-claim-debunked-experts-1311656",
+    "title": "'THEY'RE SELLING UNICORNS:' ISRAEL CANCER CURE CLAIM DEBUNKED BY EXPERTS"
+  },
+  {
+    "url": "https://github.com/fabiospampinato/notable#readme",
+    "title": "Show HN: Notable – The markdown-based note-taking app that doesn't suck"
+  },
+  {
+    "url": "https://www.justice.gov/opa/pr/justice-department-announces-court-authorized-efforts-map-and-disrupt-botnet-used-north",
+    "title": "Justice Department Announces Court-Authorized Efforts to Map and Disrupt Botnet"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19043182",
+    "title": "Use a special phrase to mark paywalled articles on HN"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/29/opinion/artificial-intelligence-surveillance.html",
+    "title": "Warning Everything Is Going Deep: ‘The Age of Surveillance Capitalism’"
+  },
+  {
+    "url": "https://blog.freedombone.net/dark-messenger",
+    "title": "Dark Messenger: Mobile XMPP Over TOR"
+  },
+  {
+    "url": "https://tech.townsourced.com/post/boltdb-vs-badger/",
+    "title": "BoltDB vs. Badger: A Comparison of Go Key-Value Databases"
+  },
+  {
+    "url": "https://www.cs.uaf.edu/users/chappell/public_html/misc/freesp.html",
+    "title": "Freedom of speech memo, President of the university of Alaska, March 2001"
+  },
+  {
+    "url": "https://haydenjames.io/linux-networking-commands-scripts/",
+    "title": "I Tried to List All Linux Networking Commands and Scripts"
+  },
+  {
+    "url": "https://www.forbes.com/sites/jasonevangelho/2019/01/30/the-new-pinebook-pro-will-challenge-google-chromebooks-for-199/",
+    "title": "New Pinebook Pro Will Challenge Google Chromebooks for $199"
+  },
+  {
+    "url": "https://www.businessinsider.com/lyft-juno-sue-new-york-city-minimum-wage-law-for-drivers-2019-1",
+    "title": "Lyft and Juno are suing New York City after new minimum wage requirements"
+  },
+  {
+    "url": "https://arstechnica.com/gadgets/2019/01/the-roomba-lawnmower-is-finally-happening/",
+    "title": "The Roomba lawnmower is finally happening"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/nyc-council-questions-tax-breaks-and-economic-impact-of-amazon-hq2/",
+    "title": "NYC Council questions tax breaks and economic impact of Amazon HQ2"
+  },
+  {
+    "url": "https://torrentfreak.com/youtube-strikes-now-being-used-as-scammers-extortion-tool/",
+    "title": "YouTube Strikes Now Being Used as Scammers’ Extortion Tool"
+  },
+  {
+    "url": "https://hashnode.com/post/docker-tutorial-for-beginners-cjrj2hg5001s2ufs1nker9he2",
+    "title": "Docker tutorial for beginners"
+  },
+  {
+    "url": "https://medium.com/@louisbarclay/become-ceo-of-this-sexy-startup-for-just-1-a-month-6f3db6828410",
+    "title": "Become CEO of this sexy startup for just $1 a month"
+  },
+  {
+    "url": "https://www.inc.com/christine-lagorio/steve-blank-lean-startup-founders-project.html",
+    "title": "A Screaming Boss Helped Steve Blank Develop His Brilliant Startup Philosophy"
+  },
+  {
+    "url": "https://www.newyorker.com/science/elements/a-study-on-driverless-car-ethics-offers-a-troubling-look-into-our-values",
+    "title": "A Study on Driverless-Car Ethics"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/29/18202602/san-francisco-facial-recognition-ban-proposal",
+    "title": "San Francisco proposal would ban government facial recognition use in the city"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19026014",
+    "title": "Ask HN: Are there any online lawyer services?"
+  },
+  {
+    "url": "https://thenextweb.com/apple/2019/01/31/after-facebook-google-apologizes-for-running-a-user-data-collection-program-on-ios/",
+    "title": "After Facebook, Google apologizes for running a user data collection program"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-foxconn-wisconsin-exclusive/exclusive-foxconn-reconsidering-plans-to-make-lcd-panels-at-wisconsin-plant-idUSKCN1PO0FV",
+    "title": "Foxconn reconsidering plans to make LCD panels at Wisconsin plant"
+  },
+  {
+    "url": "https://twitter.com/oliviaabland/status/1090281095805980672",
+    "title": "I had a job interview for a position at a company called Web Applications UK"
+  },
+  {
+    "url": "https://uk.reuters.com/article/uk-usa-spying-raven-specialreport/special-report-inside-the-uaes-secret-hacking-team-of-u-s-mercenaries-idUKKCN1PO1A6",
+    "title": "The UAE’s hacking team of U.S. mercenaries"
+  },
+  {
+    "url": "https://medium.com/@lukeberner/7e3f455b71a1",
+    "title": "I abused 2FA to maintain persistence after a password change"
+  },
+  {
+    "url": "https://nwn.blogs.com/nwn/2019/01/nylon-pinkney-sl-comics-flickr.html",
+    "title": "When your UX is so bad your userbase ridicules it in a whole series of comics"
+  },
+  {
+    "url": "https://github.com/LedgerHQ/ledger-live-mobile",
+    "title": "Ledger Live: A mobile companion app for Ledger hardware wallets"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19034707",
+    "title": "Ask HN: How do you come up with side projects?"
+  },
+  {
+    "url": "https://mashable.com/article/facebook-employees-react-teen-spying-app-blind/",
+    "title": "'Fuck ethics. Money is everything': Facebook employees react to scandal"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/30/18204186/facebook-q4-2018-earnings-user-growth-revenue-increase-privacy-scandals",
+    "title": "Facebook keeps growing despite scandals and privacy outrage"
+  },
+  {
+    "url": "https://www.dailymail.co.uk/health/article-6648545/Mind-altering-parasite-spread-CATS-lead-schizophrenia.html",
+    "title": "Mind-altering parasite spread by cats 'may lead to schizophreni'"
+  },
+  {
+    "url": "https://www.freep.com/story/weather/2019/01/30/consumers-energy-dte-usage-polar-vortex/2724017002/",
+    "title": "Michigan electric, gas capacity down significantly during polar vortex"
+  },
+  {
+    "url": "https://www.sciencemuseum.org.uk/about-us/press-office/3d-scan-reveals-intricate-detail-iconic-locomotive",
+    "title": "3D scan reveals intricate detail of iconic 1829 locomotive"
+  },
+  {
+    "url": "https://blog.floydhub.com/instagram-street-art/",
+    "title": "On Building an Instagram Street Art Dataset and Detection Model"
+  },
+  {
+    "url": "https://medium.com/automation-generation/hft-like-trading-algorithm-in-300-lines-of-code-you-can-run-now-983bede4f13a",
+    "title": "Show HN: HFT-Like Trading Algo in 300 Lines of Python"
+  },
+  {
+    "url": "https://www.businessinsider.com/facebook-q4-2018-earnings-2019-1",
+    "title": "FB soars after hours after beating top and bottom line for Q4 earnings"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/apple-bans-facebook-vpn/",
+    "title": "Apple bans Facebook’s Research app that paid users for data"
+  },
+  {
+    "url": "https://www.microsoft.com/en-us/Investor/earnings/FY-2019-Q2/press-release-webcast",
+    "title": "Microsoft announces record earnings on strong cloud growth"
+  },
+  {
+    "url": "https://mashable.com/article/facebook-will-stop-disclosing-metrics-for-main-app/#wrBjaaQghaqs",
+    "title": "Facebook doesn't want to talk about how many people use its app anymore"
+  },
+  {
+    "url": "https://nummberr.com/",
+    "title": "Show HN: Nummberr a random number generator PWA"
+  },
+  {
+    "url": "https://betterhumans.coach.me/how-to-walk-100-000-steps-in-one-day-5087adbd4569",
+    "title": "How to Walk 100,000 Steps in One Day"
+  },
+  {
+    "url": "https://openimagedenoise.github.io/",
+    "title": "Intel Open Image Denoise: High-Performance Denoising Library for Ray Tracing"
+  },
+  {
+    "url": "https://medium.com/@christianalfoni/reducing-the-pain-of-developing-apps-cd10b2e6a83c",
+    "title": "Reducing the pain of developing apps"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19042334",
+    "title": "Ask HN: Which large tech company will best prepare me to be a startup founder?"
+  },
+  {
+    "url": "https://quid.works/",
+    "title": "Show HN: Quid – try micropayments instead of ads or subscriptions"
+  },
+  {
+    "url": "https://towardsdatascience.com/learn-how-to-listen-edaea38fb276",
+    "title": "Learn How to Listen – One of the hardest parts of being a data scientist"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19040843",
+    "title": "Ask HN: What are your rules-of-thumb for personal finance and saving?"
+  },
+  {
+    "url": "https://www.reuters.com/article/idUSKCN1PO0FV",
+    "title": "Foxconn reconsidering plans to make LCD panels at Wisconsin plant"
+  },
+  {
+    "url": "https://developers.google.com/web/updates/2019/01/nic72",
+    "title": "New in Chrome 72"
+  },
+  {
+    "url": "https://www.da-platform.com/blog/match_recognize-where-flink-sql-and-complex-event-processing-meet",
+    "title": "MATCH_RECOGNIZE: Where Flink Sql and Complex Event Processing Meet"
+  },
+  {
+    "url": "https://fusionauth.io/blog/2019/01/29/white-paper-developers-guide-gdpr",
+    "title": "Developers guide to GDPR"
+  },
+  {
+    "url": "http://blog.felipe.rs/2019/01/29/demystifying-join-algorithms/",
+    "title": "Demystifying JOIN Algorithms"
+  },
+  {
+    "url": "https://techcrunch.com/2019/01/30/elon-musk-wants-teslas-to-automatically-call-a-tow-truck-when-something-breaks/",
+    "title": "Elon Musk wants Teslas to automatically call a tow truck when something breaks"
+  },
+  {
+    "url": "http://paulrubenstein.co.uk/variational-autoencoders-are-not-autoencoders/",
+    "title": "Variational Autoencoders are not autoencoders"
+  },
+  {
+    "url": "https://arstechnica.com/gaming/2019/01/an-ai-crushed-two-human-pros-at-starcraft-but-it-wasnt-a-fair-fight/",
+    "title": "An AI crushed two human pros at StarCraft–but it wasn’t a fair fight"
+  },
+  {
+    "url": "https://medium.com/@karl.pickett/benchmarking-a-toy-c-task-vs-a-go-goroutine-is-there-any-difference-248f73f7f7b7",
+    "title": "Benchmarking 1M C# tasks vs. Go goroutines"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19028449",
+    "title": "Launch HN: Scribe 2.0 (YC W17) – Configurable, Actionable Alerts on Slack"
+  },
+  {
+    "url": "https://www.reuters.com/article/us-foxconn-wisconsin-exclusive-idUSKCN1PO0FV",
+    "title": "Foxconn reconsidering plans to make LCD panels at Wisconsin plant"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19032802",
+    "title": "Ask HN: Is there any social network you trust?"
+  },
+  {
+    "url": "https://habr.com/en/post/437912/",
+    "title": "A small notebook for a system administrator"
+  },
+  {
+    "url": "https://www.research.ibm.com/artificial-intelligence/trusted-ai/diversity-in-faces/",
+    "title": "Diversity in Faces: A Dataset of Annotations of 1M Human Facial images"
+  },
+  {
+    "url": "https://hothardware.com/news/amd-lisa-su-q4-7nm-strength-epyc-double-performance",
+    "title": "AMD Talks Datacenter Share Gains as EPYC's 2X Uplift per Socket Drives Revenue"
+  },
+  {
+    "url": "https://tails.boum.org/news/version_3.12/index.en.html",
+    "title": "Tails 3.12 is out"
+  },
+  {
+    "url": "https://outage.report/gmail",
+    "title": "Gmail Services Global Outage"
+  },
+  {
+    "url": "https://github.com/komeiji-satori/Dress",
+    "title": "Dress: learn how to GitHub by posting your cosplay"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/The_Blazing_World",
+    "title": "The Blazing World"
+  },
+  {
+    "url": "https://markets.businessinsider.com/news/stocks/facebook-chaos-after-apple-blocks-internal-iphone-apps-report-2019-1-1027910304",
+    "title": "Chaos has reportedly erupted inside Facebook as Apple revoked FB's certificate"
+  },
+  {
+    "url": "https://www.businessinsider.com/facebook-chaos-after-apple-blocks-internal-iphone-apps-report-2019-1",
+    "title": "Facebook employees unable to open internal apps"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19040139",
+    "title": "Ask HN: How to practise Algo/DS for interviews that are every 2-3 years?"
+  },
+  {
+    "url": "https://github.com/Microsoft/vscode/wiki/Roadmap",
+    "title": "VS Code Roadmap 2019"
+  },
+  {
+    "url": "https://www.propublica.org/article/facebook-blocks-ad-transparency-tools",
+    "title": "Facebook Moves to Block Ad Transparency Tools"
+  },
+  {
+    "url": "https://twitter.com/zcorpan/status/1090719253379104779",
+    "title": "Mozilla developer fixes Chromium bug caused by Google breaking the spec"
+  },
+  {
+    "url": "https://iai.tv/articles/the-history-and-politics-of-boredom-auid-1208",
+    "title": "The History and Politics of Boredom"
+  },
+  {
+    "url": "https://www.wired.com/story/facebook-hires-privacy-critics/",
+    "title": "Facebook Hires Up Three of Its Biggest Privacy Critics"
+  },
+  {
+    "url": "https://fermatslibrary.com/s/the-value-of-science",
+    "title": "The Value of Science (1955)"
+  },
+  {
+    "url": "https://www.mercurynews.com/2019/01/29/go-into-debt-to-pay-rent-startup-pays-your-rent-with-high-interest-loans/",
+    "title": "California startup lets you finance your rent with high-interest loans"
+  },
+  { "url": "https://blog.ycombinator.com/yc-120/", "title": "YC 120" },
+  {
+    "url": "https://abc7chicago.com/weather/watch-live-steam-rises-off-lake-michigan-in-chicago-as-temps-plunge/5113047/",
+    "title": "Steam rises off Lake Michigan in Chicago as temps plunge to –23 degrees"
+  },
+  {
+    "url": "http://bit-player.org/2019/a-room-with-a-view",
+    "title": "A Room with a View"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2019/01/29/microsoft_internet_explorer_10/",
+    "title": "Microsoft decides IE 10 has had its fun: Termination set for Jan 2020"
+  },
+  {
+    "url": "https://www.cnn.com/videos/weather/2019/01/30/chicago-train-tracks-fire-newsource-orig.cnn",
+    "title": "Why Chicago train tracks are being set on fire"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2019/01/30/programming_bugs/",
+    "title": "Boffins debunk study showing some languages can be more buggy than others"
+  },
+  {
+    "url": "https://www.reddit.com/r/business/comments/aliemz/chaos_has_reportedly_erupted_inside_facebook_as/",
+    "title": "Apple blocks Facebook from running its internal iOS apps"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/30/18204350/google-screenwise-app-ios-apple-violation",
+    "title": "Google disables app that monitored iPhone usage in violation of Apple’s rules"
+  },
+  {
+    "url": "https://www.theguardian.com/commentisfree/2019/jan/30/facebook-is-predicting-if-youll-kill-yourself-thats-wrong",
+    "title": "Facebook is predicting if you'll kill yourself. That's wrong"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19040873",
+    "title": "Ask HN: Recommedation on system design book?"
+  },
+  {
+    "url": "https://lemire.me/blog/2019/01/29/rethinking-hammings-questions/",
+    "title": "Rethinking Hamming’s questions"
+  },
+  {
+    "url": "https://googleprojectzero.blogspot.com/2019/01/voucherswap-exploiting-mig-reference.html?m=1",
+    "title": "Voucher_swap: Exploiting MIG reference counting in iOS 12"
+  },
+  {
+    "url": "https://phys.org/news/2019-01-all-in-one-transparent-transistors.html",
+    "title": "All-in-one transparent transistors"
+  },
+  {
+    "url": "http://www.cultofmac.com/603708/chinese-spy-allegedly-caught-stealing-self-driving-car-secrets-from-apple/",
+    "title": "Chinese spy allegedly caught stealing self-driving car secrets from Apple"
+  },
+  {
+    "url": "http://ttendency.cs.ucl.ac.uk/projects/type_study/documents/type_study.pdf",
+    "title": "To Type or Not to Type: Quantifying Detectable Bugs in JavaScript [pdf]"
+  },
+  {
+    "url": "https://www.cnbc.com/2019/01/30/facebooks-sheryl-sandberg-defends-research-app-says-users-opted-in.html",
+    "title": "Sheryl Sandberg defends Facebook data-collecting app: Users 'knew’"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19024575",
+    "title": "Ask HN: Highest paying remote companies?"
+  },
+  {
+    "url": "https://gizmodo.com/i-cut-google-out-of-my-life-it-screwed-up-everything-1830565500",
+    "title": "Goodbye Big Five: Google"
+  },
+  {
+    "url": "http://nymag.com/intelligencer/2019/01/buzzfeed-top-traffic-quizzes-teen.html",
+    "title": "Buzzfeed paid the teen who made its top quizzes in free swag"
+  },
+  {
+    "url": "https://github.com/nature40/pimod",
+    "title": "Show HN: Pimod – Reconfigure Raspberry Pi Images with Docker-Like Configuration"
+  },
+  {
+    "url": "http://web.stanford.edu/class/cs181/",
+    "title": "Stanford Course: Computers, Ethics, and Public Policy"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19039016",
+    "title": "Ask HN: What are the most fun areas of programming?"
+  },
+  {
+    "url": "https://www.zdnet.com/article/amazon-gets-harrison-ford-to-reveal-the-grim-future-of-alexa/",
+    "title": "Amazon gets Harrison Ford to reveal the grim future of Alexa"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19028764",
+    "title": "Ask HN: If my company bills me out at $165/hr what should my salary be?"
+  },
+  {
+    "url": "https://shkspr.mobi/blog/2019/01/i-robot-the-3-laws-considered-harmful/",
+    "title": "“I, Robot” – the 3 laws considered harmful"
+  },
+  {
+    "url": "https://sanfrancisco.cbslocal.com/2019/01/29/east-bay-biochemist-sells-gene-editing-kit-for-the-masses/",
+    "title": "East Bay Biochemist Sells ‘Gene-Editing Kit’ for the Masses"
+  },
+  {
+    "url": "https://www.nbcbayarea.com/news/local/Another-Apple-Engineer-Accused-of-Stealing-Autonomous-Vehicle-Trade-Secrets-505055701.html",
+    "title": "Another Apple Engineer Accused of Stealing Autonomous Vehicle Trade Secrets"
+  },
+  {
+    "url": "https://www.wsj.com/articles/teenager-and-his-mom-tried-to-warn-apple-of-facetime-bug-11548783393",
+    "title": "Teenager and His Mom Tried to Warn Apple of FaceTime Bug"
+  },
+  {
+    "url": "https://www.wired.com/story/facebook-research-app-lessons/",
+    "title": "By defying Apple's rules, Facebook shows it never learns"
+  },
+  {
+    "url": "https://blogs.msdn.microsoft.com/dotnet/2019/01/29/announcing-net-core-3-preview-2/",
+    "title": "Announcing .NET Core 3 Preview 2"
+  },
+  {
+    "url": "https://www.businessinsider.com/instagram-tv-service-igtv-recommended-potential-child-abuse-2018-9",
+    "title": "Instagram's new TV service recommended videos of potential child abuse"
+  },
+  {
+    "url": "https://www.anandtech.com/show/13909/ces-2019-amd-ceo-dr-lisa-su",
+    "title": "CES 2019 Question and Answer Session with AMD CEO, Dr. Lisa Su"
+  },
+  {
+    "url": "http://www.remotepresence.io/",
+    "title": "Show HN: Remote Presence – faking your presence on Slack"
+  },
+  {
+    "url": "https://nakedsecurity.sophos.com/2016/11/24/how-your-speakers-could-be-turned-into-eavesdropping-microphones/",
+    "title": "Your Speakers Could Be Turned into Eavesdropping Microphones (2016)"
+  },
+  {
+    "url": "https://www.cnbc.com/2019/01/29/facebook-hires-nate-cardozo-eff-privacy-critic-for-whatsapp-privacy.html",
+    "title": "Facebook hires one of its biggest privacy critics to oversee WhatsApp privacy"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19032180",
+    "title": "Ask HN: What are your go-to checklists?"
+  },
+  {
+    "url": "https://events.linuxfoundation.org/wp-content/uploads/2017/11/When-eBPF-Meets-FUSE-Improving-Performance-of-User-File-Systems-Ashish-Bijlani-Georgia-Tech.pdf",
+    "title": "EBPF and FUSE = Faster FUSE File Systems [pdf]"
+  },
+  {
+    "url": "https://twitter.com/alexeheath/status/1090618327502897152",
+    "title": "Apple revoked Facebook’s iOS developer certificate"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19036698",
+    "title": "If iframes are evil, why do top websites allow ad networks to embed with them?"
+  },
+  {
+    "url": "https://medium.com/sandbox-vr/were-building-the-holodeck-with-andreessen-horowitz-79e2cb18046",
+    "title": "We’re Building the Holodeck with Andreessen Horowitz"
+  },
+  {
+    "url": "https://www.nydailynews.com/news/politics/ny-pol-amazon-city-council-union-workers-20190130-story.html",
+    "title": "Amazon will oppose unionization bids in New York City"
+  },
+  {
+    "url": "https://www.businessinsider.com/us-indictment-against-huawei-t-mobile-reads-spy-movie-2019-1",
+    "title": "Huawei's attempts to copycat a T-Mobile robot read like a comical spy movie"
+  },
+  {
+    "url": "https://arstechnica.com/tech-policy/2019/01/lawyer-sues-apple-claims-facetime-bug-allowed-recording-of-deposition/",
+    "title": "Lawyer sues Apple, claims FaceTime bug “allowed” recording of deposition"
+  },
+  {
+    "url": "https://siepr.stanford.edu/news/drop-facebook",
+    "title": "Tuning Out: What Happens When You Drop Facebook?"
+  },
+  {
+    "url": "http://www.informit.com/articles/article.aspx?p=2213858&WT.mc_id=Author_Knuth_20Questions",
+    "title": "Twenty Questions for Donald Knuth (2014)"
+  },
+  {
+    "url": "https://camelcamelcamel.com/",
+    "title": "CamelCamelCamel is down for a week, 3 failed hard drives and $45k"
+  },
+  {
+    "url": "https://www.apple.com/business/resources/docs/iOS_Security_Overview.pdf",
+    "title": "Apple iOS Security Overview: Secure by Design [pdf]"
+  },
+  {
+    "url": "https://aeon.co/ideas/believing-without-evidence-is-always-morally-wrong",
+    "title": "Believing without evidence is always morally wrong"
+  },
+  {
+    "url": "https://medium.com/@lenoreestrada/munchery-how-a-venture-backed-startup-swindled-a-group-of-women-and-minority-owned-companies-out-e64ee610511b",
+    "title": "Munchery swindled a group of women and minority owned companies out of over $50k"
+  },
+  {
+    "url": "https://rythere.com/best-most-beautiful-places-visit-france/",
+    "title": "Most Beautiful Places to Visit in France 2019 France Travel"
+  },
+  {
+    "url": "https://www.johnwdefeo.com/articles/future-of-white-hat-seo",
+    "title": "What If Google Doesn't Reward White Hat SEO?"
+  },
+  {
+    "url": "https://www.groovehq.com/blog/rebirth-of-groove/?r",
+    "title": "The Rebirth of Groove"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/29/18187178/pentagon-research-documents-invisibility-cloaking-wormholes-warp-drive-department-of-defense",
+    "title": "Pentagon compiled research into invisibility cloaking, wormholes, and warp drive"
+  },
+  {
+    "url": "https://medium.com/@DavidKPiano/the-facetime-bug-and-the-dangers-of-implicit-state-machines-a5f0f61bdaa2",
+    "title": "The FaceTime Bug and the Dangers of Implicit State Machines"
+  },
+  {
+    "url": "https://venturebeat.com/2019/01/30/fbi-charges-second-apple-employee-with-stealing-autonomous-car-secrets/",
+    "title": "FBI Charges Second Apple Employee with Stealing Autonomous Car Secrets"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/29/books/review/roger-mcnamee-zucked.html",
+    "title": "An Anti-Facebook Manifesto, by an Early Facebook Investor"
+  },
+  {
+    "url": "https://www.theregister.co.uk/2018/06/18/bjarne_stroustrup_c_plus_plus/",
+    "title": "Bjarne Stroustrup warns of dangerous future plans for his C++ (2018)"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/29/opinion/zuckerberg-facebook-ads.html",
+    "title": "Mark Zuckerberg’s Delusion of Consumer Consent"
+  },
+  {
+    "url": "https://www.engadget.com/2019/01/30/lyft-reportedly-suing-over-nyc-minimum-wage-law/",
+    "title": "Lyft Will Reportedly Sue Over New York's Minimum Pay for Drivers Law"
+  },
+  {
+    "url": "https://www.businessinsider.com/facebook-employees-angry-after-apple-blocks-its-internal-ios-apps-2019-1",
+    "title": "Facebook employees 'angry' after Apple blocks its internal iOS apps"
+  },
+  {
+    "url": "https://leavemealone.xyz/",
+    "title": "Show HN: Leave Me Alone – A privacy focused email unsubscription service"
+  },
+  {
+    "url": "https://edition.cnn.com/2019/01/28/health/hiv-status-data-leak-singapore-intl/index.html",
+    "title": "HIV status of over 14,000 people leaked online, Singapore authorities say"
+  },
+  {
+    "url": "https://www.apple.com/investor/earnings-call/",
+    "title": "Apple Financial Results – Q1 2019 Conference Call LIVE"
+  },
+  {
+    "url": "https://news.yahoo.com/inside-key-hawaii-intelligence-outpost-listening-pacific-174040136.html",
+    "title": "Inside a key Hawaii intelligence outpost listening in on the Pacific"
+  },
+  {
+    "url": "https://www.consumerreports.org/food-safety/arsenic-and-lead-are-in-your-fruit-juice-what-you-need-to-know/",
+    "title": "Arsenic and Lead Are in Your Fruit Juice"
+  },
+  {
+    "url": "https://threader.app/thread/1090410029256081408",
+    "title": "A thread by Stanford Computer Science lecturer regarding Facebook spying methods"
+  },
+  {
+    "url": "https://www.foxnews.com/tech/americans-hit-with-26-3-billion-robocalls-last-year-causing-some-to-not-answer-their-phone",
+    "title": "Robocalls reach ridiculous level, as people are afraid to answer their phones"
+  },
+  {
+    "url": "https://www.muckrock.com/news/archives/2019/jan/30/doe-enron-data/",
+    "title": "Terabytes of Enron data have quietly gone missing from the Department of Energy"
+  },
+  {
+    "url": "https://consortiumnews.com/2018/07/19/inside-wikileaks-working-with-the-publisher-that-changed-the-world/",
+    "title": "WikiLeaks: Working with the Publisher That Changed the World"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19028201",
+    "title": "Ask HN: How to ask your employer to let you own your personal projects"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19025488",
+    "title": "Ask HN: Which new programming language are you planning to pick up in 2019?"
+  },
+  {
+    "url": "https://m.signalvnoise.com/paying-tribute-to-the-web-with-view-source/",
+    "title": "DHH: Paying Tribute to the Web with View Source"
+  },
+  {
+    "url": "https://www.theguardian.com/sport/2019/jan/29/golden-globe-race-jean-luc-van-den-heede-solo-yacht",
+    "title": "73-year-old sailor wins round-the-world solo-race without modern instruments"
+  },
+  {
+    "url": "https://www.sciencedaily.com/releases/2019/01/190122084401.htm",
+    "title": "Artificial intelligence can cut time needed to process abnormal chest X-rays"
+  },
+  {
+    "url": "https://medium.com/react-in-depth/why-react-suspense-will-be-a-game-changer-37b40fea71ec",
+    "title": "Why React Suspense Will Be a Game Changer"
+  },
+  {
+    "url": "https://www.fastcompany.com/90299141/how-facebook-is-paying-teens-to-harvest-their-data-after-an-app-store-ban-project-atlas",
+    "title": "How Facebook is quietly paying teens to gather their data after an App Store ban"
+  },
+  {
+    "url": "https://www.nbcnews.com/tech/security/how-teenage-fortnite-player-found-apple-s-facetime-bug-why-n963961",
+    "title": "A teenager found Apple's FaceTime bug – and why it was so hard to report it"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=yM4Rb0DTyKU",
+    "title": "Designing a circular knitting machine from scratch [video]"
+  },
+  {
+    "url": "https://twitter.com/LouisDhauwe/status/1088729484054933504",
+    "title": "If your radar is being ignored, just join the team and fix it yourself"
+  },
+  {
+    "url": "https://pushdata.io/blog/1",
+    "title": "The case for vanilla front-end development"
+  },
+  {
+    "url": "https://theoutline.com/post/4143/telegram-is-the-hot-new-source-for-illegal-downloads?zd=3&zi=xew4vxww",
+    "title": "Telegram is the hot new source for pirated content (2018)"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=Lj1a8rdX6DU",
+    "title": "What Engineers Found When They Tore Apart Tesla's Model 3"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19031470",
+    "title": "Ask HN: Steps to forming a company?"
+  },
+  {
+    "url": "https://www.zdnet.com/article/japanese-government-plans-to-hack-into-citizens-iot-devices/",
+    "title": "Japanese government plans to hack into citizens' IoT devices"
+  },
+  {
+    "url": "https://hbr.org/1995/09/the-power-of-talk-who-gets-heard-and-why",
+    "title": "The Power of Talk: Who Gets Heard and Why (1995)"
+  },
+  {
+    "url": "https://hackernoon.com/building-a-remote-friendly-company-an-interview-with-webflow-ceo-vlad-magdalin-3597d55df44c",
+    "title": "Building a Remote-Friendly Company at Webflow (YC S13)"
+  },
+  {
+    "url": "https://www.politico.eu/article/corruption-europe-shortfalls-fuelling-global-democracy-crisis/",
+    "title": "Anti-corruption shortfalls fuelling ‘global democracy crisis’"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/The_Cuckoo%27s_Egg",
+    "title": "The Cuckoo's Egg"
+  },
+  {
+    "url": "https://mathvault.ca/10-commandments/",
+    "title": "[Illustrated Guide] the 10 Commandments of Higher Mathematical Learning"
+  },
+  {
+    "url": "https://heartbeat.fritz.ai/how-tensorflow-lite-optimizes-neural-networks-for-mobile-machine-learning-e6ffa7f8ee12",
+    "title": "TensorFlow Lite adds GPU support for Android making ML models run 4-7X faster"
+  },
+  {
+    "url": "https://www.sciencedaily.com/releases/2019/01/190129081919.htm",
+    "title": "Engineers translate brain signals directly into speech"
+  },
+  {
+    "url": "https://nypost.com/2019/01/27/american-stooges-for-venezuelas-dictator/",
+    "title": "American stooges for Venezuela’s dictator"
+  },
+  {
+    "url": "https://medium.com/@carlosedp/building-a-hybrid-x86-64-and-arm-kubernetes-cluster-e7f94ff6e51d",
+    "title": "Building a Hybrid x86–64 and ARM Kubernetes Cluster"
+  },
+  {
+    "url": "http://blog.robertelder.org/computer-science-for-engineers/",
+    "title": "An Overview of Computer Science Concepts for Engineers"
+  },
+  {
+    "url": "https://medium.com/tensorflow/what-are-symbolic-and-imperative-apis-in-tensorflow-2-0-dfccecb01021",
+    "title": "What Are Symbolic and Imperative APIs in TensorFlow 2.0?"
+  },
+  {
+    "url": "https://medium.com/@lukeberner/how-i-abused-2fa-to-maintain-persistence-after-a-password-change-google-microsoft-instagram-7e3f455b71a1",
+    "title": "I abused 2FA to maintain persistence after a password change"
+  },
+  {
+    "url": "https://www.theatlantic.com/ideas/archive/2019/01/will-we-ever-have-flying-cars/581473/",
+    "title": "Why Flying Cars Are an Impossible Dream"
+  },
+  {
+    "url": "https://www.theguardian.com/news/2019/jan/22/the-new-elites-phoney-crusade-to-save-the-world-without-changing-anything",
+    "title": "The new elite’s phoney crusade to save the world – without changing anything"
+  },
+  {
+    "url": "https://www.nbcnews.com/politics/2020-election/elizabeth-warren-s-plan-tax-super-rich-has-been-tried-n963971?cid=eml_nbn_20190129",
+    "title": "Plan to tax the super-rich has been tried before. Here's what happened"
+  },
+  {
+    "url": "https://aeon.co/ideas/foodie-localism-loves-farming-in-theory-but-not-in-practice",
+    "title": "Foodie Localism Loves Farming in Theory but Not in Practice"
+  },
+  {
+    "url": "https://www.iflscience.com/plants-and-animals/namibian-desert-lions-spotted-hunting-and-eating-marine-creatures/",
+    "title": "Namibian Desert Lions Spotted Hunting and Eating Marine Creatures"
+  },
+  {
+    "url": "https://www.thesun.co.uk/tech/8303195/alexander-the-great-was-alive-while-body-was-prepared-for-burial-after-rare-disease-left-him-paralysed/",
+    "title": "Alexander the Great ‘was ALIVE while his body was prepared for burial’"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19026746",
+    "title": "Ask HN: Best File Naming Convention?"
+  },
+  {
+    "url": "https://news.ycombinator.com/item?id=19026552",
+    "title": "Ask HN: What was your experience moving from Xamarin to native iOS/Android"
+  },
+  {
+    "url": "https://www.theguardian.com/cities/2019/jan/28/no-one-likes-being-a-tourist-the-rise-of-the-anti-tour",
+    "title": "'No one likes being a tourist': the rise of the anti-tour"
+  },
+  {
+    "url": "https://medium.com/@jinkangcen/i-know-why-google-cloud-is-falling-behind-9f7357c3abc3",
+    "title": "I know why Google Cloud is falling behind"
+  },
+  {
+    "url": "https://medium.com/@steven.appdrag/social-brand-destruction-a-survivors-account-1d988225611c",
+    "title": "Social brand destruction: A survivor’s account"
+  },
+  {
+    "url": "https://www.theverge.com/2019/1/29/18202880/facebook-research-enterprise-root-certificate-onavo-techcrunch",
+    "title": "Facebook has been paying teens $20 a month for total access to their phones"
+  },
+  {
+    "url": "https://twitter.com/MissEllieMae/status/1090217105797074944",
+    "title": "“Just stop talking about philanthropy, and start talking about taxes.”"
+  },
+  {
+    "url": "https://blog.scalyr.com/2018/08/custom-regex-parser/",
+    "title": "Built for Speed: Custom Parser for Regex at Scale"
+  },
+  {
+    "url": "https://webplatform.news/issues/2019-01-29",
+    "title": "Rails 6 just committed to shipping source maps by default in production"
+  },
+  {
+    "url": "https://www.wired.com/story/nest-cameras-pew-die-pie-north-korea-passwords/",
+    "title": "Nest Cams Hijacked in the Name of PewDiePie and North Korea Pranks"
+  },
+  {
+    "url": "https://medium.com/merantix/journey-from-academic-paper-to-industry-usage-cf57fe598f31",
+    "title": "What building Conditional Imitation Learning taught about reproducing a paper"
+  },
+  {
+    "url": "https://mashable.com/article/apple-warned-of-facetime-bug/",
+    "title": "Apple was warned of the FaceTime bug over a week ago"
+  },
+  {
+    "url": "https://hashrocket.com/blog/posts/sql-inner-join-vs-outer-join",
+    "title": "Sql: Inner Join vs. Outer Join"
+  },
+  {
+    "url": "https://www.macrumors.com/2019/01/28/apple-disables-group-facetime-due-to-bug/",
+    "title": "Apple Disables Group FaceTime as Temporary Workaround to Major Privacy Bug"
+  },
+  {
+    "url": "https://www.theguardian.com/world/2019/jan/28/fate-of-castles-in-the-air-in-turkeys-151m-ghost-town",
+    "title": "Fate of castles in the air in Turkey’s £151m ghost town"
+  },
+  {
+    "url": "https://waitbutwhy.com/2014/06/taming-mammoth-let-peoples-opinions-run-life.html",
+    "title": "Taming the Mammoth: Why You Should Stop Caring What Other People Think (2014)"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=x4La5hrqWXM",
+    "title": "US Intel Community Westling with Deep Fake and Other Technologies"
+  },
+  {
+    "url": "https://www.nationalgeographic.com/animals/2019/01/blue-eyes-mutation-coyotes-spreading-in-california/",
+    "title": "Mutant blue-eyed coyotes spreading through California"
+  },
+  {
+    "url": "https://www.fastcompany.com/90297443/this-guy-holds-the-guinness-world-record-for-collecting-spreadsheets",
+    "title": "Meet the Guy Who Holds the Guinness World Record for Collecting Spreadsheets"
+  },
+  {
+    "url": "https://www.jpost.com/HEALTH-SCIENCE/A-cure-for-cancer-Israeli-scientists-say-they-think-they-found-one-578939",
+    "title": "Israeli scientists say they found a cure for cancer"
+  },
+  {
+    "url": "https://twitter.com/lambda_conf/status/1089461074070523904",
+    "title": "Book of Monads, first edition"
+  },
+  {
+    "url": "https://adcontrarian.blogspot.com/2019/01/why-online-ads-havent-built-brands.html",
+    "title": "Why online ads haven't built brands"
+  },
+  {
+    "url": "https://www.zdnet.com/article/google-oracle-java-win-will-kill-software-development-so-supreme-court-must-rule/",
+    "title": "Google: Oracle Java win will kill software development, so SCOTUS must rule"
+  },
+  {
+    "url": "https://www.buzzfeed.com/heidiblake/poison-in-the-system",
+    "title": "Evidence of Kremlin assassination plot that British authorities sidelined"
+  },
+  {
+    "url": "https://www.reddit.com/r/cscareerquestions/comments/al2p6q/7_months_into_fang_company_want_out/efad55p/",
+    "title": "Amazon has forced attrition rates (someone has to go every year)"
+  },
+  {
+    "url": "https://www.recode.net/2019/1/30/18203231/apple-says-its-banning-facebooks-research-that-collected-users-personal-information",
+    "title": "Apple to ban Facebook’s research app that collects users’ personal information"
+  },
+  {
+    "url": "https://www.salon.com/2019/01/30/a-gold-standard-study-finds-deleting-facebook-is-great-for-your-mental-health/",
+    "title": "A “gold standard” study finds deleting Facebook is great for your mental health"
+  },
+  {
+    "url": "https://firebase.googleblog.com/2019/01/cloud-firestore-in-general-availability.htm",
+    "title": "Google Cloud Firestore Is Now Generally Available"
+  },
+  {
+    "url": "http://time.com/5190977/how-oat-milk-could-change-the-way-you-drink-coffee/",
+    "title": "Oat Milk Could Change the Way You Drink Coffee (2018)"
+  },
+  {
+    "url": "https://www.usgamer.net/articles/facebook-unsealed-documents-whales-mobile-games",
+    "title": "Facebook Referred to Kids as Young as Five as “Whales” for Its Monetized Games"
+  },
+  {
+    "url": "https://nickjanetakis.com/blog/i-tried-linux-as-my-main-dev-environment-but-was-forced-back-to-windows",
+    "title": "I Tried Linux as My Main Dev Environment but Was Forced Back to Windows"
+  },
+  {
+    "url": "https://www.reuters.com/investigates/special-report/usa-spying-raven/",
+    "title": "Ex-NSA cyberspies reveal how they helped hack foes of UAE"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/29/technology/facetime-glitch-apple.html",
+    "title": "Apple Was Slow to Act on FaceTime Bug That Allows Spying on iPhones"
+  },
+  {
+    "url": "https://www.wired.com/story/a-childs-puzzle-helped-uncover-how-magnets-really-work/",
+    "title": "A Child’s Puzzle Helped Uncover How Magnets Work"
+  },
+  {
+    "url": "https://news.nationalgeographic.com/2018/05/nasa-emdrive-impossible-physics-independent-tests-magnetic-space-science/",
+    "title": "The first independent tests of the EmDrive suggest a mundane explanation (2018)"
+  },
+  {
+    "url": "https://www.nytimes.com/2019/01/28/world/black-cube-nso-citizen-lab-intelligence.html",
+    "title": "The Case of the Bumbling Spy: A Watchdog Group Gets Him on Camera"
+  },
+  {
+    "url": "https://seekingalpha.com/news/3427520-apple-banning-facebooks-info-sucking-research-app",
+    "title": "Apple banning Facebook's info-sucking research app"
+  }
 ]


### PR DESCRIPTION
I got some pushback from the linting team about excluding these from linting in m-c, so here we are.

All these were auto-fixed by the linter *except for script.js* which has some hand-edits.
