### PR TITLE
[DISCO-3540] Remove gzip encoding header for merino

### DIFF
--- a/components/merino/src/curated_recommendations/http.rs
+++ b/components/merino/src/curated_recommendations/http.rs
@@ -19,7 +19,6 @@ impl HttpClient {
         trace!("making request: {url}");
         let response: Response = Request::post(url)
             .header(header_names::ACCEPT, "application/json")?
-            .header(header_names::ACCEPT_ENCODING, "gzip")?
             .header(header_names::USER_AGENT, user_agent_header)?
             .json(request)
             .send()?;


### PR DESCRIPTION
This change removes the gzip header from the HTTP request. We suspect gzipped responses from production are causing JSON deserialization to fail in the Rust+Swift client.

We'll push this and verify that removing the header resolves the issue once it builds.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
