### PR TITLE
Bug 1967899 - Add a way for consumers to fetch localized names and other alternates for geonames

### DIFF
--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -20,7 +20,7 @@ use crate::{
     config::{SuggestGlobalConfig, SuggestProviderConfig},
     db::{ConnectionType, IngestedRecord, Sqlite3Extension, SuggestDao, SuggestDb},
     error::Error,
-    geoname::{Geoname, GeonameMatch},
+    geoname::{Geoname, GeonameAlternates, GeonameMatch},
     metrics::{MetricsContext, SuggestIngestionMetrics, SuggestQueryMetrics},
     provider::{SuggestionProvider, SuggestionProviderConstraints, DEFAULT_INGEST_PROVIDERS},
     rs::{
@@ -316,6 +316,17 @@ impl SuggestStore {
     ) -> SuggestApiResult<Vec<GeonameMatch>> {
         self.inner.fetch_geonames(query, match_name_prefix, filter)
     }
+
+    /// Fetches a geoname's names stored in the database.
+    ///
+    /// See `fetch_geoname_alternates` in `geoname.rs` for documentation.
+    #[handle_error(Error)]
+    pub fn fetch_geoname_alternates(
+        &self,
+        geoname: &Geoname,
+    ) -> SuggestApiResult<GeonameAlternates> {
+        self.inner.fetch_geoname_alternates(geoname)
+    }
 }
 
 impl SuggestStore {
@@ -557,6 +568,12 @@ impl<S> SuggestStoreInner<S> {
                 filter.as_ref().map(|f| f.iter().collect()),
             )
         })
+    }
+
+    pub fn fetch_geoname_alternates(&self, geoname: &Geoname) -> Result<GeonameAlternates> {
+        self.dbs()?
+            .reader
+            .read(|dao| dao.fetch_geoname_alternates(geoname))
     }
 }
 

--- a/components/suggest/src/weather.rs
+++ b/components/suggest/src/weather.rs
@@ -99,7 +99,7 @@ impl SuggestDao<'_> {
         let words: Vec<_> = kw_lower
             .split_whitespace()
             .flat_map(|w| {
-                w.split(|c| !char::is_alphabetic(c))
+                w.split(|c| !char::is_alphanumeric(c))
                     .filter(|s| !s.is_empty())
             })
             .collect();
@@ -628,8 +628,6 @@ mod tests {
             (
                 "weather a",
                 vec![
-                    // The made-up long-name city starts with "a".
-                    geoname::tests::long_name_city().into(),
                     // A suggestion without a city is returned because the query
                     // also matches a keyword ("weather") + a prefix of another
                     // keyword ("ab").


### PR DESCRIPTION
This adds a `fetch_geoname_alternates` function that returns a struct containing localized names and other alternates for a geoname, its country, and its admin divisions.

It also changes the RS schema for alternates records: Each alternate can now be a string (as before) or an object with `is_preferred` and `is_short` booleans. These bools come straight from the geonames data, and we use them to help decide which alternates to return from `fetch_geoname_alternates`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
