### PR TITLE
Separate out SQLite disk errors

### DIFF
--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -181,6 +181,24 @@ impl GetErrorHandling for Error {
                 })
                 .report_error("logins-sync"),
             },
+            Error::SqlError(rusqlite::Error::SqliteFailure(err, _)) => match err.code {
+                rusqlite::ErrorCode::DatabaseCorrupt => {
+                    ErrorHandling::convert(LoginsApiError::UnexpectedLoginsApiError {
+                        reason: self.to_string(),
+                    })
+                    .report_error("logins-db-corrupt")
+                }
+                rusqlite::ErrorCode::DiskFull => {
+                    ErrorHandling::convert(LoginsApiError::UnexpectedLoginsApiError {
+                        reason: self.to_string(),
+                    })
+                    .report_error("logins-db-disk-full")
+                }
+                _ => ErrorHandling::convert(LoginsApiError::UnexpectedLoginsApiError {
+                    reason: self.to_string(),
+                })
+                .report_error("logins-unexpected"),
+            },
             // Unexpected errors that we report to Sentry.  We should watch the reports for these
             // and do one or more of these things if we see them:
             //   - Fix the underlying issue


### PR DESCRIPTION
Use different error type strings for DB corruption and disk full.  This way we can track these errors differently in Sentry.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
