### PR TITLE
Add tracing_support::TracingEvent.target_prefix

### DIFF
--- a/components/support/tracing/src/layer.rs
+++ b/components/support/tracing/src/layer.rs
@@ -79,6 +79,7 @@ where
                 let event = crate::Event {
                     level: level.into(),
                     target: target.to_string(),
+                    target_prefix: prefix.to_string(),
                     name: event.metadata().name().to_string(),
                     message,
                     fields: serde_json::to_value(&fields).unwrap_or_default(),

--- a/components/support/tracing/src/lib.rs
+++ b/components/support/tracing/src/lib.rs
@@ -142,6 +142,7 @@ pub type Event = TracingEvent;
 pub struct TracingEvent {
     pub level: Level,
     pub target: String,
+    pub target_prefix: String,
     pub name: String,
     pub message: String,
     pub fields: serde_json::Value,

--- a/components/support/tracing/src/testing.rs
+++ b/components/support/tracing/src/testing.rs
@@ -21,7 +21,7 @@ pub fn init_for_tests() {
     });
 }
 
-/// Like `init_for_tests` but uses the specified `level` is logging is not configured in the environment.
+/// Like `init_for_tests` but uses the specified `level` if logging is not configured in the environment.
 pub fn init_for_tests_with_level(level: crate::Level) {
     // This is intended to be equivalent to `env_logger::try_init().ok();`
     // `debug!()` output is seen. We could maybe add logging for `#[tracing::instrument]`?


### PR DESCRIPTION
Consumers in JS will need to know what this prefix is. Even though it's trivially derived on the foreign side, given Rust already knows this it seems to make sense to supply it.

@bendk I'm kinda torn here - JS doing a trivial string split might actually be faster than the extra `RustBuffer` this will cuase uniffi to use, so maybe insisting foreign code does that split is fine. I'm almost leaning against it, but my JS patch had to do this twice, so I'm really not sure - wdyt?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
