### PR TITLE
Bug 1967867 - Unify keywords metrics logic

### DIFF
--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -26,6 +26,7 @@ use crate::{
         DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedDynamicRecord,
         DownloadedDynamicSuggestion, DownloadedFakespotSuggestion, DownloadedMdnSuggestion,
         DownloadedPocketSuggestion, DownloadedWikipediaSuggestion, Record, SuggestRecordId,
+        SuggestRecordType,
     },
     schema::{clear_database, SuggestConnectionInitializer},
     suggestion::{cook_raw_suggestion_url, FtsMatchInfo, Suggestion},
@@ -1451,6 +1452,32 @@ impl<'a> SuggestDao<'a> {
         self.get_meta::<String>(&provider_config_meta_key(provider))?
             .map_or_else(|| Ok(None), |json| Ok(serde_json::from_str(&json)?))
     }
+
+    /// Gets keywords metrics for a record type.
+    pub fn get_keywords_metrics(&self, record_type: SuggestRecordType) -> Result<KeywordsMetrics> {
+        let data = self.conn.try_query_row(
+            r#"
+            SELECT
+                max(max_len) AS len,
+                max(max_word_count) AS word_count
+            FROM
+                keywords_metrics
+            WHERE
+                record_type = :record_type
+            "#,
+            named_params! {
+                ":record_type": record_type,
+            },
+            |row| -> Result<(usize, usize)> { Ok((row.get("len")?, row.get("word_count")?)) },
+            true, // cache
+        )?;
+        Ok(data
+            .map(|(max_len, max_word_count)| KeywordsMetrics {
+                max_len,
+                max_word_count,
+            })
+            .unwrap_or_default())
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -1844,32 +1871,68 @@ impl<'conn> PrefixKeywordInsertStatement<'conn> {
     }
 }
 
-pub(crate) struct KeywordMetricsInsertStatement<'conn>(rusqlite::Statement<'conn>);
+#[derive(Debug, Default)]
+pub(crate) struct KeywordsMetrics {
+    pub(crate) max_len: usize,
+    pub(crate) max_word_count: usize,
+}
 
-impl<'conn> KeywordMetricsInsertStatement<'conn> {
-    pub(crate) fn new(conn: &'conn Connection) -> Result<Self> {
-        Ok(Self(conn.prepare(
-            "INSERT INTO keywords_metrics(
-                 record_id,
-                 provider,
-                 max_length,
-                 max_word_count
-             )
-             VALUES(?, ?, ?, ?)
-             ",
-        )?))
+/// This can be used to update metrics as keywords are inserted into the DB.
+/// Create a `KeywordsMetricsUpdater`, call `update` on it as each keyword is
+/// inserted, and then call `finish` after all keywords have been inserted.
+pub(crate) struct KeywordsMetricsUpdater {
+    pub(crate) max_len: usize,
+    pub(crate) max_word_count: usize,
+}
+
+impl KeywordsMetricsUpdater {
+    pub(crate) fn new() -> Self {
+        Self {
+            max_len: 0,
+            max_word_count: 0,
+        }
     }
 
-    pub(crate) fn execute(
-        &mut self,
+    pub(crate) fn update(&mut self, keyword: &str) {
+        self.max_len = std::cmp::max(self.max_len, keyword.len());
+        self.max_word_count =
+            std::cmp::max(self.max_word_count, keyword.split_whitespace().count());
+    }
+
+    /// Inserts keywords metrics into the database. This assumes you have a
+    /// cache object inside the `cache` cell that caches the metrics. It will be
+    /// cleared since it will be invalidated by the metrics update.
+    pub(crate) fn finish<T>(
+        &self,
+        conn: &Connection,
         record_id: &SuggestRecordId,
-        provider: SuggestionProvider,
-        max_len: usize,
-        max_word_count: usize,
+        record_type: SuggestRecordType,
+        cache: &mut OnceCell<T>,
     ) -> Result<()> {
-        self.0
-            .execute((record_id.as_str(), provider, max_len, max_word_count))
-            .with_context("keyword metrics insert")?;
+        let mut insert_stmt = conn.prepare(
+            r#"
+            INSERT OR REPLACE INTO keywords_metrics(
+                record_id,
+                record_type,
+                max_len,
+                max_word_count
+            )
+            VALUES(?, ?, ?, ?)
+            "#,
+        )?;
+        insert_stmt
+            .execute((
+                record_id.as_str(),
+                record_type,
+                self.max_len,
+                self.max_word_count,
+            ))
+            .with_context("keywords metrics insert")?;
+
+        // We just made some insertions that might invalidate the data in the
+        // cache. Clear it so it's repopulated the next time it's accessed.
+        cache.take();
+
         Ok(())
     }
 }

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -261,6 +261,12 @@ impl fmt::Display for SuggestRecordType {
     }
 }
 
+impl ToSql for SuggestRecordType {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.as_str()))
+    }
+}
+
 impl SuggestRecordType {
     /// Get all record types to iterate over
     ///


### PR DESCRIPTION
* Change the `keywords_metrics` table so it's based on record types instead of providers. Geonames keywords don't map to a provider but everything maps to a record type.
* Update the geonames implementation so it uses `keywords_metrics` and get rid of `geonames_metrics`.
* Add `KeywordsMetricsUpdater` and `KeywordsMetrics` helpers.
* Update `GeonameCache` and `WeatherCache` so they keep a `KeywordsMetrics`.
* Remove `max_keyword_length` and `max_keyword_word_count` from the weather record since those values are computed by `KeywordsMetricsUpdater` now.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
