### PR TITLE
Tracing speedup

### DIFF
--- a/components/support/rust-log-forwarder/src/lib.rs
+++ b/components/support/rust-log-forwarder/src/lib.rs
@@ -96,7 +96,7 @@ pub fn set_logger(logger: Option<Box<dyn AppServicesLogger>>) {
     GLOBAL_SUBSCRIBER.call_once(|| {
         use tracing_subscriber::prelude::*;
         tracing_subscriber::registry()
-            .with(tracing_support::SimpleEventLayer)
+            .with(tracing_support::simple_event_layer())
             .init();
     });
 
@@ -182,8 +182,8 @@ mod test {
         let sink = Arc::new(ForwarderEventSink {});
         tracing_support::register_event_sink("rust_log_forwarder", Level::Debug.into(), sink);
 
-        tracing::event!(tracing::Level::INFO, "Test message");
-        tracing::event!(tracing::Level::WARN, "Test message2");
+        tracing_support::info!("Test message");
+        tracing_support::warn!("Test message2");
         logger.check_records(vec![
             Record {
                 level: Level::Info,


### PR DESCRIPTION
Added a callsite filter for the simple event layer.  This allows us to avoid the lock + map lookup for non-app-services crates.

I think this is about as good as we can do performance-wise:
* Non app-services crates are statically disabled, no lock/map lookup needed
* App-services crates are dynamically handled.  We need to do the lock/map lookup each time, since we don't know when outside crates will call `register_event_sink`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
