### PR TITLE
Bug 1974333 - Greedily match on single weather keywords

### DIFF
--- a/components/suggest/src/weather.rs
+++ b/components/suggest/src/weather.rs
@@ -121,23 +121,44 @@ impl SuggestDao<'_> {
             })?;
 
         // Step 3: Map each valid token path to a `TokenPath` and discard
-        // invalid paths. Save the paths that include cities, but for paths that
-        // include keywords alone, only set a flag.
-        let mut kw_alone = false;
+        // invalid paths. Save the paths that include cities. For paths that
+        // include keywords alone, only keep track of the minimum keyword count
+        // across all paths. e.g., if one path has one keyword alone and another
+        // path has two keywords alone, set `kws_alone_min_count` to 1.
+        let mut kws_alone_min_count: Option<usize> = None;
         let mut city_token_paths: Vec<_> = raw_token_paths
             .into_iter()
             .filter_map(|rtp| {
                 TokenPath::from_raw_token_path(rtp).and_then(|tp| match tp {
                     TokenPath::City(ctp) => Some(ctp),
-                    TokenPath::WeatherKeywordAlone => {
-                        kw_alone = true;
+                    TokenPath::WeatherKeywordsAlone(count) => {
+                        kws_alone_min_count = kws_alone_min_count
+                            .map(|min_count| std::cmp::min(min_count, count))
+                            .or(Some(count));
                         None
                     }
                 })
             })
             .collect();
 
-        // Step 4: Sort city token paths, first by city match length descending
+        // Step 4: If any token path is one keyword alone, return a suggestion
+        // without a city even if there are other token paths with cities. In
+        // other words, greedily match on a single keyword. As a simplified
+        // example, if "rain" and "rain in" are keywords and the query is "rain
+        // in", there will be two token paths:
+        //
+        // 1. "rain in" keyword alone
+        // 2. "rain" keyword + Indianapolis city match (for example)
+        //
+        // We want to return a suggestion only for the first path, "rain in".
+        if kws_alone_min_count == Some(1) {
+            return Ok(vec![Suggestion::Weather {
+                city: None,
+                score: w_cache.score,
+            }]);
+        }
+
+        // Step 5: Sort city token paths, first by city match length descending
         // and then by other geoname match length descending. The idea is that
         // the more of a name the user matched, the better the match. If two
         // paths are still equal, break the tie by population descending.
@@ -160,7 +181,8 @@ impl SuggestDao<'_> {
             }
         });
 
-        // Step 5: Map token paths to `Suggestion`s.
+        // Step 6: If there are any city token paths, return suggestions for
+        // them.
         //
         // The cities with the max match lengths are now at the front of the
         // list. There may be multiple matches with the max match lengths, and
@@ -173,7 +195,7 @@ impl SuggestDao<'_> {
             let mut geoname_ids = HashSet::new();
             let (max_city_match_len, max_other_geoname_match_len) =
                 (first_ctp.city_match_len, first_ctp.other_geoname_match_len);
-            Ok(city_token_paths
+            return Ok(city_token_paths
                 .into_iter()
                 .take_while(|ctp| {
                     ctp.city_match_len == max_city_match_len
@@ -190,15 +212,19 @@ impl SuggestDao<'_> {
                         })
                     }
                 })
-                .collect())
-        } else if kw_alone {
-            Ok(vec![Suggestion::Weather {
+                .collect());
+        }
+
+        // Step 7: If there are any paths with multiple keywords, return a
+        // single suggestion without a city.
+        if kws_alone_min_count.is_some() {
+            return Ok(vec![Suggestion::Weather {
                 city: None,
                 score: w_cache.score,
-            }])
-        } else {
-            Ok(Vec::new())
+            }]);
         }
