### PR TITLE
Bug 1958992 - suggest: Improve geonames l10n and weather-suggestions matching.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
  "clap 4.2.2",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.3",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -892,7 +892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.3",
 ]
 
 [[package]]
@@ -2586,6 +2586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,7 +3224,7 @@ dependencies = [
  "email_address",
  "glob",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.3",
  "jsonschema",
  "lazy_static",
  "reqwest 0.11.18",
@@ -3798,7 +3807,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.3",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -3907,7 +3916,7 @@ checksum = "30d3e647e9eb04ddfef78dfee2d5b3fefdf94821c84b710a3d8ebc89ede8b164"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.3",
  "log",
  "multimap",
  "once_cell",
@@ -3928,7 +3937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56075c27b20ae524d00f247b8a4dc333e5784f889fe63099f8e626bc8d73486c"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.3",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -4973,6 +4982,7 @@ dependencies = [
  "extend",
  "hex",
  "interrupt-support",
+ "itertools 0.14.0",
  "once_cell",
  "parking_lot",
  "rc_crypto",
@@ -4984,6 +4994,8 @@ dependencies = [
  "sql-support",
  "tempfile",
  "thiserror 1.0.31",
+ "unicase",
+ "unicode-normalization",
  "uniffi",
  "url",
  "viaduct",

--- a/components/suggest/Cargo.toml
+++ b/components/suggest/Cargo.toml
@@ -16,7 +16,7 @@ interrupt-support = { path = "../support/interrupt" }
 once_cell = "1.5"
 parking_lot = ">=0.11,<=0.12"
 remote_settings = { path = "../remote_settings" }
-rusqlite = { version = "0.33.0", features = ["functions", "bundled", "load_extension"] }
+rusqlite = { version = "0.33.0", features = ["functions", "bundled", "load_extension", "collation"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 error-support = { path = "../support/error" }
@@ -25,6 +25,9 @@ viaduct = { path = "../viaduct" }
 viaduct-reqwest = { path = "../support/viaduct-reqwest", optional=true }
 tempfile = { version = "3.2.0", optional = true }
 thiserror = "1"
+# This is an old version of `unicase` but it's the one mozilla-central uses.
+unicase = "2.6"
+unicode-normalization = "0.1"
 uniffi = { version = "0.29.0" }
 url = { version = "2.1", features = ["serde"] }
 
@@ -33,6 +36,7 @@ error-support = { path = "../support/error", features = ["testing"] }
 criterion = "0.5"
 expect-test = "1.4"
 hex = "0.4"
+itertools = "0.14"
 rc_crypto = { path = "../support/rc_crypto" }
 
 [build-dependencies]

--- a/components/suggest/src/benchmarks/geoname.rs
+++ b/components/suggest/src/benchmarks/geoname.rs
@@ -17,7 +17,6 @@ pub struct GeonameBenchmark {
 pub struct FetchGeonamesArgs {
     query: &'static str,
     match_name_prefix: bool,
-    geoname_type: Option<GeonameType>,
     filter: Option<Vec<Geoname>>,
 }
 
@@ -49,7 +48,6 @@ impl BenchmarkWithInput for GeonameBenchmark {
             .fetch_geonames(
                 i_input.fetch_args.query,
                 i_input.fetch_args.match_name_prefix,
-                i_input.fetch_args.geoname_type,
                 i_input.fetch_args.filter,
             )
             .unwrap_or_else(|e| panic!("Error fetching geonames: {e}"));
@@ -67,13 +65,19 @@ impl BenchmarkWithInput for GeonameBenchmark {
 
 pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
     let ny_state = Geoname {
-        geoname_id: 8,
+        geoname_id: 5128638,
+        geoname_type: GeonameType::Admin1,
         name: "New York".to_string(),
-        latitude: 43.00035,
-        longitude: -75.4999,
+        feature_class: "A".to_string(),
+        feature_code: "ADM1".to_string(),
         country_code: "US".to_string(),
-        admin1_code: "NY".to_string(),
+        admin1_code: Some("NY".to_string()),
+        admin2_code: None,
+        admin3_code: None,
+        admin4_code: None,
         population: 19274244,
+        latitude: "43.00035".to_string(),
+        longitude: "-75.4999".to_string(),
     };
 
     vec![
@@ -84,7 +88,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "nomatch",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -96,7 +99,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "no match",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -108,7 +110,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "no match either",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -120,7 +121,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "this is a very long string that does not match anything in the geonames database but it sure is very long",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -134,7 +134,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "nomatch",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -146,7 +145,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "no match",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -158,7 +156,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "no match either",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -170,7 +167,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "this is a very long string that does not match anything in the geonames database but it sure is very long",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: false,
@@ -184,7 +180,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "ny",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -196,7 +191,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "nyc",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -208,7 +202,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "ca",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -220,7 +213,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "pdx",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -232,7 +224,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "roc",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -246,7 +237,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "ny",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -258,7 +248,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "nyc",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -270,7 +259,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "ca",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -282,7 +270,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "pdx",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -294,7 +281,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "roc",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -308,7 +294,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "new york",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -320,7 +305,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "rochester",
                     match_name_prefix: false,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -334,7 +318,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "new york",
                     match_name_prefix: true,
-                    geoname_type: None,
                     filter: None,
                 },
                 should_match: true,
@@ -346,33 +329,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "rochester",
                     match_name_prefix: true,
-                    geoname_type: None,
-                    filter: None,
-                },
-                should_match: true,
-            }
-        ),
-
-        // restricting to a geoname type
-        (
-            "geoname-fetch-type-city-ny",
-            GeonameBenchmark {
-                args: FetchGeonamesArgs {
-                    query: "ny",
-                    match_name_prefix: false,
-                    geoname_type: Some(GeonameType::City),
-                    filter: None,
-                },
-                should_match: true,
-            }
-        ),
-        (
-            "geoname-fetch-type-region-ny",
-            GeonameBenchmark {
-                args: FetchGeonamesArgs {
-                    query: "ny",
-                    match_name_prefix: false,
-                    geoname_type: Some(GeonameType::Region),
                     filter: None,
                 },
                 should_match: true,
@@ -386,59 +342,6 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                 args: FetchGeonamesArgs {
                     query: "ny",
                     match_name_prefix: false,
-                    geoname_type: None,
-                    filter: Some(vec![ny_state.clone()]),
-                },
-                should_match: true,
-            }
-        ),
-
-        // restricting to a geoname type + filtering
-        (
-            "geoname-fetch-type-filter-city-ny",
-            GeonameBenchmark {
-                args: FetchGeonamesArgs {
-                    query: "ny",
-                    match_name_prefix: false,
-                    geoname_type: Some(GeonameType::City),
-                    filter: Some(vec![ny_state.clone()]),
-                },
-                should_match: true,
-            }
-        ),
-        (
-            "geoname-fetch-type-filter-region-ny",
-            GeonameBenchmark {
-                args: FetchGeonamesArgs {
-                    query: "ny",
-                    match_name_prefix: false,
-                    geoname_type: Some(GeonameType::Region),
-                    filter: Some(vec![ny_state.clone()]),
-                },
-                should_match: true,
-            }
-        ),
-
-        // restricting to a geoname type + filtering w/ prefix matching
-        (
-            "geoname-fetch-type-filter-prefix-city-ny",
-            GeonameBenchmark {
-                args: FetchGeonamesArgs {
-                    query: "ny",
-                    match_name_prefix: true,
-                    geoname_type: Some(GeonameType::City),
-                    filter: Some(vec![ny_state.clone()]),
-                },
-                should_match: true,
-            }
-        ),
-        (
-            "geoname-fetch-type-filter-prefix-region-ny",
-            GeonameBenchmark {
-                args: FetchGeonamesArgs {
-                    query: "ny",
-                    match_name_prefix: true,
-                    geoname_type: Some(GeonameType::Region),
                     filter: Some(vec![ny_state.clone()]),
                 },
                 should_match: true,

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -1366,6 +1366,11 @@ impl<'a> SuggestDao<'a> {
         )?;
         self.scope.err_if_interrupted()?;
         self.conn.execute_cached(
+            "DELETE FROM geonames_alternates WHERE record_id = :record_id",
+            named_params! { ":record_id": record_id.as_str() },
+        )?;
+        self.scope.err_if_interrupted()?;
+        self.conn.execute_cached(
             "DELETE FROM geonames_metrics WHERE record_id = :record_id",
             named_params! { ":record_id": record_id.as_str() },
         )?;

--- a/components/suggest/src/geoname.rs
+++ b/components/suggest/src/geoname.rs
@@ -6,20 +6,27 @@
 /// GeoNames support. GeoNames is an open-source geographical database of place
 /// names worldwide, including cities, regions, and countries [1]. Notably it's
 /// used by MaxMind's databases [2]. We use GeoNames to detect city and region
-/// names and to map cities to regions.
+/// names and to map cities to regions. Specifically we use the data at [3];
+/// also see [3] for documentation.
 ///
 /// [1]: https://www.geonames.org/
 /// [2]: https://www.maxmind.com/en/geoip-databases
+/// [3]: https://download.geonames.org/export/dump/
 use rusqlite::{named_params, Connection};
 use serde::Deserialize;
 use sql_support::ConnExt;
-use std::hash::{Hash, Hasher};
+use std::{
+    borrow::Cow,
+    hash::{Hash, Hasher},
+};
+use unicase::UniCase;
+use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 
 use crate::{
     db::SuggestDao,
     error::RusqliteResultExt,
     metrics::MetricsContext,
-    rs::{deserialize_f64_or_default, Client, Record, SuggestRecordId},
+    rs::{Client, Record, SuggestRecordId},
     store::SuggestStoreInner,
     Result,
 };
@@ -27,9 +34,19 @@ use crate::{
 /// The type of a geoname.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, uniffi::Enum)]
 pub enum GeonameType {
+    Country,
+    /// A state, province, prefecture, district, borough, etc.
+    Admin1,
+    Admin2,
+    Admin3,
+    Admin4,
+    AdminOther,
+    /// A city, town, village, populated place, etc.
     City,
-    Region,
+    Other,
 }
+
+pub type GeonameId = i64;
 
 /// A single geographic place.
 ///
@@ -37,46 +54,99 @@ pub enum GeonameType {
 /// the GeoNames documentation [1]. We exclude fields we don't need.
 ///
 /// [1]: https://download.geonames.org/export/dump/readme.txt
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(Clone, Debug, Eq, PartialEq, uniffi::Record)]
 pub struct Geoname {
     /// The `geonameid` straight from the geoname table.
-    pub geoname_id: i64,
+    pub geoname_id: GeonameId,
+    /// The geoname type. This is derived from `feature_class` and
+    /// `feature_code` as a more convenient representation of the type.
+    pub geoname_type: GeonameType,
     /// This is pretty much the place's canonical name. Usually there will be a
     /// row in the alternates table with the same name, but not always. When
     /// there is such a row, it doesn't always have `is_preferred_name` set, and
     /// in fact fact there may be another row with a different name with
     /// `is_preferred_name` set.
     pub name: String,
-    /// Latitude in decimal degrees.
-    pub latitude: f64,
-    /// Longitude in decimal degrees.
-    pub longitude: f64,
     /// ISO-3166 two-letter uppercase country code, e.g., "US".
     pub country_code: String,
-    /// The top-level administrative region for the place within its country,
-    /// like a state or province. For the U.S., the two-letter uppercase state
-    /// abbreviation.
-    pub admin1_code: String,
+    /// Primary geoname category. Examples:
+    ///
+    /// "PCLI" - Independent political entity: country
+    /// "A" - Administrative division: state, province, borough, district, etc.
+    /// "P" - Populated place: city, village, etc.
+    pub feature_class: String,
+    /// Secondary geoname category, depends on `feature_class`. Examples:
+    ///
+    /// "ADM1" - Administrative division 1
+    /// "PPL" - Populated place like a city
+    pub feature_code: String,
+    /// Administrative division 1.
+    pub admin1_code: Option<String>,
+    /// Administrative division 2.
+    pub admin2_code: Option<String>,
+    /// Administrative division 3.
+    pub admin3_code: Option<String>,
+    /// Administrative division 4.
+    pub admin4_code: Option<String>,
     /// Population size.
     pub population: u64,
+    /// Latitude in decimal degrees (as a string).
+    pub latitude: String,
+    /// Longitude in decimal degrees (as a string).
+    pub longitude: String,
 }
 
 impl Geoname {
-    /// Whether `self` and `other` have the same region and country. If one is a
-    /// city and the other is a region, this will return `true` if the city is
-    /// located in the region.
-    pub fn has_same_region(&self, other: &Self) -> bool {
-        self.admin1_code == other.admin1_code && self.country_code == other.country_code
+    /// Whether `self` and `other` are related. For example, if one is a city
+    /// and the other is an administrative division, this will return `true` if
+    /// the city is located in the division.
+    pub fn is_related_to(&self, other: &Self) -> bool {
+        let self_level = usize::from(self.admin_level());
+        let other_level = usize::from(other.admin_level());
+
+        let self_admins = self.admin_array();
+        let other_admins = other.admin_array();
+
+        // Each admin level needs to be the same in `self` and `other` up to the
+        // minimum level of `self` and `other`.
+        for (level, (self_admin, other_admin)) in
+            std::iter::zip(self_admins.iter(), other_admins.iter()).enumerate()
+        {
+            if self_level < level || other_level < level {
+                break;
+            }
+            if self_admin != other_admin {
+                return false;
+            }
+        }
+
+        // At this point, admin levels are the same up to the minimum level. If
+        // the types of `self` and `other` aren't the same, then one is an admin
+        // division of the other. If they are the same type, then they need to
+        // be the same geoname.
+        self.geoname_type != other.geoname_type || self.geoname_id == other.geoname_id
+    }
+
+    fn admin_array(&self) -> [Option<&str>; 5] {
+        [
+            Some(&self.country_code),
+            self.admin1_code.as_deref(),
+            self.admin2_code.as_deref(),
+            self.admin3_code.as_deref(),
+            self.admin4_code.as_deref(),
+        ]
+    }
+
+    fn admin_level(&self) -> u8 {
+        match self.geoname_type {
+            GeonameType::Country => 0,
+            GeonameType::Admin1 => 1,
+            GeonameType::Admin2 => 2,
+            GeonameType::Admin3 => 3,
+            _ => 4,
+        }
     }
 }
-
-impl PartialEq for Geoname {
-    fn eq(&self, other: &Geoname) -> bool {
-        self.geoname_id == other.geoname_id
-    }
-}
-
-impl Eq for Geoname {}
 
 impl Hash for Geoname {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -97,7 +167,6 @@ pub struct GeonameMatch {
 
 #[derive(Clone, Debug, Eq, PartialEq, uniffi::Enum)]
 pub enum GeonameMatchType {
-    /// For U.S. states, abbreviations are the usual two-letter codes ("CA").
     Abbreviation,
     AirportCode,
     /// This includes any names that aren't abbreviations or airport codes.
@@ -124,70 +193,69 @@ pub struct GeonameCache {
     pub max_name_word_count: usize,
 }
 
+/// See `Geoname` for documentation.
 #[derive(Clone, Debug, Deserialize)]
-pub(crate) struct DownloadedGeonameAttachment {
-    /// The max length of all names in the attachment. Used for name metrics. We
-    /// pre-compute this to avoid doing duplicate work on all user's machines.
-    pub max_alternate_name_length: u32,
-    /// The max word count across all names in the attachment. Used for name
-    /// metrics. We pre-compute this to avoid doing duplicate work on all user's
-    /// machines.
-    pub max_alternate_name_word_count: u32,
-    pub geonames: Vec<DownloadedGeoname>,
-}
-
-/// This corresponds to a single row in the main "geoname" table described in
-/// the GeoNames documentation [1] except where noted. It represents a single
-/// place. We exclude fields we don't need.
-///
-/// [1] https://download.geonames.org/export/dump/readme.txt
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct DownloadedGeoname {
-    /// The `geonameid` straight from the geoname table.
-    pub id: i64,
-    /// NOTE: For ease of implementation, this name should always also be
-    /// included as a lowercased alternate name even if the original GeoNames
-    /// data doesn't include it as an alternate.
-    pub name: String,
-    /// "P" - Populated place like a city or village.
-    /// "A" - Administrative division like a country, state, or region.
-    pub feature_class: String,
-    /// "ADM1" - Primary administrative division like a U.S. state.
-    pub feature_code: String,
-    /// ISO-3166 two-letter uppercase country code, e.g., "US".
-    pub country_code: String,
-    /// For the U.S., the two-letter uppercase state abbreviation.
-    pub admin1_code: String,
-    /// This can be helpful for resolving name conflicts. If two geonames have
-    /// the same name, we might prefer the one with the larger population.
-    pub population: u64,
-    /// Latitude in decimal degrees. Expected to be a string in the RS data.
-    #[serde(deserialize_with = "deserialize_f64_or_default")]
-    pub latitude: f64,
-    /// Longitude in decimal degrees. Expected to be a string in the RS data.
-    #[serde(deserialize_with = "deserialize_f64_or_default")]
-    pub longitude: f64,
-    /// List of names that the place is known by. Despite the word "alternate",
-    /// this often includes the place's proper name. This list is pulled from
-    /// the "alternate names" table described in the GeoNames documentation and
-    /// included here inline.
-    ///
-    /// NOTE: For ease of implementation, this list should always include a
-    /// lowercase version of `name` even if the original GeoNames record doesn't
-    /// include it as an alternate.
-    ///
-    /// Version 1 of this field was a `Vec<String>`.
-    pub alternate_names_2: Vec<DownloadedGeonameAlternate>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct DownloadedGeonameAlternate {
-    /// Lowercase alternate name.
+struct DownloadedGeoname {
+    id: GeonameId,
     name: String,
-    /// The value of the `iso_language` field for the alternate. This will be
-    /// `None` for the alternate we artificially create for the `name` in the
-    /// corresponding geoname record.
-    iso_language: Option<String>,
+    ascii_name: Option<String>,
+    feature_class: String,
+    feature_code: String,
+    country: String,
+    admin1: Option<String>,
+    admin2: Option<String>,
+    admin3: Option<String>,
+    admin4: Option<String>,
+    population: Option<u64>,
+    latitude: Option<String>,
+    longitude: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct DownloadedGeonamesAlternatesAttachment {
+    /// The language of the names in this attachment as a lowercase ISO 639
+    /// code: "en", "de", "fr", etc. Can also be a geonames pseduo-language like
+    /// "abbr" for abbreviations and "iata" for airport codes.
+    language: String,
+    /// Tuples of geoname IDs and their localized names.
+    names_by_geoname_id: Vec<(GeonameId, Vec<String>)>,
+}
+
+/// Compares two strings ignoring case, Unicode combining marks, and some
+/// punctuation. Intended to be used as a Sqlite collating sequence for
+/// comparing geoname names.
+pub fn geonames_collate(a: &str, b: &str) -> std::cmp::Ordering {
+    UniCase::new(collate_remove_chars(a)).cmp(&UniCase::new(collate_remove_chars(b)))
+}
+
+fn collate_remove_chars(s: &str) -> Cow<'_, str> {
+    let borrowable = !s
+        .nfkd()
+        .any(|c| is_combining_mark(c) || matches!(c, '.' | ',' | '-'));
+
+    if borrowable {
+        Cow::from(s)
+    } else {
+        s.nfkd()
+            .filter_map(|c| {
+                if is_combining_mark(c) {
+                    // Remove Unicode combining marks:
+                    // "Que\u{0301}bec" => "Quebec"
+                    None
+                } else {
+                    match c {
+                        // Remove '.' and ',':
+                        // "St. Louis, U.S.A." => "St Louis USA"
+                        '.' | ',' => None,
+                        // Replace '-' with space:
+                        // "Carmel-by-the-Sea" => "Carmel by the Sea"
+                        '-' => Some(' '),
+                        _ => Some(c),
+                    }
+                }
+            })
+            .collect::<_>()
+    }
 }
 
 impl SuggestDao<'_> {
@@ -200,18 +268,12 @@ impl SuggestDao<'_> {
     /// will match. Prefix matching is never performed on abbreviations and
     /// airport codes because we don't currently have a use case for that.
     ///
-    /// `geoname_type` restricts returned geonames to the specified type. `None`
-    /// restricts geonames to cities and regions. There's no way to return
-    /// geonames of other types, but we shouldn't ingest other types to begin
-    /// with.
-    ///
-    /// `filter` restricts returned geonames to certain cities or regions.
-    /// Cities can be restricted to certain regions by including the regions in
-    /// `filter`, and regions can be restricted to those containing certain
-    /// cities by including the cities in `filter`. This is especially useful
-    /// since city and region names are not unique. `filter` is disjunctive: If
-    /// any item in `filter` matches a geoname, the geoname will be filtered in.
-    /// If `filter` is empty, all geonames will be filtered out.
+    /// `filter` restricts returned geonames to those that are related to the
+    /// ones in the filter. Cities can be restricted to administrative divisions
+    /// by including the divisions in `filter` and vice versa. This is
+    /// especially useful since place names are not unique. `filter` is
+    /// conjunctive: All geonames in `filter` must be related to a geoname in
+    /// order for it to be filtered in.
     ///
     /// The returned matches will include all matching types for a geoname, one
     /// match per type per geoname. For example, if the query matches both a
@@ -223,74 +285,97 @@ impl SuggestDao<'_> {
         &self,
         query: &str,
         match_name_prefix: bool,
-        geoname_type: Option<GeonameType>,
         filter: Option<Vec<&Geoname>>,
     ) -> Result<Vec<GeonameMatch>> {
-        let city_pred = "(g.feature_class = 'P')";
-        let region_pred = "(g.feature_class = 'A' AND g.feature_code = 'ADM1')";
-        let type_pred = match geoname_type {
-            None => format!("({} OR {})", city_pred, region_pred),
-            Some(GeonameType::City) => city_pred.to_string(),
-            Some(GeonameType::Region) => region_pred.to_string(),
-        };
+        let candidate_name = query;
         Ok(self
             .conn
             .query_rows_and_then_cached(
-                &format!(
-                    r#"
-                    SELECT
-                        g.id,
-                        g.name,
-                        g.latitude,
-                        g.longitude,
-                        g.feature_class,
-                        g.country_code,
-                        g.admin1_code,
-                        g.population,
-                        a.name != :name AS prefix,
-                        (SELECT CASE
-                             -- abbreviation
-                             WHEN a.iso_language = 'abbr' THEN 1
-                             -- airport code
-                             WHEN a.iso_language IN ('iata', 'icao', 'faac') THEN 2
-                             -- name
-                             ELSE 3
-                             END
-                        ) AS match_type
-                    FROM
-                        geonames g
-                    JOIN
-                        geonames_alternates a ON g.id = a.geoname_id
-                    WHERE
-                        {}
-                        AND CASE :prefix
-                            WHEN FALSE THEN a.name = :name
-                            ELSE (a.name = :name OR (
-                                (a.name BETWEEN :name AND :name || X'FFFF')
-                                AND match_type = 3
-                            ))
-                            END
-                    GROUP BY
-                        g.id, match_type
-                    ORDER BY
-                        g.feature_class = 'P' DESC, g.population DESC, g.id ASC, a.iso_language ASC
-                    "#,
-                    type_pred
-                ),
+                r#"
+                SELECT
+                    g.id,
+                    g.name,
+                    g.feature_class,
+                    g.feature_code,
+                    g.country_code,
+                    g.admin1_code,
+                    g.admin2_code,
+                    g.admin3_code,
+                    g.admin4_code,
+                    g.population,
+                    g.latitude,
+                    g.longitude,
+                    a.name != :name AS prefix,
+                    (SELECT CASE
+                         -- abbreviation
+                         WHEN a.language = 'abbr' THEN 1
+                         -- airport code
+                         WHEN a.language IN ('iata', 'icao', 'faac') THEN 2
+                         -- name
+                         ELSE 3
+                         END
+                    ) AS match_type
+                FROM
+                    geonames g
+                JOIN
+                    geonames_alternates a ON g.id = a.geoname_id
+                WHERE
+                    a.name = :name
+                    OR (
+                        :prefix
+                        AND match_type = 3
+                        AND (a.name BETWEEN :name AND :name || X'FFFF')
+                    )
+                GROUP BY
+                    g.id, match_type
+                ORDER BY
+                    g.feature_class = 'P' DESC, g.population DESC, g.id ASC, a.language ASC
+                "#,
                 named_params! {
-                    ":name": query.to_lowercase(),
+                    ":name": candidate_name,
                     ":prefix": match_name_prefix,
                 },
                 |row| -> Result<Option<GeonameMatch>> {
+                    let feature_class: String = row.get("feature_class")?;
+                    let feature_code: String = row.get("feature_code")?;
+                    let geoname_type = match feature_class.as_str() {
+                        "A" => {
+                            if feature_code.starts_with("P") {
+                                GeonameType::Country
+                            } else {
+                                match feature_code.as_str() {
+                                    "ADM1" => GeonameType::Admin1,
+                                    "ADM2" => GeonameType::Admin2,
+                                    "ADM3" => GeonameType::Admin3,
+                                    "ADM4" => GeonameType::Admin4,
+                                    _ => GeonameType::AdminOther,
+                                }
+                            }
+                        }
+                        "P" => GeonameType::City,
+                        _ => GeonameType::Other,
+                    };
                     let g_match = GeonameMatch {
                         geoname: Geoname {
                             geoname_id: row.get("id")?,
+                            geoname_type,
                             name: row.get("name")?,
-                            latitude: row.get("latitude")?,
-                            longitude: row.get("longitude")?,
+                            feature_class,
+                            feature_code,
                             country_code: row.get("country_code")?,
                             admin1_code: row.get("admin1_code")?,
-                            population: row.get("population")?,
+                            admin2_code: row.get("admin2_code")?,
+                            admin3_code: row.get("admin3_code")?,
+                            admin4_code: row.get("admin4_code")?,
+                            population: row
+                                .get::<_, Option<u64>>("population")?
+                                .unwrap_or_default(),
+                            latitude: row
+                                .get::<_, Option<String>>("latitude")?
+                                .unwrap_or_default(),
+                            longitude: row
+                                .get::<_, Option<String>>("longitude")?
+                                .unwrap_or_default(),
                         },
                         prefix: row.get("prefix")?,
                         match_type: match row.get::<_, i32>("match_type")? {
@@ -300,11 +385,11 @@ impl SuggestDao<'_> {
                         },
                     };
                     if let Some(geonames) = &filter {
-                        geonames
-                            .iter()
-                            .find(|g| g.has_same_region(&g_match.geoname))
-                            .map(|_| Ok(Some(g_match)))
-                            .unwrap_or(Ok(None))
+                        if geonames.iter().all(|g| g.is_related_to(&g_match.geoname)) {
+                            Ok(Some(g_match))
+                        } else {
+                            Ok(None)
+                        }
                     } else {
                         Ok(Some(g_match))
                     }
@@ -319,29 +404,75 @@ impl SuggestDao<'_> {
     fn insert_geonames(
         &mut self,
         record_id: &SuggestRecordId,
-        attachments: &[DownloadedGeonameAttachment],
+        geonames: &[DownloadedGeoname],
     ) -> Result<()> {
         self.scope.err_if_interrupted()?;
+
         let mut geoname_insert = GeonameInsertStatement::new(self.conn)?;
+        for geoname in geonames {
+            geoname_insert.execute(record_id, geoname)?;
+        }
+
+        // Add alternates for each geoname's primary name (`geoname.name`) and
+        // ASCII name. `language` is set to null for these alternates.
+        self.insert_geonames_alternates_from_iter(
+            record_id,
+            None, // language
+            geonames.iter().flat_map(|g| {
+                [
+                    Some((g.id, g.name.as_str())),
+                    g.ascii_name.as_deref().map(|ascii_name| (g.id, ascii_name)),
+                ]
+                .into_iter()
+                .flatten()
+            }),
+        )?;
+
+        Ok(())
+    }
+
+    /// Inserts GeoNames alternates data into the database.
+    fn insert_geonames_alternates(
+        &mut self,
+        record_id: &SuggestRecordId,
+        attachments: &[DownloadedGeonamesAlternatesAttachment],
+    ) -> Result<()> {
+        for attach in attachments {
+            self.insert_geonames_alternates_from_iter(
+                record_id,
+                Some(&attach.language),
+                attach
+                    .names_by_geoname_id
+                    .iter()
+                    .flat_map(|(geoname_id, names)| {
+                        names.iter().map(|name| (*geoname_id, name.as_str()))
+                    }),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn insert_geonames_alternates_from_iter<'a, I>(
+        &mut self,
+        record_id: &SuggestRecordId,
+        language: Option<&str>,
+        iter: I,
+    ) -> Result<()>
+    where
+        I: Iterator<Item = (GeonameId, &'a str)>,
+    {
+        self.scope.err_if_interrupted()?;
         let mut alt_insert = GeonameAlternateInsertStatement::new(self.conn)?;
         let mut metrics_insert = GeonameMetricsInsertStatement::new(self.conn)?;
         let mut max_len = 0;
         let mut max_word_count = 0;
-        for attach in attachments {
-            for geoname in &attach.geonames {
-                geoname_insert.execute(record_id, geoname)?;
-                for alt in &geoname.alternate_names_2 {
-                    alt_insert.execute(alt, geoname.id)?;
-                }
-            }
-            max_len = std::cmp::max(max_len, attach.max_alternate_name_length as usize);
-            max_word_count = std::cmp::max(
-                max_word_count,
-                attach.max_alternate_name_word_count as usize,
-            );
+        for (geoname_id, name) in iter {
+            alt_insert.execute(record_id, geoname_id, language, name)?;
+            max_len = std::cmp::max(max_len, name.len());
+            max_word_count = std::cmp::max(max_word_count, name.split_whitespace().count());
         }
 
-        // Update geoname metrics.
+        // Update alternates metrics.
         metrics_insert.execute(record_id, max_len, max_word_count)?;
 
         // We just made some insertions that might invalidate the data in the
@@ -379,7 +510,7 @@ where
     S: Client,
 {
     /// Inserts a GeoNames record into the database.
-    pub fn process_geoname_record(
+    pub fn process_geonames_record(
         &self,
         dao: &mut SuggestDao,
         record: &Record,
@@ -387,6 +518,18 @@ where
     ) -> Result<()> {
         self.download_attachment(dao, record, context, |dao, record_id, data| {
             dao.insert_geonames(record_id, data)
+        })
+    }
+
+    /// Inserts a GeoNames record into the database.
+    pub fn process_geonames_alternates_record(
+        &self,
+        dao: &mut SuggestDao,
+        record: &Record,
+        context: &mut MetricsContext,
+    ) -> Result<()> {
+        self.download_attachment(dao, record, context, |dao, record_id, data| {
+            dao.insert_geonames_alternates(record_id, data)
         })
     }
 }
@@ -400,33 +543,39 @@ impl<'conn> GeonameInsertStatement<'conn> {
                  id,
                  record_id,
                  name,
-                 latitude,
-                 longitude,
                  feature_class,
                  feature_code,
                  country_code,
                  admin1_code,
-                 population
+                 admin2_code,
+                 admin3_code,
+                 admin4_code,
+                 population,
+                 latitude,
+                 longitude
              )
-             VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ",
         )?))
     }
 
     fn execute(&mut self, record_id: &SuggestRecordId, g: &DownloadedGeoname) -> Result<()> {
         self.0
-            .execute((
+            .execute(rusqlite::params![
                 &g.id,
                 record_id.as_str(),
                 &g.name,
-                &g.latitude,
-                &g.longitude,
                 &g.feature_class,
                 &g.feature_code,
-                &g.country_code,
-                &g.admin1_code,
+                &g.country,
+                &g.admin1,
+                &g.admin2,
+                &g.admin3,
+                &g.admin4,
                 &g.population,
-            ))
+                &g.latitude,
+                &g.longitude,
+            ])
             .with_context("geoname insert")?;
         Ok(())
     }
@@ -437,19 +586,26 @@ struct GeonameAlternateInsertStatement<'conn>(rusqlite::Statement<'conn>);
 impl<'conn> GeonameAlternateInsertStatement<'conn> {
     fn new(conn: &'conn Connection) -> Result<Self> {
         Ok(Self(conn.prepare(
-            "INSERT OR REPLACE INTO geonames_alternates(
-                 name,
+            "INSERT OR IGNORE INTO geonames_alternates(
+                 record_id,
                  geoname_id,
-                 iso_language
+                 language,
+                 name
              )
-             VALUES(?, ?, ?)
+             VALUES(?, ?, ?, ?)
              ",
         )?))
     }
 
-    fn execute(&mut self, a: &DownloadedGeonameAlternate, geoname_id: i64) -> Result<()> {
+    fn execute(
+        &mut self,
+        record_id: &SuggestRecordId,
+        geoname_id: GeonameId,
+        language: Option<&str>,
+        name: &str,
+    ) -> Result<()> {
         self.0
-            .execute((&a.name, geoname_id, &a.iso_language))
+            .execute((record_id.as_str(), geoname_id, language, name))
             .with_context("geoname alternate insert")?;
         Ok(())
     }
@@ -493,6 +649,7 @@ pub(crate) mod tests {
         testing::*,
         SuggestIngestionConstraints,
     };
+    use itertools::Itertools;
     use serde_json::Value as JsonValue;
 
     pub(crate) const LONG_NAME: &str = "aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll mmm nnn ooo ppp qqq rrr sss ttt uuu vvv www x yyy zzz";
@@ -507,309 +664,861 @@ pub(crate) mod tests {
         }
     }
 
+    pub(crate) fn geoname_alternates_mock_record(id: &str, json: JsonValue) -> MockRecord {
+        MockRecord {
+            collection: Collection::Other,
+            record_type: SuggestRecordType::GeonamesAlternates,
+            id: id.to_string(),
+            inline_data: None,
+            attachment: Some(MockAttachment::Json(json)),
+        }
+    }
+
     pub(crate) fn new_test_store() -> TestStore {
         TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(geoname_mock_record("geonames-0", geonames_data())),
+                .with_record(geoname_mock_record("geonames-0", geonames_data()))
+                .with_record(geoname_alternates_mock_record(
+                    "geonames-alternates-en",
+                    geonames_alternates_data_en(),
+                ))
+                .with_record(geoname_alternates_mock_record(
+                    "geonames-alternates-abbr",
+                    geonames_alternates_data_abbr(),
+                ))
+                .with_record(geoname_alternates_mock_record(
+                    "geonames-alternates-iata",
+                    geonames_alternates_data_iata(),
+                )),
         )
     }
 
     fn geonames_data() -> serde_json::Value {
+        json!([
+            // Waterloo, AL
+            {
+                "id": 4096497,
+                "name": "Waterloo",
+                "feature_class": "P",
+                "feature_code": "PPL",
+                "country": "US",
+                "admin1": "AL",
+                "admin2": "077",
+                "population": 200,
+                "latitude": "34.91814",
+                "longitude": "-88.0642",
+            },
+            // AL
+            {
+                "id": 4829764,
+                "name": "Alabama",
+                "feature_class": "A",
+                "feature_code": "ADM1",
+                "country": "US",
+                "admin1": "AL",
+                "population": 4530315,
+                "latitude": "32.75041",
+                "longitude": "-86.75026",
+            },
+            // Waterloo, IA
+            {
+                "id": 4880889,
+                "name": "Waterloo",
+                "feature_class": "P",
+                "feature_code": "PPLA2",
+                "country": "US",
+                "admin1": "IA",
+                "admin2": "013",
+                "admin3": "94597",
+                "population": 68460,
+                "latitude": "42.49276",
+                "longitude": "-92.34296",
+            },
+            // IA
+            {
+                "id": 4862182,
+                "name": "Iowa",
+                "feature_class": "A",
+                "feature_code": "ADM1",
+                "country": "US",
+                "admin1": "IA",
+                "population": 2955010,
+                "latitude": "42.00027",
+                "longitude": "-93.50049",
+            },
+            // New York City
+            {
+                "id": 5128581,
+                "name": "New York City",
+                "feature_class": "P",
+                "feature_code": "PPL",
+                "country": "US",
+                "admin1": "NY",
+                "population": 8804190,
+                "latitude": "40.71427",
+                "longitude": "-74.00597",
+            },
+            // Rochester, NY
+            {
+                "id": 5134086,
+                "name": "Rochester",
+                "feature_class": "P",
+                "feature_code": "PPLA2",
+                "country": "US",
+                "admin1": "NY",
+                "admin2": "055",
+                "admin3": "63000",
+                "population": 209802,
+                "latitude": "43.15478",
+                "longitude": "-77.61556",
+            },
+            // NY state
+            {
+                "id": 5128638,
+                "name": "New York",
+                "feature_class": "A",
+                "feature_code": "ADM1",
+                "country": "US",
+                "admin1": "NY",
+                "population": 19274244,
+                "latitude": "43.00035",
+                "longitude": "-75.4999",
+            },
+            // Waco, TX: Has a surprising IATA airport code that's a
+            // common English word and not a prefix of the city name
+            {
+                "id": 4739526,
+                "name": "Waco",
+                "feature_class": "P",
+                "feature_code": "PPLA2",
+                "country": "US",
+                "admin1": "TX",
+                "admin2": "309",
+                "population": 132356,
+                "latitude": "31.54933",
+                "longitude": "-97.14667",
+            },
+            // TX
+            {
+                "id": 4736286,
+                "name": "Texas",
+                "feature_class": "A",
+                "feature_code": "ADM1",
+                "country": "US",
+                "admin1": "TX",
+                "population": 22875689,
+                "latitude": "31.25044",
+                "longitude": "-99.25061",
+            },
+            // Made-up city with a long name
+            {
+                "id": 999,
+                "name": "Long Name",
+                "feature_class": "P",
+                "feature_code": "PPLA2",
+                "country": "US",
+                "admin1": "NY",
+                "population": 2,
+                "latitude": "38.06084",
+                "longitude": "-97.92977",
+            },
+            // St. Louis (has '.' in name)
+            {
+                "id": 4407066,
+                "name": "St. Louis",
+                "feature_class": "P",
+                "feature_code": "PPLA2",
+                "country": "US",
+                "admin1": "MO",
+                "admin2": "510",
+                "population": 315685,
+                "latitude": "38.62727",
+                "longitude": "-90.19789",
+            },
+            // Carmel-by-the-Sea (has '-' in name)
+            {
+                "id": 5334320,
+                "name": "Carmel-by-the-Sea",
+                "feature_class": "P",
+                "feature_code": "PPL",
+                "country": "US",
+                "admin1": "CA",
+                "admin2": "053",
+                "population": 3897,
+                "latitude": "36.55524",
+                "longitude": "-121.92329",
+            },
+            // United States
+            {
+                "id": 6252001,
+                "name": "United States",
+                "feature_class": "A",
+                "feature_code": "PCLI",
+                "country": "US",
+                "admin1": "00",
+                "population": 327167434,
+                "latitude": "39.76",
+                "longitude": "-98.5",
+            },
+            // Canada
+            {
+                "id": 6251999,
+                "name": "Canada",
+                "feature_class": "A",
+                "feature_code": "PCLI",
+                "country": "CA",
+                "admin1": "00",
+                "population": 37058856,
+                "latitude": "60.10867",
+                "longitude": "-113.64258",
+            },
+            // ON
+            {
+                "id": 6093943,
+                "name": "Ontario",
+                "feature_class": "A",
+                "feature_code": "ADM1",
+                "country": "CA",
+                "admin1": "08",
+                "population": 12861940,
+                "latitude": "49.25014",
+                "longitude": "-84.49983",
+            },
+            // Waterloo, ON
+            {
+                "id": 6176823,
+                "name": "Waterloo",
+                "feature_class": "P",
+                "feature_code": "PPL",
+                "country": "CA",
+                "admin1": "08",
+                "admin2": "3530",
+                "population": 104986,
+                "latitude": "43.4668",
+                "longitude": "-80.51639",
+            },
+            // UK
+            {
+                "id": 2635167,
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "feature_class": "A",
+                "feature_code": "PCLI",
+                "country": "GB",
+                "admin1": "00",
+                "population": 66488991,
+                "latitude": "54.75844",
+                "longitude": "-2.69531",
+            },
+            // England
+            {
+                "id": 6269131,
+                "name": "England",
+                "feature_class": "A",
+                "feature_code": "ADM1",
+                "country": "GB",
+                "admin1": "ENG",
+                "population": 57106398,
+                "latitude": "52.16045",
+                "longitude": "-0.70312",
+            },
+            // Liverpool (metropolitan borough, admin2 for Liverpool city)
+            {
+                "id": 3333167,
+                "name": "Liverpool",
+                "feature_class": "A",
+                "feature_code": "ADM2",
+                "country": "GB",
+                "admin1": "ENG",
+                "admin2": "H8",
+                "population": 484578,
+                "latitude": "53.41667",
+                "longitude": "-2.91667",
+            },
+            // Liverpool (city)
+            {
+                "id": 2644210,
+                "name": "Liverpool",
+                "feature_class": "P",
+                "feature_code": "PPLA2",
+                "country": "GB",
+                "admin1": "ENG",
+                "admin2": "H8",
+                "population": 864122,
+                "latitude": "53.41058",
+                "longitude": "-2.97794",
+            },
+            // Gößnitz, DE (has non-basic-Latin chars and an `ascii_name`)
+            {
+                "id": 2918770,
+                "name": "Gößnitz",
+                "ascii_name": "Goessnitz",
+                "feature_class": "P",
+                "feature_code": "PPL",
+                "country": "DE",
+                "admin1": "15",
+                "admin2": "00",
+                "admin3": "16077",
+                "admin4": "16077012",
+                "population": 4104,
+                "latitude": "50.88902",
+                "longitude": "12.43292",
+            },
+        ])
+    }
+
+    fn geonames_alternates_data_en() -> serde_json::Value {
         json!({
-            "max_alternate_name_length": LONG_NAME.len(),
-            "max_alternate_name_word_count": LONG_NAME.split_whitespace().collect::<Vec<_>>().len(),
-            "geonames": [
-                // Waterloo, AL
-                {
-                    "id": 1,
-                    "name": "Waterloo",
-                    "latitude": "34.91814",
-                    "longitude": "-88.0642",
-                    "feature_class": "P",
-                    "feature_code": "PPL",
-                    "country_code": "US",
-                    "admin1_code": "AL",
-                    "population": 200,
-                    "alternate_names": ["waterloo"],
-                    "alternate_names_2": [
-                        { "name": "waterloo" },
-                    ],
-                },
-                // AL
-                {
-                    "id": 2,
-                    "name": "Alabama",
-                    "latitude": "32.75041",
-                    "longitude": "-86.75026",
-                    "feature_class": "A",
-                    "feature_code": "ADM1",
-                    "country_code": "US",
-                    "admin1_code": "AL",
-                    "population": 4530315,
-                    "alternate_names": ["al", "alabama"],
-                    "alternate_names_2": [
-                        { "name": "alabama" },
-                        { "name": "al", "iso_language": "abbr" },
-                    ],
-                },
-                // Waterloo, IA
-                {
-                    "id": 3,
-                    "name": "Waterloo",
-                    "latitude": "42.49276",
-                    "longitude": "-92.34296",
-                    "feature_class": "P",
-                    "feature_code": "PPLA2",
-                    "country_code": "US",
-                    "admin1_code": "IA",
-                    "population": 68460,
-                    "alternate_names": ["waterloo"],
-                    "alternate_names_2": [
-                        { "name": "waterloo" },
-                    ],
-                },
-                // IA
-                {
-                    "id": 4,
-                    "name": "Iowa",
-                    "latitude": "42.00027",
-                    "longitude": "-93.50049",
-                    "feature_class": "A",
-                    "feature_code": "ADM1",
-                    "country_code": "US",
-                    "admin1_code": "IA",
-                    "population": 2955010,
-                    "alternate_names": ["ia", "iowa"],
-                    "alternate_names_2": [
-                        { "name": "iowa" },
-                        { "name": "ia", "iso_language": "abbr" },
-                    ],
-                },
-                // Waterloo (Lake, not a city or region)
-                {
-                    "id": 5,
-                    "name": "waterloo lake",
-                    "latitude": "31.25044",
-                    "longitude": "-99.25061",
-                    "feature_class": "H",
-                    "feature_code": "LK",
-                    "country_code": "US",
-                    "admin1_code": "TX",
-                    "population": 0,
-                    "alternate_names_2": [
-                        { "name": "waterloo lake" },
-                        { "name": "waterloo", "iso_language": "en" },
-                    ],
-                },
+            "language": "en",
+            "names_by_geoname_id": [
+                // United States
+                [6252001, [
+                    "United States",
+                    "America",
+                    "United States of America",
+                    "USA",
+                ]],
+                // UK
+                [2635167, [
+                    "Great Britain",
+                    "Britain",
+                    "United Kingdom",
+                    "UK",
+                    "U.K.",
+                    "United Kingdom of Great Britain and Northern Ireland",
+                    "U.K",
+                ]],
                 // New York City
-                {
-                    "id": 6,
-                    "name": "New York City",
-                    "latitude": "40.71427",
-                    "longitude": "-74.00597",
-                    "feature_class": "P",
-                    "feature_code": "PPL",
-                    "country_code": "US",
-                    "admin1_code": "NY",
-                    "population": 8804190,
-                    "alternate_names_2": [
-                        { "name": "new york city" },
-                        { "name": "new york", "iso_language": "en" },
-                        { "name": "nyc", "iso_language": "abbr" },
-                        { "name": "ny", "iso_language": "abbr" },
-                    ],
-                },
-                // Rochester, NY
-                {
-                    "id": 7,
-                    "name": "Rochester",
-                    "latitude": "43.15478",
-                    "longitude": "-77.61556",
-                    "feature_class": "P",
-                    "feature_code": "PPLA2",
-                    "country_code": "US",
-                    "admin1_code": "NY",
-                    "population": 209802,
-                    "alternate_names_2": [
-                        { "name": "rochester" },
-                        { "name": "roc", "iso_language": "iata" },
-                    ],
-                },
-                // NY state
-                {
-                    "id": 8,
-                    "name": "New York",
-                    "latitude": "43.00035",
-                    "longitude": "-75.4999",
-                    "feature_class": "A",
-                    "feature_code": "ADM1",
-                    "country_code": "US",
-                    "admin1_code": "NY",
-                    "population": 19274244,
-                    "alternate_names_2": [
-                        { "name": "new york" },
-                        { "name": "ny", "iso_language": "abbr" },
-                    ],
-                },
-                // Waco, TX: Has a surprising IATA airport code that's a
-                // common English word and not a prefix of the city name
-                {
-                    "id": 9,
-                    "name": "Waco",
-                    "latitude": "31.54933",
-                    "longitude": "-97.14667",
-                    "feature_class": "P",
-                    "feature_code": "PPLA2",
-                    "country_code": "US",
-                    "admin1_code": "TX",
-                    "population": 132356,
-                    "alternate_names_2": [
-                        { "name": "waco" },
-                        { "name": "act", "iso_language": "iata" },
-                    ],
-                },
-                // TX
-                {
-                    "id": 10,
-                    "name": "Texas",
-                    "latitude": "31.25044",
-                    "longitude": "-99.25061",
-                    "feature_class": "A",
-                    "feature_code": "ADM1",
-                    "country_code": "US",
-                    "admin1_code": "TX",
-                    "population": 22875689,
-                    "alternate_names_2": [
-                        { "name": "texas" },
-                        { "name": "tx", "iso_language": "abbr" },
-                    ],
-                },
+                [5128581, [
+                    "New York",
+                ]],
                 // Made-up city with a long name
-                {
-                    "id": 999,
-                    "name": "Long Name",
-                    "latitude": "38.06084",
-                    "longitude": "-97.92977",
-                    "feature_class": "P",
-                    "feature_code": "PPLA2",
-                    "country_code": "US",
-                    "admin1_code": "NY",
-                    "population": 2,
-                    "alternate_names_2": [
-                        { "name": "long name" },
-                        { "name": LONG_NAME, "iso_language": "en" },
-                    ],
-                },
+                [999, [LONG_NAME]],
+            ],
+        })
+    }
+
+    fn geonames_alternates_data_abbr() -> serde_json::Value {
+        json!({
+            "language": "abbr",
+            "names_by_geoname_id": [
+                // AL
+                [4829764, ["AL"]],
+                // IA
+                [4862182, ["IA"]],
+                // ON
+                [6093943, [
+                    "ON",
+                    "Ont.",
+                ]],
+                // NY State
+                [5128638, ["NY"]],
+                // TX
+                [4736286, ["TX"]],
+                // New York City
+                [5128581, [
+                    "NYC",
+                    "NY",
+                ]],
+                // United States
+                [6252001, [
+                    "U.S.",
+                    "USA",
+                    "U.S.A.",
+                    "US",
+                ]],
+                // Liverpool (metropolitan borough, admin2 for Liverpool city)
+                [3333167, ["LIV"]],
+                // UK
+                [2635167, [
+                    "Great Britain",
+                    "Britain",
+                    "United Kingdom",
+                    "UK",
+                    "U.K.",
+                    "United Kingdom of Great Britain and Northern Ireland",
+                    "U.K",
+                ]],
+            ],
+        })
+    }
+
+    fn geonames_alternates_data_iata() -> serde_json::Value {
+        json!({
+            "language": "iata",
+            "names_by_geoname_id": [
+                // Waco, TX
+                [4739526, ["ACT"]],
+                // Rochester, NY
+                [5134086, ["ROC"]],
             ],
         })
     }
 
     pub(crate) fn waterloo_al() -> Geoname {
         Geoname {
-            geoname_id: 1,
+            geoname_id: 4096497,
+            geoname_type: GeonameType::City,
             name: "Waterloo".to_string(),
-            latitude: 34.91814,
-            longitude: -88.0642,
+            feature_class: "P".to_string(),
+            feature_code: "PPL".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "AL".to_string(),
+            admin1_code: Some("AL".to_string()),
+            admin2_code: Some("077".to_string()),
+            admin3_code: None,
+            admin4_code: None,
             population: 200,
+            latitude: "34.91814".to_string(),
+            longitude: "-88.0642".to_string(),
         }
     }
 
     pub(crate) fn waterloo_ia() -> Geoname {
         Geoname {
-            geoname_id: 3,
+            geoname_id: 4880889,
+            geoname_type: GeonameType::City,
             name: "Waterloo".to_string(),
-            latitude: 42.49276,
-            longitude: -92.34296,
+            feature_class: "P".to_string(),
+            feature_code: "PPLA2".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "IA".to_string(),
+            admin1_code: Some("IA".to_string()),
+            admin2_code: Some("013".to_string()),
+            admin3_code: Some("94597".to_string()),
+            admin4_code: None,
             population: 68460,
+            latitude: "42.49276".to_string(),
+            longitude: "-92.34296".to_string(),
         }
     }
 
     pub(crate) fn nyc() -> Geoname {
         Geoname {
-            geoname_id: 6,
+            geoname_id: 5128581,
+            geoname_type: GeonameType::City,
             name: "New York City".to_string(),
-            latitude: 40.71427,
-            longitude: -74.00597,
+            feature_class: "P".to_string(),
+            feature_code: "PPL".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "NY".to_string(),
+            admin1_code: Some("NY".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
             population: 8804190,
+            latitude: "40.71427".to_string(),
+            longitude: "-74.00597".to_string(),
         }
     }
 
     pub(crate) fn rochester() -> Geoname {
         Geoname {
-            geoname_id: 7,
+            geoname_id: 5134086,
+            geoname_type: GeonameType::City,
             name: "Rochester".to_string(),
-            latitude: 43.15478,
-            longitude: -77.61556,
+            feature_class: "P".to_string(),
+            feature_code: "PPLA2".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "NY".to_string(),
+            admin1_code: Some("NY".to_string()),
+            admin2_code: Some("055".to_string()),
+            admin3_code: Some("63000".to_string()),
+            admin4_code: None,
             population: 209802,
+            latitude: "43.15478".to_string(),
+            longitude: "-77.61556".to_string(),
         }
     }
 
     pub(crate) fn waco() -> Geoname {
         Geoname {
-            geoname_id: 9,
+            geoname_id: 4739526,
+            geoname_type: GeonameType::City,
             name: "Waco".to_string(),
-            latitude: 31.54933,
-            longitude: -97.14667,
+            feature_class: "P".to_string(),
+            feature_code: "PPLA2".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "TX".to_string(),
+            admin1_code: Some("TX".to_string()),
+            admin2_code: Some("309".to_string()),
+            admin3_code: None,
+            admin4_code: None,
             population: 132356,
+            latitude: "31.54933".to_string(),
+            longitude: "-97.14667".to_string(),
         }
     }
 
     pub(crate) fn long_name_city() -> Geoname {
         Geoname {
             geoname_id: 999,
+            geoname_type: GeonameType::City,
             name: "Long Name".to_string(),
-            latitude: 38.06084,
-            longitude: -97.92977,
+            feature_class: "P".to_string(),
+            feature_code: "PPLA2".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "NY".to_string(),
+            admin1_code: Some("NY".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
             population: 2,
+            latitude: "38.06084".to_string(),
+            longitude: "-97.92977".to_string(),
         }
     }
 
     pub(crate) fn al() -> Geoname {
         Geoname {
-            geoname_id: 2,
+            geoname_id: 4829764,
+            geoname_type: GeonameType::Admin1,
             name: "Alabama".to_string(),
-            latitude: 32.75041,
-            longitude: -86.75026,
+            feature_class: "A".to_string(),
+            feature_code: "ADM1".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "AL".to_string(),
+            admin1_code: Some("AL".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
             population: 4530315,
+            latitude: "32.75041".to_string(),
+            longitude: "-86.75026".to_string(),
         }
     }
 
     pub(crate) fn ia() -> Geoname {
         Geoname {
-            geoname_id: 4,
+            geoname_id: 4862182,
+            geoname_type: GeonameType::Admin1,
             name: "Iowa".to_string(),
-            latitude: 42.00027,
-            longitude: -93.50049,
+            feature_class: "A".to_string(),
+            feature_code: "ADM1".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "IA".to_string(),
+            admin1_code: Some("IA".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
             population: 2955010,
+            latitude: "42.00027".to_string(),
+            longitude: "-93.50049".to_string(),
         }
     }
 
     pub(crate) fn ny_state() -> Geoname {
         Geoname {
-            geoname_id: 8,
+            geoname_id: 5128638,
+            geoname_type: GeonameType::Admin1,
             name: "New York".to_string(),
-            latitude: 43.00035,
-            longitude: -75.4999,
+            feature_class: "A".to_string(),
+            feature_code: "ADM1".to_string(),
             country_code: "US".to_string(),
-            admin1_code: "NY".to_string(),
+            admin1_code: Some("NY".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
             population: 19274244,
+            latitude: "43.00035".to_string(),
+            longitude: "-75.4999".to_string(),
         }
+    }
+
+    pub(crate) fn st_louis() -> Geoname {
+        Geoname {
+            geoname_id: 4407066,
+            geoname_type: GeonameType::City,
+            name: "St. Louis".to_string(),
+            feature_class: "P".to_string(),
+            feature_code: "PPLA2".to_string(),
+            country_code: "US".to_string(),
+            admin1_code: Some("MO".to_string()),
+            admin2_code: Some("510".to_string()),
+            admin3_code: None,
+            admin4_code: None,
+            population: 315685,
+            latitude: "38.62727".to_string(),
+            longitude: "-90.19789".to_string(),
+        }
+    }
+
+    pub(crate) fn carmel() -> Geoname {
+        Geoname {
+            geoname_id: 5334320,
+            geoname_type: GeonameType::City,
+            name: "Carmel-by-the-Sea".to_string(),
+            feature_class: "P".to_string(),
+            feature_code: "PPL".to_string(),
+            country_code: "US".to_string(),
+            admin1_code: Some("CA".to_string()),
+            admin2_code: Some("053".to_string()),
+            admin3_code: None,
+            admin4_code: None,
+            population: 3897,
+            latitude: "36.55524".to_string(),
+            longitude: "-121.92329".to_string(),
+        }
+    }
+
+    pub(crate) fn us() -> Geoname {
+        Geoname {
+            geoname_id: 6252001,
+            geoname_type: GeonameType::Country,
+            name: "United States".to_string(),
+            feature_class: "A".to_string(),
+            feature_code: "PCLI".to_string(),
+            country_code: "US".to_string(),
+            admin1_code: Some("00".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
+            population: 327167434,
+            latitude: "39.76".to_string(),
+            longitude: "-98.5".to_string(),
+        }
+    }
+
+    pub(crate) fn canada() -> Geoname {
+        Geoname {
+            geoname_id: 6251999,
+            geoname_type: GeonameType::Country,
+            name: "Canada".to_string(),
+            feature_class: "A".to_string(),
+            feature_code: "PCLI".to_string(),
+            country_code: "CA".to_string(),
+            admin1_code: Some("00".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
+            population: 37058856,
+            latitude: "60.10867".to_string(),
+            longitude: "-113.64258".to_string(),
+        }
+    }
+
+    pub(crate) fn on() -> Geoname {
+        Geoname {
+            geoname_id: 6093943,
+            geoname_type: GeonameType::Admin1,
+            name: "Ontario".to_string(),
+            feature_class: "A".to_string(),
+            feature_code: "ADM1".to_string(),
+            country_code: "CA".to_string(),
+            admin1_code: Some("08".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
+            population: 12861940,
+            latitude: "49.25014".to_string(),
+            longitude: "-84.49983".to_string(),
+        }
+    }
+
+    pub(crate) fn waterloo_on() -> Geoname {
+        Geoname {
+            geoname_id: 6176823,
+            geoname_type: GeonameType::City,
+            name: "Waterloo".to_string(),
+            feature_class: "P".to_string(),
+            feature_code: "PPL".to_string(),
+            country_code: "CA".to_string(),
+            admin1_code: Some("08".to_string()),
+            admin2_code: Some("3530".to_string()),
+            admin3_code: None,
+            admin4_code: None,
+            population: 104986,
+            latitude: "43.4668".to_string(),
+            longitude: "-80.51639".to_string(),
+        }
+    }
+
+    pub(crate) fn uk() -> Geoname {
+        Geoname {
+            geoname_id: 2635167,
+            geoname_type: GeonameType::Country,
+            name: "United Kingdom of Great Britain and Northern Ireland".to_string(),
+            feature_class: "A".to_string(),
+            feature_code: "PCLI".to_string(),
+            country_code: "GB".to_string(),
+            admin1_code: Some("00".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
+            population: 66488991,
+            latitude: "54.75844".to_string(),
+            longitude: "-2.69531".to_string(),
+        }
+    }
+
+    pub(crate) fn england() -> Geoname {
+        Geoname {
+            geoname_id: 6269131,
+            geoname_type: GeonameType::Admin1,
+            name: "England".to_string(),
+            feature_class: "A".to_string(),
+            feature_code: "ADM1".to_string(),
+            country_code: "GB".to_string(),
+            admin1_code: Some("ENG".to_string()),
+            admin2_code: None,
+            admin3_code: None,
+            admin4_code: None,
+            population: 57106398,
+            latitude: "52.16045".to_string(),
+            longitude: "-0.70312".to_string(),
+        }
+    }
+
+    pub(crate) fn liverpool_metro() -> Geoname {
+        Geoname {
+            geoname_id: 3333167,
+            geoname_type: GeonameType::Admin2,
+            name: "Liverpool".to_string(),
+            feature_class: "A".to_string(),
+            feature_code: "ADM2".to_string(),
+            country_code: "GB".to_string(),
+            admin1_code: Some("ENG".to_string()),
+            admin2_code: Some("H8".to_string()),
+            admin3_code: None,
+            admin4_code: None,
+            population: 484578,
+            latitude: "53.41667".to_string(),
+            longitude: "-2.91667".to_string(),
+        }
+    }
+
+    pub(crate) fn liverpool_city() -> Geoname {
+        Geoname {
+            geoname_id: 2644210,
+            geoname_type: GeonameType::City,
+            name: "Liverpool".to_string(),
+            feature_class: "P".to_string(),
+            feature_code: "PPLA2".to_string(),
+            country_code: "GB".to_string(),
+            admin1_code: Some("ENG".to_string()),
+            admin2_code: Some("H8".to_string()),
+            admin3_code: None,
+            admin4_code: None,
+            population: 864122,
+            latitude: "53.41058".to_string(),
+            longitude: "-2.97794".to_string(),
+        }
+    }
+
+    pub(crate) fn goessnitz() -> Geoname {
+        Geoname {
+            geoname_id: 2918770,
+            geoname_type: GeonameType::City,
+            name: "Gößnitz".to_string(),
+            feature_class: "P".to_string(),
+            feature_code: "PPL".to_string(),
+            country_code: "DE".to_string(),
+            admin1_code: Some("15".to_string()),
+            admin2_code: Some("00".to_string()),
+            admin3_code: Some("16077".to_string()),
+            admin4_code: Some("16077012".to_string()),
+            population: 4104,
+            latitude: "50.88902".to_string(),
+            longitude: "12.43292".to_string(),
+        }
+    }
+
+    #[test]
+    fn is_related_to() -> anyhow::Result<()> {
+        // The geonames in each vec should be pairwise related.
+        let tests = [
+            vec![waterloo_ia(), ia(), us()],
+            vec![waterloo_al(), al(), us()],
+            vec![waterloo_on(), on(), canada()],
+            vec![liverpool_city(), liverpool_metro(), england(), uk()],
+        ];
+        for geonames in tests {
+            for g in &geonames {
+                // A geoname should always be related to itself.
+                assert!(
+                    g.is_related_to(g),
+                    "g.is_related_to(g) should always be true: {:?}",
+                    g
+                );
+            }
+            for a_and_b in geonames.iter().permutations(2) {
+                assert!(
+                    a_and_b[0].is_related_to(a_and_b[1]),
+                    "is_related_to: {:?}",
+                    a_and_b
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn is_not_related_to() -> anyhow::Result<()> {
+        // The geonames in each vec should not be pairwise related.
+        let tests = [
+            vec![waterloo_ia(), al()],
+            vec![waterloo_ia(), on()],
+            vec![waterloo_ia(), canada(), uk()],
+            vec![waterloo_al(), ia()],
+            vec![waterloo_al(), on()],
+            vec![waterloo_al(), canada(), uk()],
+            vec![waterloo_on(), al()],
+            vec![waterloo_on(), ia()],
+            vec![waterloo_on(), us(), uk()],
+            vec![
+                waterloo_ia(),
+                waterloo_al(),
+                waterloo_on(),
+                liverpool_city(),
+            ],
+            vec![liverpool_city(), us(), canada()],
+            vec![liverpool_metro(), us(), canada()],
+            vec![england(), us(), canada()],
+            vec![al(), ia(), on(), england()],
+            vec![us(), canada(), uk()],
+        ];
+        for geonames in tests {
+            for a_and_b in geonames.iter().permutations(2) {
+                assert!(
+                    !a_and_b[0].is_related_to(a_and_b[1]),
+                    "!is_related_to: {:?}",
+                    a_and_b
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn geonames_collate() -> anyhow::Result<()> {
+        let tests = [
+            ["AbC xYz", "ABC XYZ", "abc xyz"].as_slice(),
+            &["Àęí", "Aei", "àęí", "aei"],
+            &[
+                // "Québec" with single 'é' char
+                "Qu\u{00e9}bec",
+                // "Québec" with ASCII 'e' followed by combining acute accent
+                "Que\u{0301}bec",
+                "Quebec",
+                "quebec",
+            ],
+            &[
+                "Gößnitz",
+                "Gössnitz",
+                "Goßnitz",
+                "Gossnitz",
+                "gößnitz",
+                "gössnitz",
+                "goßnitz",
+                "gossnitz",
+            ],
+            &["St. Louis", "St... Louis", "St Louis"],
+            &["U.S.A.", "US.A.", "U.SA.", "U.S.A", "USA.", "U.SA", "USA"],
+            &["Carmel-by-the-Sea", "Carmel by the Sea"],
+            &[".,-'()[]?<>", ".,-'()[]?<>"],
+        ];
+        for strs in tests {
+            for a_and_b in strs.iter().permutations(2) {
+                assert_eq!(
+                    super::geonames_collate(a_and_b[0], a_and_b[1]),
+                    std::cmp::Ordering::Equal,
+                    "Comparing: {:?}",
+                    a_and_b
+                );
+            }
+        }
+        Ok(())
     }
 
     #[test]
@@ -828,7 +1537,6 @@ pub(crate) mod tests {
         struct Test {
             query: &'static str,
             match_name_prefix: bool,
-            geoname_type: Option<GeonameType>,
             filter: Option<Vec<Geoname>>,
             expected: Vec<GeonameMatch>,
         }
@@ -837,7 +1545,6 @@ pub(crate) mod tests {
             Test {
                 query: "ia",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: ia(),
@@ -848,7 +1555,6 @@ pub(crate) mod tests {
             Test {
                 query: "ia",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: ia(),
@@ -859,18 +1565,12 @@ pub(crate) mod tests {
             Test {
                 query: "ia",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![waterloo_ia(), waterloo_al()]),
-                expected: vec![GeonameMatch {
-                    geoname: ia(),
-                    match_type: GeonameMatchType::Abbreviation,
-                    prefix: false,
-                }],
+                expected: vec![],
             },
             Test {
                 query: "ia",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![waterloo_ia()]),
                 expected: vec![GeonameMatch {
                     geoname: ia(),
@@ -881,22 +1581,7 @@ pub(crate) mod tests {
             Test {
                 query: "ia",
                 match_name_prefix: false,
-                geoname_type: None,
-                filter: Some(vec![waterloo_al()]),
-                expected: vec![],
-            },
-            Test {
-                query: "ia",
-                match_name_prefix: false,
-                geoname_type: Some(GeonameType::City),
-                filter: None,
-                expected: vec![],
-            },
-            Test {
-                query: "ia",
-                match_name_prefix: false,
-                geoname_type: Some(GeonameType::Region),
-                filter: None,
+                filter: Some(vec![us()]),
                 expected: vec![GeonameMatch {
                     geoname: ia(),
                     match_type: GeonameMatchType::Abbreviation,
@@ -904,9 +1589,38 @@ pub(crate) mod tests {
                 }],
             },
             Test {
+                query: "ia",
+                match_name_prefix: false,
+                filter: Some(vec![waterloo_al()]),
+                expected: vec![],
+            },
+            Test {
+                query: "ia",
+                match_name_prefix: false,
+                filter: Some(vec![canada()]),
+                expected: vec![],
+            },
+            Test {
+                query: "ia",
+                match_name_prefix: false,
+                filter: Some(vec![uk()]),
+                expected: vec![],
+            },
+            Test {
+                query: "iaxyz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "iaxyz",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
                 query: "iowa",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: ia(),
@@ -917,7 +1631,6 @@ pub(crate) mod tests {
             Test {
                 query: "al",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: al(),
@@ -929,7 +1642,6 @@ pub(crate) mod tests {
             Test {
                 query: "al",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
                     GeonameMatch {
@@ -947,7 +1659,6 @@ pub(crate) mod tests {
             Test {
                 query: "waterloo",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![ia()]),
                 expected: vec![GeonameMatch {
                     geoname: waterloo_ia(),
@@ -958,7 +1669,6 @@ pub(crate) mod tests {
             Test {
                 query: "waterloo",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![al()]),
                 expected: vec![GeonameMatch {
                     geoname: waterloo_al(),
@@ -969,18 +1679,20 @@ pub(crate) mod tests {
             Test {
                 query: "waterloo",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![ny_state()]),
                 expected: vec![],
             },
             Test {
                 query: "waterloo",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
-                // Waterloo, IA should be first since it has a larger
-                // population.
+                // Matches should be returned by population descending.
                 expected: vec![
+                    GeonameMatch {
+                        geoname: waterloo_on(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
                     GeonameMatch {
                         geoname: waterloo_ia(),
                         match_type: GeonameMatchType::Name,
@@ -996,9 +1708,13 @@ pub(crate) mod tests {
             Test {
                 query: "water",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
+                    GeonameMatch {
+                        geoname: waterloo_on(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: true,
+                    },
                     GeonameMatch {
                         geoname: waterloo_ia(),
                         match_type: GeonameMatchType::Name,
@@ -1014,14 +1730,147 @@ pub(crate) mod tests {
             Test {
                 query: "water",
                 match_name_prefix: false,
-                geoname_type: None,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![us()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: waterloo_ia(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: waterloo_al(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![al(), us()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_al(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![us(), al()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_al(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![ia(), al()]),
+                expected: vec![],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![canada()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_on(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![on()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_on(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![on(), canada()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_on(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![canada(), on()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_on(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![al(), canada()]),
+                expected: vec![],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![on(), us()]),
+                expected: vec![],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![waterloo_al()]),
+                expected: vec![GeonameMatch {
+                    geoname: waterloo_al(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "waterloo",
+                match_name_prefix: false,
+                filter: Some(vec![uk()]),
+                expected: vec![],
+            },
+            Test {
+                query: "waterlooxyz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "waterlooxyz",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "waterloo xyz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "waterloo xyz",
+                match_name_prefix: true,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "ny",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 // NYC should be first since cities are ordered before regions.
                 expected: vec![
@@ -1039,26 +1888,7 @@ pub(crate) mod tests {
             },
             Test {
                 query: "ny",
-                match_name_prefix: true,
-                geoname_type: None,
-                filter: None,
-                expected: vec![
-                    GeonameMatch {
-                        geoname: nyc(),
-                        match_type: GeonameMatchType::Abbreviation,
-                        prefix: false,
-                    },
-                    GeonameMatch {
-                        geoname: ny_state(),
-                        match_type: GeonameMatchType::Abbreviation,
-                        prefix: false,
-                    },
-                ],
-            },
-            Test {
-                query: "ny",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![nyc()]),
                 expected: vec![
                     GeonameMatch {
@@ -1076,7 +1906,6 @@ pub(crate) mod tests {
             Test {
                 query: "ny",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: Some(vec![ny_state()]),
                 expected: vec![
                     GeonameMatch {
@@ -1092,9 +1921,8 @@ pub(crate) mod tests {
                 ],
             },
             Test {
-                query: "ny",
+                query: "nyc",
                 match_name_prefix: false,
-                geoname_type: Some(GeonameType::City),
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: nyc(),
@@ -1103,20 +1931,8 @@ pub(crate) mod tests {
                 }],
             },
             Test {
-                query: "ny",
-                match_name_prefix: false,
-                geoname_type: Some(GeonameType::Region),
-                filter: None,
-                expected: vec![GeonameMatch {
-                    geoname: ny_state(),
-                    match_type: GeonameMatchType::Abbreviation,
-                    prefix: false,
-                }],
-            },
-            Test {
                 query: "NeW YoRk",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
                     GeonameMatch {
@@ -1134,7 +1950,6 @@ pub(crate) mod tests {
             Test {
                 query: "NY",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
                     GeonameMatch {
@@ -1152,14 +1967,12 @@ pub(crate) mod tests {
             Test {
                 query: "new",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "new",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
                     GeonameMatch {
@@ -1177,49 +1990,42 @@ pub(crate) mod tests {
             Test {
                 query: "new york foo",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "new york foo",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "new foo",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "foo new york",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "foo new york",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "foo new",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![],
             },
             Test {
                 query: "roc",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: rochester(),
@@ -1231,7 +2037,6 @@ pub(crate) mod tests {
             Test {
                 query: "roc",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
                     GeonameMatch {
@@ -1249,7 +2054,6 @@ pub(crate) mod tests {
             Test {
                 query: "long name",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: long_name_city(),
@@ -1260,12 +2064,519 @@ pub(crate) mod tests {
             Test {
                 query: LONG_NAME,
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: long_name_city(),
                     match_type: GeonameMatchType::Name,
                     prefix: false,
+                }],
+            },
+            Test {
+                query: "ac",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "ac",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "act",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: waco(),
+                    match_type: GeonameMatchType::AirportCode,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "act",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: waco(),
+                    match_type: GeonameMatchType::AirportCode,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "us",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: us(),
+                    match_type: GeonameMatchType::Abbreviation,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "us",
+                match_name_prefix: false,
+                filter: Some(vec![waterloo_ia()]),
+                expected: vec![GeonameMatch {
+                    geoname: us(),
+                    match_type: GeonameMatchType::Abbreviation,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "us",
+                match_name_prefix: false,
+                filter: Some(vec![ia()]),
+                expected: vec![GeonameMatch {
+                    geoname: us(),
+                    match_type: GeonameMatchType::Abbreviation,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "canada",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: canada(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "canada",
+                match_name_prefix: false,
+                filter: Some(vec![on()]),
+                expected: vec![GeonameMatch {
+                    geoname: canada(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "canada",
+                match_name_prefix: false,
+                filter: Some(vec![waterloo_on(), on()]),
+                expected: vec![GeonameMatch {
+                    geoname: canada(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "uk",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![
+                    // "UK" is listed as both an 'en' alternate and 'abbr'
+                    // alternate. The abbreviation should be first since 'abbr'
+                    // is ordered before 'en'.
+                    GeonameMatch {
+                        geoname: uk(),
+                        match_type: GeonameMatchType::Abbreviation,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: uk(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "st. louis",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: st_louis(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "st louis",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: st_louis(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "st.",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: st_louis(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "st. l",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: st_louis(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "st l",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: st_louis(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "st.",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "st l",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "carmel-by-the-sea",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: carmel(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "carmel by the sea",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: carmel(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "carmel-",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: carmel(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "carmel-b",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: carmel(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "carmel b",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: carmel(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "carmel-",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "carmel-b",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "carmel b",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![liverpool_metro()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![england()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![uk()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![liverpool_metro(), england()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![liverpool_metro(), uk()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![england(), uk()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "liverpool",
+                match_name_prefix: false,
+                filter: Some(vec![liverpool_metro(), england(), uk()]),
+                expected: vec![
+                    GeonameMatch {
+                        geoname: liverpool_city(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                    GeonameMatch {
+                        geoname: liverpool_metro(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
+                ],
+            },
+            Test {
+                query: "gößnitz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "gössnitz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "goßnitz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "gossnitz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "goessnitz",
+                match_name_prefix: false,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: false,
+                }],
+            },
+            Test {
+                query: "gö",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "göß",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "gößn",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "gös",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "goß",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "goßn",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "gos",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
+                }],
+            },
+            Test {
+                query: "goss",
+                match_name_prefix: true,
+                filter: None,
+                expected: vec![GeonameMatch {
+                    geoname: goessnitz(),
+                    match_type: GeonameMatchType::Name,
+                    prefix: true,
                 }],
             },
         ];
@@ -1280,14 +2591,10 @@ pub(crate) mod tests {
                     Some(gs_refs)
                 };
                 assert_eq!(
-                    dao.fetch_geonames(
-                        t.query,
-                        t.match_name_prefix,
-                        t.geoname_type.clone(),
-                        filters
-                    )?,
+                    dao.fetch_geonames(t.query, t.match_name_prefix, filters)?,
                     t.expected,
-                    "Test: {:?}",
+                    "query={:?} -- Full test: {:?}",
+                    t.query,
                     t
                 );
             }
@@ -1301,24 +2608,43 @@ pub(crate) mod tests {
     fn geonames_metrics() -> anyhow::Result<()> {
         before_each();
 
-        // Add a couple of records with different metrics. We're just testing
-        // metrics so the other values don't matter.
+        // Add a some records: a core geonames record and some alternates
+        // records. The names in each should contribute to metrics.
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
                 .with_record(geoname_mock_record(
                     "geonames-0",
+                    json!([
+                        {
+                            "id": 4096497,
+                            "name": "Waterloo",
+                            "feature_class": "P",
+                            "feature_code": "PPL",
+                            "country": "US",
+                            "admin1": "AL",
+                            "admin2": "077",
+                            "population": 200,
+                            "latitude": "34.91814",
+                            "longitude": "-88.0642",
+                        },
+                    ]),
+                ))
+                .with_record(geoname_alternates_mock_record(
+                    "geonames-alternates-0",
                     json!({
-                        "max_alternate_name_length": 10,
-                        "max_alternate_name_word_count": 5,
-                        "geonames": []
+                        "language": "en",
+                        "names_by_geoname_id": [
+                            [4096497, ["a b c d e"]],
+                        ],
                     }),
                 ))
-                .with_record(geoname_mock_record(
-                    "geonames-1",
+                .with_record(geoname_alternates_mock_record(
+                    "geonames-alternates-1",
                     json!({
-                        "max_alternate_name_length": 20,
-                        "max_alternate_name_word_count": 2,
-                        "geonames": []
+                        "language": "en",
+                        "names_by_geoname_id": [
+                            [1, ["abcdefghik lmnopqrstu"]],
+                        ],
                     }),
                 )),
         );
@@ -1331,43 +2657,61 @@ pub(crate) mod tests {
 
         store.read(|dao| {
             let cache = dao.geoname_cache();
-            assert_eq!(cache.max_name_length, 20);
-            assert_eq!(cache.max_name_word_count, 5);
+            assert_eq!(cache.max_name_length, 21); // "abcdefghik lmnopqrstu"
+            assert_eq!(cache.max_name_word_count, 5); // "a b c d e"
             Ok(())
         })?;
 
-        // Delete the first record. The metrics should change.
+        // Delete the first alternates record. The metrics should change.
         store
             .client_mut()
-            .delete_record(geoname_mock_record("geonames-0", json!({})));
+            .delete_record(geoname_mock_record("geonames-alternates-0", json!({})));
         store.ingest(SuggestIngestionConstraints {
             providers: Some(vec![SuggestionProvider::Weather]),
             ..SuggestIngestionConstraints::all_providers()
         });
         store.read(|dao| {
             let cache = dao.geoname_cache();
-            assert_eq!(cache.max_name_length, 20);
-            assert_eq!(cache.max_name_word_count, 2);
+            assert_eq!(cache.max_name_length, 21); // "abcdefghik lmnopqrstu"
+            assert_eq!(cache.max_name_word_count, 2); // "abcdefghik lmnopqrstu"
+            Ok(())
+        })?;
+
+        // Delete the second alternates record. The metrics should change again.
+        store
+            .client_mut()
+            .delete_record(geoname_mock_record("geonames-alternates-1", json!({})));
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Weather]),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+        store.read(|dao| {
+            let cache = dao.geoname_cache();
+            assert_eq!(cache.max_name_length, 8); // "waterloo"
+            assert_eq!(cache.max_name_word_count, 1); // "waterloo"
             Ok(())
         })?;
 
         // Add a new record. The metrics should change again.
-        store.client_mut().add_record(geoname_mock_record(
-            "geonames-3",
-            json!({
-                "max_alternate_name_length": 15,
-                "max_alternate_name_word_count": 3,
-                "geonames": []
-            }),
-        ));
+        store
+            .client_mut()
+            .add_record(geoname_alternates_mock_record(
+                "geonames-alternates-2",
+                json!({
+                    "language": "en",
+                    "names_by_geoname_id": [
+                        [2, ["abcd efgh iklm"]],
+                    ],
+                }),
+            ));
         store.ingest(SuggestIngestionConstraints {
             providers: Some(vec![SuggestionProvider::Weather]),
             ..SuggestIngestionConstraints::all_providers()
         });
         store.read(|dao| {
             let cache = dao.geoname_cache();
-            assert_eq!(cache.max_name_length, 20);
-            assert_eq!(cache.max_name_word_count, 3);
+            assert_eq!(cache.max_name_length, 14); // "abcd efgh iklm"
+            assert_eq!(cache.max_name_word_count, 3); // "abcd efgh iklm"
             Ok(())
         })?;
 
@@ -1388,8 +2732,13 @@ pub(crate) mod tests {
         // Make sure we have a match.
         store.read(|dao| {
             assert_eq!(
-                dao.fetch_geonames("waterloo", false, None, None)?,
+                dao.fetch_geonames("waterloo", false, None)?,
                 vec![
+                    GeonameMatch {
+                        geoname: waterloo_on(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
                     GeonameMatch {
                         geoname: waterloo_ia(),
                         match_type: GeonameMatchType::Name,
@@ -1417,21 +2766,21 @@ pub(crate) mod tests {
         // The same query shouldn't match anymore and the tables should be
         // empty.
         store.read(|dao| {
-            assert_eq!(dao.fetch_geonames("waterloo", false, None, None)?, vec![],);
+            assert_eq!(dao.fetch_geonames("waterloo", false, None)?, vec![],);
 
             let g_ids = dao.conn.query_rows_and_then(
                 "SELECT id FROM geonames",
                 [],
-                |row| -> Result<i64> { Ok(row.get("id")?) },
+                |row| -> Result<GeonameId> { Ok(row.get("id")?) },
             )?;
-            assert_eq!(g_ids, Vec::<i64>::new());
+            assert_eq!(g_ids, Vec::<GeonameId>::new());
 
             let alt_g_ids = dao.conn.query_rows_and_then(
                 "SELECT geoname_id FROM geonames_alternates",
                 [],
-                |row| -> Result<i64> { Ok(row.get("geoname_id")?) },
+                |row| -> Result<GeonameId> { Ok(row.get("geoname_id")?) },
             )?;
-            assert_eq!(alt_g_ids, Vec::<i64>::new());
+            assert_eq!(alt_g_ids, Vec::<GeonameId>::new());
 
             Ok(())
         })?;
@@ -1485,8 +2834,13 @@ pub(crate) mod tests {
         // Make sure we have a match.
         store.read(|dao| {
             assert_eq!(
-                dao.fetch_geonames("waterloo", false, None, None)?,
+                dao.fetch_geonames("waterloo", false, None)?,
                 vec![
+                    GeonameMatch {
+                        geoname: waterloo_on(),
+                        match_type: GeonameMatchType::Name,
+                        prefix: false,
+                    },
                     GeonameMatch {
                         geoname: waterloo_ia(),
                         match_type: GeonameMatchType::Name,
@@ -1540,7 +2894,6 @@ pub(crate) mod tests {
         struct Test {
             query: &'static str,
             match_name_prefix: bool,
-            geoname_type: Option<GeonameType>,
             filter: Option<Vec<Geoname>>,
             expected: Vec<GeonameMatch>,
         }
@@ -1552,7 +2905,6 @@ pub(crate) mod tests {
             Test {
                 query: "ia",
                 match_name_prefix: false,
-                geoname_type: None,
                 filter: None,
                 expected: vec![GeonameMatch {
                     geoname: ia(),
@@ -1564,34 +2916,9 @@ pub(crate) mod tests {
             Test {
                 query: "ia",
                 match_name_prefix: false,
-                geoname_type: None,
-                filter: Some(vec![waterloo_ia(), waterloo_al()]),
+                filter: Some(vec![waterloo_ia()]),
                 expected: vec![GeonameMatch {
                     geoname: ia(),
-                    match_type: GeonameMatchType::Abbreviation,
-                    prefix: false,
-                }],
-            },
-            // geoname type: city
-            Test {
-                query: "ia",
-                match_name_prefix: false,
-                geoname_type: Some(GeonameType::Region),
-                filter: None,
-                expected: vec![GeonameMatch {
-                    geoname: ia(),
-                    match_type: GeonameMatchType::Abbreviation,
-                    prefix: false,
-                }],
-            },
-            // geoname type: region
-            Test {
-                query: "ny",
-                match_name_prefix: false,
-                geoname_type: Some(GeonameType::City),
-                filter: None,
-                expected: vec![GeonameMatch {
-                    geoname: nyc(),
                     match_type: GeonameMatchType::Abbreviation,
                     prefix: false,
                 }],
@@ -1600,7 +2927,6 @@ pub(crate) mod tests {
             Test {
                 query: "ny",
                 match_name_prefix: true,
-                geoname_type: None,
                 filter: None,
                 expected: vec![
                     GeonameMatch {
@@ -1619,12 +2945,7 @@ pub(crate) mod tests {
 
         for t in tests {
             assert_eq!(
-                store.fetch_geonames(
-                    t.query,
-                    t.match_name_prefix,
-                    t.geoname_type.clone(),
-                    t.filter.clone()
-                ),
+                store.fetch_geonames(t.query, t.match_name_prefix, t.filter.clone()),
                 t.expected,
                 "Test: {:?}",
                 t

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -26,7 +26,7 @@ mod yelp;
 
 pub use config::{SuggestGlobalConfig, SuggestProviderConfig};
 pub use error::{Error, SuggestApiError};
-pub use geoname::{Geoname, GeonameMatch, GeonameType};
+pub use geoname::{Geoname, GeonameMatch};
 pub use metrics::{LabeledTimingSample, SuggestIngestionMetrics};
 pub use provider::{AmpMatchingStrategy, SuggestionProvider, SuggestionProviderConstraints};
 pub use query::{QueryWithMetricsResult, SuggestionQuery};

--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -140,11 +140,18 @@ impl SuggestionProvider {
             )])),
             Self::Yelp => Some(HashMap::from([(
                 Collection::Other,
-                HashSet::from([SuggestRecordType::Icon, SuggestRecordType::Geonames]),
+                HashSet::from([
+                    SuggestRecordType::Icon,
+                    SuggestRecordType::Geonames,
+                    SuggestRecordType::GeonamesAlternates,
+                ]),
             )])),
             Self::Weather => Some(HashMap::from([(
                 Collection::Other,
-                HashSet::from([SuggestRecordType::Geonames]),
+                HashSet::from([
+                    SuggestRecordType::Geonames,
+                    SuggestRecordType::GeonamesAlternates,
+                ]),
             )])),
             Self::Fakespot => Some(HashMap::from([(
                 Collection::Fakespot,

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -37,7 +37,7 @@ use remote_settings::{
     Attachment, RemoteSettingsClient, RemoteSettingsError, RemoteSettingsRecord,
     RemoteSettingsService,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::{error::Error, query::full_keywords_to_fts_content, Result};
@@ -200,8 +200,10 @@ pub(crate) enum SuggestRecord {
     Fakespot,
     #[serde(rename = "dynamic-suggestions")]
     Dynamic(DownloadedDynamicRecord),
-    #[serde(rename = "geonames")]
+    #[serde(rename = "geonames-2")] // version 2
     Geonames,
+    #[serde(rename = "geonames-alternates")]
+    GeonamesAlternates,
 }
 
 impl SuggestRecord {
@@ -230,6 +232,7 @@ pub enum SuggestRecordType {
     Fakespot,
     Dynamic,
     Geonames,
+    GeonamesAlternates,
 }
 
 impl From<&SuggestRecord> for SuggestRecordType {
@@ -247,6 +250,7 @@ impl From<&SuggestRecord> for SuggestRecordType {
             SuggestRecord::Fakespot => Self::Fakespot,
             SuggestRecord::Dynamic(_) => Self::Dynamic,
             SuggestRecord::Geonames => Self::Geonames,
+            SuggestRecord::GeonamesAlternates => Self::GeonamesAlternates,
         }
     }
 }
@@ -276,6 +280,7 @@ impl SuggestRecordType {
             Self::Fakespot,
             Self::Dynamic,
             Self::Geonames,
+            Self::GeonamesAlternates,
         ]
     }
 
@@ -292,7 +297,8 @@ impl SuggestRecordType {
             Self::GlobalConfig => "configuration",
             Self::Fakespot => "fakespot-suggestions",
             Self::Dynamic => "dynamic-suggestions",
-            Self::Geonames => "geonames",
+            Self::Geonames => "geonames-2",
+            Self::GeonamesAlternates => "geonames-alternates",
         }
     }
 }
@@ -606,15 +612,6 @@ pub(crate) struct DownloadedGlobalConfigInner {
     /// The maximum number of times the user can click "Show less frequently"
     /// for a suggestion in the UI.
     pub show_less_frequently_cap: i32,
-}
-
-pub(crate) fn deserialize_f64_or_default<'de, D>(
-    deserializer: D,
-) -> std::result::Result<f64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    String::deserialize(deserializer).map(|s| s.parse().ok().unwrap_or_default())
 }
 
 #[cfg(test)]

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -5,7 +5,7 @@
 
 use chrono::Local;
 
-use crate::db::DEFAULT_SUGGESTION_SCORE;
+use crate::{db::DEFAULT_SUGGESTION_SCORE, geoname::Geoname};
 
 /// The template parameter for a timestamp in a "raw" sponsored suggestion URL.
 const TIMESTAMP_TEMPLATE: &str = "%YYYYMMDDHH%";
@@ -86,11 +86,7 @@ pub enum Suggestion {
         score: f64,
     },
     Weather {
-        city: Option<String>,
-        region: Option<String>,
-        country: Option<String>,
-        latitude: Option<f64>,
-        longitude: Option<f64>,
+        city: Option<Geoname>,
         score: f64,
     },
     Fakespot {


### PR DESCRIPTION
This is a substantial reworking of geonames and weather suggestions in suggest, including some breaking API changes. I didn't bother deprecating anything because AFAIK desktop is the only consumer that uses these, and we can just fix it when we vendor.

Summary of major changes:

In RS, don't store geonames' alternate names inline with the core geonames data. Instead, use separate record types. (As a reminder, "alternates" just means variants of a geoname's main name, like "NYC" and "NY" are alternates for New York City.) So now there are two record types: core geonames data and alternates. The core records contain the main geonames data: IDs, canonical name, country, admin divisions, etc., and they can be ingested by all clients regardless of their locale or country. The alternates records are scoped by language and are intended to be ingested only by clients with matching locales.

Improve geonames fetching and weather-suggestion matching so all admin levels and countries are supported. e.g., "waterloo on", "waterloo canada", "waterloo on canada", etc.

Relax the weather parsing a little to allow multiple weather keywords ("rain weather").

Keep track of all available admin codes per geoname. There are four of them. This is necessary because a lot of countries outside North America have multiple admin levels, and determining whether a given geoname is related to another one requires comparing their admin codes.

Instead of manually computing name variants and inserting them separately into the DB, use a custom Sqlite collating sequence. ("Variants" here means removing punctuation, lowercasing, removing diacritics, etc.)

Store each geoname's `ascii_name` as an alternate. That's useful for chars like "ö", which is represented as "oe" in the ASCII name (at least the geonames data I've seen).

Minor changes:

Store latitude and longitude and strings instead of floats. I made this change to derive `Eq` for `Geoname`, but it makes sense anyway and is how I should have done it originally.

Add `Geoname::geoname_type` so consumers can easily understand whether it's a city, admin region, or country.

Remove the `geoname_type` param from `fetch_geonames`. Consumers can filter out matching geonames that they don't want instead.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
