### PR TITLE
Bug 1972112 - Add `run_maintenance` for autofill / logins

### DIFF
--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -127,6 +127,13 @@ interface Store {
     [Throws=AutofillApiError, Self=ByArc]
     void scrub_encrypted_data();
 
+    /// Run maintenance on the DB
+    ///
+    /// This is intended to be run during idle time and will take steps / to clean up / shrink the
+    /// database.
+    [Throws=AutofillApiError]
+    void run_maintenance();
+
     [Self=ByArc]
     void register_with_sync_manager();
 };

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -11,7 +11,7 @@ use rusqlite::{
     types::{FromSql, ToSql},
     Connection,
 };
-use sql_support::{self, ConnExt};
+use sql_support::{self, run_maintenance, ConnExt};
 use std::path::Path;
 use std::sync::{Arc, Mutex, Weak};
 use sync15::engine::{SyncEngine, SyncEngineId};
@@ -159,6 +159,13 @@ impl Store {
         // Force the sync engine to refetch data (only need to do this for the credit cards, since the
         // addresses engine doesn't store encrypted data).
         crate::sync::credit_card::create_engine(self).reset_local_sync_data()?;
+        Ok(())
+    }
+
+    #[handle_error(Error)]
+    pub fn run_maintenance(&self) -> ApiResult<()> {
+        let conn = self.db.lock().unwrap();
+        run_maintenance(&conn)?;
         Ok(())
     }
 

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -241,6 +241,13 @@ interface LoginStore {
     [Throws=LoginsApiError]
     string? get_checkpoint();
 
+    /// Run maintenance on the DB
+    ///
+    /// This is intended to be run during idle time and will take steps / to clean up / shrink the
+    /// database.
+    [Throws=LoginsApiError]
+    void run_maintenance();
+
     [Self=ByArc]
     void register_with_sync_manager();
 };

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -8,6 +8,7 @@ use crate::login::{BulkResultEntry, EncryptedLogin, Login, LoginEntry, LoginEntr
 use crate::schema;
 use crate::LoginsSyncEngine;
 use parking_lot::Mutex;
+use sql_support::run_maintenance;
 use std::path::Path;
 use std::sync::{Arc, Weak};
 use sync15::{
@@ -266,6 +267,13 @@ impl LoginStore {
     #[handle_error(Error)]
     pub fn get_checkpoint(&self) -> ApiResult<Option<String>> {
         self.db.lock().get_meta(schema::CHECKPOINT_KEY)
+    }
+
+    #[handle_error(Error)]
+    pub fn run_maintenance(&self) -> ApiResult<()> {
+        let conn = self.db.lock();
+        run_maintenance(&conn)?;
+        Ok(())
     }
 
     // This allows the embedding app to say "make this instance available to

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -20,6 +20,7 @@ pub mod debug_tools {
 
 mod each_chunk;
 mod lazy;
+mod maintenance;
 mod maybe_cached;
 pub mod open_database;
 mod repeat;
@@ -27,6 +28,7 @@ mod repeat;
 pub use conn_ext::*;
 pub use each_chunk::*;
 pub use lazy::*;
+pub use maintenance::run_maintenance;
 pub use maybe_cached::*;
 pub use repeat::*;
 

--- a/components/support/sql/src/maintenance.rs
+++ b/components/support/sql/src/maintenance.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::ConnExt;
+use rusqlite::{Connection, Result};
+
+/// Run maintenance on the DB
+///
+/// `run_maintenance()` is intended to be run during idle time and will take steps to clean up /
+/// shrink the database.
+pub fn run_maintenance(conn: &Connection) -> Result<()> {
+    vacuum(conn)?;
+    conn.execute_one("PRAGMA optimize")?;
+    conn.execute_one("PRAGMA wal_checkpoint(PASSIVE)")?;
+    Ok(())
+}
+
+/// Run vacuum on the DB
+fn vacuum(conn: &Connection) -> Result<()> {
+    let auto_vacuum_setting: u32 = conn.query_one("PRAGMA auto_vacuum")?;
+    if auto_vacuum_setting == 2 {
+        // Ideally, we run an incremental vacuum to delete 2 pages
+        conn.execute_one("PRAGMA incremental_vacuum(2)")?;
+    } else {
+        // If auto_vacuum=incremental isn't set, configure it and run a full vacuum.
+        error_support::warn!(
+            "run_maintenance_vacuum: Need to run a full vacuum to set auto_vacuum=incremental"
+        );
+        conn.execute_one("PRAGMA auto_vacuum=incremental")?;
+        conn.execute_one("VACUUM")?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Adding `run_maintenance` for autofill/logins.

I didn't split this up or add metrics like we did for places because I highly doubt we're going to have performances issues with these functions. The places metrics are fine and needs to do more work then these components (the prune step and places DBs are larger in general).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
