### PR TITLE
Add sync settings metrics for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - The `ContextIDComponent` constructor can now synchronously invoke the rotation callback when it receives an invalid timestamp from callers; in such cases, it falls back to the current timestamp and forces an ID rotation.
 - `rotate_context_id` is no longer public since consumers can use `force_rotation` instead.
 
+### Sync Manager
+- Added sync settings metrics for mobile. [#6786](https://github.com/mozilla/application-services/pull/6786)
+
 [Full Changelog](In progress)
 
 # v140.0 (_2025-05-23_)

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
@@ -13,6 +13,7 @@ import mozilla.telemetry.glean.private.StringMetricType
 import org.json.JSONException
 import org.json.JSONObject
 import org.mozilla.appservices.syncmanager.GleanMetrics.Pings
+import org.mozilla.appservices.syncmanager.GleanMetrics.SyncSettings
 import org.mozilla.appservices.syncmanager.GleanMetrics.AddressesSyncV2 as AddressesSync
 import org.mozilla.appservices.syncmanager.GleanMetrics.BookmarksSyncV2 as BookmarksSync
 import org.mozilla.appservices.syncmanager.GleanMetrics.CreditcardsSyncV2 as CreditcardsSync
@@ -484,5 +485,20 @@ object SyncTelemetry {
             errors.add(InvalidTelemetryException.InvalidEvents(e))
         }
         return errors
+    }
+
+    fun processOpenSyncSettingsMenuTelemetry() {
+        SyncSettings.openMenu.record()
+    }
+
+    fun processSaveSyncSettingsTelemetry(enabledEngines: List<String>, disabledEngines: List<String>) {
+        val enabledList = if (enabledEngines.any()) enabledEngines.joinToString(separator = ",") else null
+        val disabledList = if (disabledEngines.any()) disabledEngines.joinToString(separator = ",") else null
+        val extras = SyncSettings.SaveExtra(
+            disabledEngines = disabledList,
+            enabledEngines = enabledList,
+        )
+
+        SyncSettings.save.record(extras)
     }
 }

--- a/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
+++ b/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
@@ -29,6 +29,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.appservices.syncmanager.GleanMetrics.Pings
+import org.mozilla.appservices.syncmanager.GleanMetrics.SyncSettings
 import java.util.Date
 import java.util.UUID
 import org.mozilla.appservices.syncmanager.GleanMetrics.BookmarksSyncV2 as BookmarksSync
@@ -1272,5 +1273,27 @@ class SyncTelemetryTest {
 
     private fun MutableMap<String, Int>.incrementForKey(key: String) {
         this[key] = 1 + this.getOrElse(key, { 0 })
+    }
+
+    @Test
+    fun `checks received open sync settings menu telemetry when it should`() {
+        SyncTelemetry.processOpenSyncSettingsMenuTelemetry()
+        val events = SyncSettings.openMenu.testGetValue()!!
+        assertEquals(1, events.size)
+        assertEquals("sync_settings", events.elementAt(0).category)
+        assertEquals("open_menu", events.elementAt(0).name)
+    }
+
+    @Test
+    fun `checks received save sync settings telemetry when it should`() {
+        val enabledEngines = listOf<String>("bookmarks", "tabs")
+        val disabledEngines = listOf<String>("logins")
+        SyncTelemetry.processSaveSyncSettingsTelemetry(enabledEngines, disabledEngines)
+        val events = SyncSettings.save.testGetValue()!!
+        assertEquals(1, events.size)
+        assertEquals("sync_settings", events.elementAt(0).category)
+        assertEquals("save", events.elementAt(0).name)
+        assertEquals("bookmarks,tabs", events.elementAt(0).extra!!["enabled_engines"])
+        assertEquals("logins", events.elementAt(0).extra!!["disabled_engines"])
     }
 }

