### PR TITLE
Update changelog for recent search changes in bug 1976993

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,10 @@
 
 ### Search
 
-- `JSONEngineUrls` now has an optional `visual_search` URL, supporting visual
-  search endpoints in engine configs.
-- `JSONEngineUrl` and `SearchEngineUrl` now have an optional `display_name`,
-  which is useful if a URL corresponds to a brand name distinct from the
-  engine's brand name.
+- `SearchEngineUrls` now has an optional `visual_search` field, supporting
+  visual search endpoints in engine configs.
+- `SearchEngineUrl` now has an optional `display_name` field, which is useful if
+  a URL corresponds to a brand name distinct from the engine's brand name.
 
 # v141.0 (_2025-06-23_)
 


### PR DESCRIPTION
I made a couple mistakes when I updated the changelog in #6494: `SearchEngineUrls` has the new `visual_search` field too but I forgot to mention it, and there's no need to mention `JSONEngineUrls` and `JSONEngineUrl` since they aren't public.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