+
+        Ok(Vec::new())
     }
 
     fn match_weather_tokens(
@@ -280,8 +306,8 @@ impl SuggestDao<'_> {
             WHERE
                 s.provider = :provider
                 AND (
-                    CASE :prefix WHEN FALSE THEN k.keyword = :keyword
-                    ELSE (k.keyword BETWEEN :keyword AND :keyword || X'FFFF') END
+                    k.keyword = :keyword
+                    OR (:prefix AND (k.keyword BETWEEN :keyword AND :keyword || X'FFFF'))
                 )
             "#,
             named_params! {
@@ -417,7 +443,8 @@ struct WeatherKeywordMatch {
 #[allow(clippy::large_enum_variant)]
 enum TokenPath {
     City(CityTokenPath),
-    WeatherKeywordAlone,
+    // The `usize` is the number of keywords matched in the path.
+    WeatherKeywordsAlone(usize),
 }
 
 struct CityTokenPath {
@@ -428,7 +455,7 @@ struct CityTokenPath {
 
 impl TokenPath {
     fn from_raw_token_path(rtp: Vec<Token>) -> Option<Self> {
-        let mut kw_matched = false;
+        let mut kw_match_count = 0;
         let mut any_kw_match_full = false;
         let mut city_match: Option<GeonameMatch> = None;
         let mut city_match_len = 0;
@@ -438,7 +465,7 @@ impl TokenPath {
         for t in rtp {
             match t {
                 Token::WeatherKeyword(kwm) => {
-                    kw_matched = true;
+                    kw_match_count += 1;
                     any_kw_match_full = any_kw_match_full || !kwm.is_prefix;
                 }
                 Token::Geoname {
@@ -481,7 +508,7 @@ impl TokenPath {
                 // la weather
                 // los angeles weather
                 // pdx weather
-                (kw_matched && any_kw_match_full)
+                (kw_match_count > 0 && any_kw_match_full)
                     // The query has weather keyword(s) (full or prefix) + a
                     // full city abbreviation:
                     //
@@ -492,7 +519,7 @@ impl TokenPath {
                     // weather la
                     // weather la c
                     // weather la ca
-                    || (kw_matched && !cm.prefix && cm.match_type.is_abbreviation())
+                    || (kw_match_count > 0 && !cm.prefix && cm.match_type.is_abbreviation())
                     // The query has a full city proper name:
                     //
                     // los angeles
@@ -524,9 +551,9 @@ impl TokenPath {
                     other_geoname_match_len: max_other_geoname_match_len,
                 }));
             }
-        } else if kw_matched && max_other_geoname_match_len == 0 {
+        } else if kw_match_count > 0 && max_other_geoname_match_len == 0 {
             // This path matched weather keyword(s) alone.
-            return Some(Self::WeatherKeywordAlone);
+            return Some(Self::WeatherKeywordsAlone(kw_match_count));
         }
 
         None
@@ -777,6 +804,157 @@ mod tests {
                 q
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn weather_keyword_includes_city_prefix() -> anyhow::Result<()> {
+        before_each();
+
+        let kws = [
+            "weather",
+            "weather ",
+            // These keywords start with the "weather" keyword and end in
+            // prefixes of "new york"
+            "weather n",
+            "weather ne",
+            "weather new",
+            // These keywords are prefixes of "new york"
+            "new",
+            "new ",
+            "new y",
+            "new yo",
+        ];
+
+        let mut store = geoname::tests::new_test_store();
+        store
+            .client_mut()
+            .add_record(SuggestionProvider::Weather.record(
+                "weather-1",
+                json!({
+                    "min_keyword_length": 0,
+                    "keywords": kws,
+                    "score": 0.24
+                }),
+            ));
+
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Weather]),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+
+        // Make sure "new york" really matches a city.
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("new york")),
+            vec![Suggestion::Weather {
+                score: 0.24,
+                city: Some(geoname::tests::nyc()),
+            }],
+        );
+
+        // Queries for each of the keywords alone should match a suggestion
+        // without a city, even though for example "weather new" also matches
+        // the "weather" keyword and a prefix of "new york".
+        for q in kws {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::weather(q)),
+                vec![Suggestion::Weather {
+                    score: 0.24,
+                    city: None,
+                }],
+                "Keyword alone query: {:?}",
+                q
+            );
+        }
+
+        // These queries match both the "weather" keyword and a city but are not
+        // also keywords themselves, so their suggestions should include the
+        // city.
+        let city_matches = [
+            "weather new y",
+            "weather new yo",
+            "weather new yor",
+            "weather new york",
+        ];
+        for q in city_matches {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::weather(q)),
+                vec![Suggestion::Weather {
+                    score: 0.24,
+                    city: Some(geoname::tests::nyc()),
+                }],
+                "City query: {:?}",
+                q
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn weather_keyword_same_as_city() -> anyhow::Result<()> {
+        before_each();
+
+        let mut store = geoname::tests::new_test_store();
+        store
+            .client_mut()
+            .add_record(SuggestionProvider::Weather.record(
+                "weather-1",
+                json!({
+                    "min_keyword_length": 0,
+                    "keywords": [],
+                    "score": 0.24
+                }),
+            ));
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Weather]),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+
+        // Make sure "new york" really matches a city.
+        for q in ["new york", "new york city"] {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::weather("new york")),
+                vec![Suggestion::Weather {
+                    score: 0.24,
+                    city: Some(geoname::tests::nyc()),
+                }],
+                "new york query: {:?}",
+                q
+            );
+        }
+
+        store
+            .client_mut()
+            .update_record(SuggestionProvider::Weather.record(
+                "weather-1",
+                json!({
+                    "min_keyword_length": 0,
+                    "keywords": ["new york"],
+                    "score": 0.24
+                }),
+            ));
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Weather]),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("new york")),
+            vec![Suggestion::Weather {
+                score: 0.24,
+                city: None,
+            }],
+        );
+
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("new york city")),
+            vec![Suggestion::Weather {
+                score: 0.24,
+                city: Some(geoname::tests::nyc()),
+            }],
+        );
 
         Ok(())
     }


### PR DESCRIPTION
This fixes the bug and also improves the weather keywords SQL query. The current query scans the whole keywords table according to its query plan:

```
SCAN k
SEARCH s USING INTEGER PRIMARY KEY (rowid=?)
```

AFAICT the problem is that the query uses `CASE` instead of simple boolean operators. The query plan of the SQL in this patch is:

```
MULTI-INDEX OR
  INDEX 1
  SEARCH k USING PRIMARY KEY (keyword=?)
  INDEX 2
  SEARCH k USING PRIMARY KEY (keyword>? AND keyword<?)
SEARCH s USING INTEGER PRIMARY KEY (rowid=?)
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
