### PR TITLE
Remove branch build docs and issue template reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,11 +7,9 @@
 - [ ] **Quality**: This PR builds and tests run cleanly
   - Note:
     - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
-    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
+    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
 - [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
 - [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
   - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
 - [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
   - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
-
-[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.

--- a/docs/howtos/branch-builds.md
+++ b/docs/howtos/branch-builds.md
@@ -3,18 +3,6 @@
 Branch builds are a way to build and test Fenix using branches from `application-services` and `firefox-android`.
 iOS is not currently supported, although we may add it in the future (see [#4966](https://github.com/mozilla/application-services/issues/4966)).
 
-## Breaking changes in an application-services branch.
-
- When we make breaking changes in an application-services branch, we typically make corresponding changes in an
- `android-components` branch.  Branch builds allow combining those branches together in order to run CI tests
- and to produce APKs for manual testing.  To trigger a branch build for this:
-
-  - Create the PR for the `application-services` branch you're working on
-  - Add `[firefox-android: branch-name]` to the PR title
-  - The branch build tasks will be listed as checks the Github PR.  In particular:
-    - `branch-build-fenix-test` and `branch-build-ac-test` will run the unit android-components/fenix unit tests
-    - `branch-build-fenix-build` will contain the Fenix APK.
-
 ## Application-services nightlies
 
 When we make non-breaking changes, we typically merge them into main and let them sit there until the next release. In


### PR DESCRIPTION
`mozilla-mobile/firefox-android` is dead; long live `mozilla-central/mobile/android/fenix`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

~~[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.~~
