### PR TITLE
Remote settings: update app-context correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 #### BREAKING CHANGE
 - Removed `Megazord.kt` and moved the contents to the new `RustComponentsInitializer.kt`.
 
+## 🔧 What's Fixed 🔧
+
+### Remote Settings
+
+- Fixed setting a new app context with `RemoteSettingsService::update_config`
+
 [Full Changelog](In progress)
 
 # v139.0 (_2025-04-28_)

--- a/components/remote_settings/src/service.rs
+++ b/components/remote_settings/src/service.rs
@@ -105,12 +105,15 @@ impl RemoteSettingsService {
         let bucket_name = config.bucket_name.unwrap_or_else(|| String::from("main"));
         let mut inner = self.inner.lock();
         for client in inner.active_clients() {
-            client
-                .internal
-                .update_config(base_url.clone(), bucket_name.clone())?;
+            client.internal.update_config(
+                base_url.clone(),
+                bucket_name.clone(),
+                config.app_context.clone(),
+            )?;
         }
         inner.base_url = base_url;
         inner.bucket_name = bucket_name;
+        inner.app_context = config.app_context;
         Ok(())
     }
 }


### PR DESCRIPTION
As I was trying to use this in desktop, I noticed that updating the app config didn't actually change the JEXL filter.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
