### PR TITLE
Make `DatabaseLoginsStorage` async

### DIFF
--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -46,14 +46,14 @@ dependencies {
     api project(':sync15')
 
     implementation project(':init_rust_components')
-
+    implementation libs.kotlinx.coroutines
     implementation libs.mozilla.glean
 
     testImplementation project(":syncmanager")
-
     testImplementation libs.androidx.test.core
     testImplementation libs.androidx.work.testing
     testImplementation libs.mozilla.glean.forUnitTests
+    testImplementation libs.kotlinx.coroutines.test
 }
 
 ext.configureUniFFIBindgen("logins")

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -12,9 +12,11 @@ package mozilla.appservices.logins
  * instantiate anything from these classes, and it's on us to fix any bustage
  * on version updates.
  */
-
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import mozilla.telemetry.glean.private.CounterMetricType
 import mozilla.telemetry.glean.private.LabeledMetricType
+import kotlin.coroutines.CoroutineContext
 import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMetrics
 
 /**
@@ -22,7 +24,11 @@ import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMet
  * LoginStore.
  */
 
-class DatabaseLoginsStorage(dbPath: String, keyManager: KeyManager) : AutoCloseable {
+class DatabaseLoginsStorage(
+    dbPath: String,
+    keyManager: KeyManager,
+    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+) : AutoCloseable {
     private var store: LoginStore
 
     init {
@@ -31,68 +37,68 @@ class DatabaseLoginsStorage(dbPath: String, keyManager: KeyManager) : AutoClosea
     }
 
     @Throws(LoginsApiException::class)
-    fun reset() {
-        this.store.reset()
+    suspend fun reset(): Unit = withContext(coroutineContext) {
+        store.reset()
     }
 
     @Throws(LoginsApiException::class)
-    fun wipeLocal() {
-        this.store.wipeLocal()
+    suspend fun wipeLocal(): Unit = withContext(coroutineContext) {
+        store.wipeLocal()
     }
 
     @Throws(LoginsApiException::class)
-    fun delete(id: String): Boolean {
-        return store.delete(id)
+    suspend fun delete(id: String): Boolean = withContext(coroutineContext) {
+        store.delete(id)
     }
 
     @Throws(LoginsApiException::class)
-    fun get(id: String): Login? {
-        return store.get(id)
+    suspend fun get(id: String): Login? = withContext(coroutineContext) {
+        store.get(id)
     }
 
     @Throws(LoginsApiException::class)
-    fun touch(id: String) {
+    suspend fun touch(id: String): Unit = withContext(coroutineContext) {
         store.touch(id)
     }
 
     @Throws(LoginsApiException::class)
-    fun isEmpty(): Boolean {
-        return store.isEmpty()
+    suspend fun isEmpty(): Boolean = withContext(coroutineContext) {
+        store.isEmpty()
     }
 
     @Throws(LoginsApiException::class)
-    fun list(): List<Login> {
-        return store.list()
+    suspend fun list(): List<Login> = withContext(coroutineContext) {
+        store.list()
     }
 
     @Throws(LoginsApiException::class)
-    fun hasLoginsByBaseDomain(baseDomain: String): Boolean {
-        return store.hasLoginsByBaseDomain(baseDomain)
+    suspend fun hasLoginsByBaseDomain(baseDomain: String): Boolean = withContext(coroutineContext) {
+        store.hasLoginsByBaseDomain(baseDomain)
     }
 
     @Throws(LoginsApiException::class)
-    fun getByBaseDomain(baseDomain: String): List<Login> {
-        return store.getByBaseDomain(baseDomain)
+    suspend fun getByBaseDomain(baseDomain: String): List<Login> = withContext(coroutineContext) {
+        store.getByBaseDomain(baseDomain)
     }
 
     @Throws(LoginsApiException::class)
-    fun findLoginToUpdate(look: LoginEntry): Login? {
-        return store.findLoginToUpdate(look)
+    suspend fun findLoginToUpdate(look: LoginEntry): Login? = withContext(coroutineContext) {
+        store.findLoginToUpdate(look)
     }
 
     @Throws(LoginsApiException::class)
-    fun add(entry: LoginEntry): Login {
-        return store.add(entry)
+    suspend fun add(entry: LoginEntry): Login = withContext(coroutineContext) {
+        store.add(entry)
     }
 
     @Throws(LoginsApiException::class)
-    fun update(id: String, entry: LoginEntry): Login {
-        return store.update(id, entry)
+    suspend fun update(id: String, entry: LoginEntry): Login = withContext(coroutineContext) {
+        store.update(id, entry)
     }
 
     @Throws(LoginsApiException::class)
-    fun addOrUpdate(entry: LoginEntry): Login {
-        return store.addOrUpdate(entry)
+    suspend fun addOrUpdate(entry: LoginEntry): Login = withContext(coroutineContext) {
+        store.addOrUpdate(entry)
     }
 
     fun registerWithSyncManager() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ protobuf-compiler = { group = "com.google.protobuf", name = "protoc", version.re
 # Kotlin
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlin-serialization = { group = "org.jetbrains.kotlin.plugin.serialization", name = "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
 


### PR DESCRIPTION
There hasn't been agreement on a grand vision for async Rust in app-services (#6549).  I think part of the reason is that ADR is discussing too many things.  This is my attempt to take a small change from that ADR and see if we agree.

This change takes the async wrapping code that's currently in android-components and moves it to our app-services wrapper.  This improves the API boundary IMO. The SYNC team and the credentials management teams are responsible for threading issues.  For example, we're the one's thinking through how to avoid blocking too many threads when we're waiting on the primary password dialog.  Since we're responsible for threading issues, we should own the code

On a practical level: I have some ideas on how to improve our threading strategy and it's simpler to think about those changes if all the code is in one repo.

Here's the corresponding android-components change: https://github.com/bendk/firefox/commit/d038ba6fd1ec1b39f76e0720e594916d61a4600a

If we agree on this, then I think we can do something similar for iOS.

What do others think?  Is this a good idea?  Do we need/want an ADR for this?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