--- a/components/sync_manager/metrics.yaml
+++ b/components/sync_manager/metrics.yaml
@@ -1017,3 +1017,41 @@ fxa_tab_v2:
       - sync-team@mozilla.com
       - skhamis@mozilla.com
     expires: never
+
+sync_settings:
+  open_menu:
+    type: event
+    description: |
+      Records when the user opens the choose sync settings menu.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-4792
+    data_reviews:
+      - https://github.com/mozilla/application-services/pull/6786#issuecomment-2967802374
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-dev@mozilla.org
+    expires: never
+
+  save:
+    type: event
+    description: |
+      Records when the user makes sync settings changes.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/SYNC-4792
+    data_reviews:
+      - https://github.com/mozilla/application-services/pull/6786#issuecomment-2967802374
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-dev@mozilla.org
+    expires: never
+    extra_keys:
+      enabled_engines:
+        description: |
+          A comma-delimited list of engines that were enabled by the user.
+        type: string
+      disabled_engines:
+        description: |
+          A comma-delimited list of engines that were disabled by the user.
+        type: string

--- a/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/SyncManager/SyncManagerComponent.swift
+++ b/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/SyncManager/SyncManagerComponent.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Glean
 
 open class SyncManagerComponent {
     private var api: SyncManager
@@ -28,5 +29,17 @@ open class SyncManagerComponent {
             let telemetry = try RustSyncTelemetryPing.fromJSONString(jsonObjectText: json)
             try processSyncTelemetry(syncTelemetry: telemetry)
         }
+    }
+
+    public static func reportOpenSyncSettingsMenuTelemetry() {
+        GleanMetrics.SyncSettings.openMenu.record()
+    }
+
+    public static func reportSaveSyncSettingsTelemetry(enabledEngines: [String], disabledEngines: [String]) {
+        let enabledList = enabledEngines.isEmpty ? nil : enabledEngines.joined(separator: ",")
+        let disabledList = disabledEngines.isEmpty ? nil : disabledEngines.joined(separator: ",")
+        let extras = GleanMetrics.SyncSettings.SaveExtra(disabledEngines: disabledList, enabledEngines: enabledList)
+
+        GleanMetrics.SyncSettings.save.record(extras)
     }
 }

--- a/megazords/ios-rust/tests/MozillaRustComponentsTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/tests/MozillaRustComponentsTests/SyncManagerTelemetryTests.swift
@@ -274,4 +274,24 @@ class SyncManagerTelemetryTests: XCTestCase {
                                   submitCreditCardsPing: submitCreditCardsPing,
                                   submitTabsPing: submitTabsPing)
     }
+
+    func testReceivesOpenSyncSettingsMenuTelemetry() {
+        SyncManagerComponent.reportOpenSyncSettingsMenuTelemetry()
+        let events = GleanMetrics.SyncSettings.openMenu.testGetValue()!
+        XCTAssertEqual(1, events.count)
+        XCTAssertEqual("sync_settings", events[0].category)
+        XCTAssertEqual("open_menu", events[0].name)
+    }
+
+    func testReceivesSaveSyncSettingsTelemetry() {
+        let enabledEngines = ["bookmarks", "tabs"]
+        let disabledEngines = ["logins"]
+        SyncManagerComponent.reportSaveSyncSettingsTelemetry(enabledEngines: enabledEngines, disabledEngines: disabledEngines)
+        let events = GleanMetrics.SyncSettings.save.testGetValue()!
+        XCTAssertEqual(1, events.count)
+        XCTAssertEqual("sync_settings", events[0].category)
+        XCTAssertEqual("save", events[0].name)
+        XCTAssertEqual("bookmarks,tabs", events[0].extra!["enabled_engines"])
+        XCTAssertEqual("logins", events[0].extra!["disabled_engines"])
+    }
 }


### PR DESCRIPTION
Added sync settings metrics and wrapper functions for iOS and Android. The metrics will report when the sync menu is opened and, upon close, what engines were enabled or disabled by the user.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
