### PR TITLE
Fix filter_adult dependencies to help with vendoring into firefox main

### DIFF
--- a/components/filter_adult/Cargo.toml
+++ b/components/filter_adult/Cargo.toml
@@ -6,12 +6,16 @@ license = "MPL-2.0"
 
 [dependencies]
 base64 = "0.22.1"
-clap = { version = "4.5.36", features = ["derive"] }
+clap = { version = "4.5.36", features = ["derive"], optional = true }
 error-support = { path = "../support/error" }
 md-5 = "0.10"
-regex = "1.11.1"
+regex = "1"
 thiserror = "1.0"
 uniffi = { version = "0.29.0" }
 
 [[bin]]
 name = "import-site-list"
+required-features = ["build-binary"]
+
+[features]
+build-binary = ["clap"]


### PR DESCRIPTION
Does not include tests / changelog changes because this is more about dependency reorganization.

The `clap` dependency is only necessary when building the `import-site-list` tool under `filter_adult`, and this now falls back to using the firefox-main version of `regex`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
