### PR TITLE
Bump UniFFI to 0.29.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,54 +82,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "anyhow"
@@ -154,38 +110,45 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "askama"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47cbc3cf73fa8d9833727bbee4835ba5c421a0d65b72daf9a7b5d0e0f9cfb57e"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
  "askama_derive",
- "askama_escape",
- "humansize",
- "num-traits",
+ "itoa",
  "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22fbe0413545c098358e56966ff22cdd039e10215ae213cfbd65032b119fc94"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
+ "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
- "nom",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash",
  "serde",
+ "serde_derive",
  "syn 2.0.89",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
+name = "askama_parser"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.12",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -483,6 +446,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.3",
+]
+
+[[package]]
 name = "caseless"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,7 +590,6 @@ version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -672,12 +648,6 @@ dependencies = [
  "termcolor",
  "unicode-width 0.1.11",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -2349,12 +2319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "iso8601"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,12 +3199,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "once_map"
@@ -4466,7 +4424,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.15.2",
  "clap 4.5.39",
  "rinja",
  "serde_yaml 0.8.24",
@@ -4997,7 +4955,7 @@ checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.19",
 ]
 
 [[package]]
@@ -5216,18 +5174,19 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62a57e90f9baed5ad02a71a0870180fa1cc35499093b2d21be2edfb68ec0f7"
+checksum = "c6d968cb62160c11f2573e6be724ef8b1b18a277aededd17033f8a912d73e2b4"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap 4.5.39",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
@@ -5236,7 +5195,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap 4.5.39",
  "uniffi",
  "uniffi_bindgen",
@@ -5244,32 +5203,35 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2242f35214f1e0e3b47c495d340c69f649f9a9ece3a943a29e275686cc884533"
+checksum = "f6b39ef1acbe1467d5d210f274fae344cb6f8766339330cb4c9688752899bf6b"
 dependencies = [
  "anyhow",
+ "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "fs-err",
  "glob",
  "goblin",
  "heck 0.5.0",
+ "indexmap 2.5.0",
  "once_cell",
- "paste",
- "rinja",
  "serde",
+ "tempfile",
  "textwrap 0.16.1",
  "toml",
+ "uniffi_internal_macros",
  "uniffi_meta",
+ "uniffi_pipeline",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c887a6c9a2857d8dc2ab0c8d578e8aa4978145b4fd65ed44296341e89aebc3cc"
+checksum = "6683e6b665423cddeacd89a3f97312cf400b2fb245a26f197adaf65c45d505b2"
 dependencies = [
  "anyhow",
  "camino",
@@ -5278,32 +5240,34 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad9fbdeb7ae4daf8d0f7704a3b638c37018eb16bb701e30fa17a2dd3e2d39c1"
+checksum = "c2d990b553d6b9a7ee9c3ae71134674739913d52350b56152b0e613595bb5a6f"
 dependencies = [
  "anyhow",
  "bytes",
  "once_cell",
- "paste",
  "static_assertions",
 ]
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9902d4ed16c65e6c0222241024dd0bfeed07ea3deb7c470eb175e5f5ef406cd"
+checksum = "04f4f224becf14885c10e6e400b95cc4d1985738140cb194ccc2044563f8a56b"
 dependencies = [
+ "anyhow",
+ "indexmap 2.5.0",
+ "proc-macro2",
  "quote",
  "syn 2.0.89",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd5f8eefba5898b901086f5e7916da67b9a5286a01cc44e910cd75fa37c630"
+checksum = "b481d385af334871d70904e6a5f129be7cd38c18fcf8dd8fd1f646b426a56d58"
 dependencies = [
  "camino",
  "fs-err",
@@ -5318,20 +5282,34 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5965b1d4ffacef1eaa72fef9c00d2491641e87ad910f6c5859b9c503ddb16a"
+checksum = "10f817868a3b171bb7bf259e882138d104deafde65684689b4694c846d322491"
 dependencies = [
  "anyhow",
  "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b147e133ad7824e32426b90bc41fda584363563f2ba747f590eca1fd6fd14e6"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.5.0",
+ "tempfile",
  "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279b82bac9a382c796a0d210bb8354a0b813499b28aa1de046c85d78ca389805"
+checksum = "caed654fb73da5abbc7a7e9c741532284532ba4762d6fe5071372df22a41730a"
 dependencies = [
  "anyhow",
  "textwrap 0.16.1",
@@ -5380,12 +5358,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -5796,15 +5768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-targets"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6002,6 +5965,15 @@ name = "winnow"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c52ac009d615e79296318c1bcce2d422aaca15ad08515e344feeda07df67a587"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -10,7 +10,7 @@ the details of which are reproduced below.
 * [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
-* [MIT License: cargo_metadata](#mit-license-cargo_metadata)
+* [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: caseless](#mit-license-caseless)
 * [MIT License: extend](#mit-license-extend)
 * [MIT License: generic-array](#mit-license-generic-array)
@@ -19,7 +19,6 @@ the details of which are reproduced below.
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: openssl-sys](#mit-license-openssl-sys)
@@ -68,6 +67,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_internal_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_pipeline](https://github.com/mozilla/uniffi-rs),
 [uniffi_udl](https://github.com/mozilla/uniffi-rs)
 
 ```
@@ -453,6 +453,9 @@ The following text applies to code linked from these dependencies:
 [android-tzdata](https://github.com/RumovZ/android-tzdata),
 [android_system_properties](https://github.com/nical/android_system_properties),
 [anyhow](https://github.com/dtolnay/anyhow),
+[askama](https://github.com/askama-rs/askama),
+[askama_derive](https://github.com/askama-rs/askama),
+[askama_parser](https://github.com/askama-rs/askama),
 [autocfg](https://github.com/cuviper/autocfg),
 [base64](https://github.com/marshallpierce/rust-base64),
 [basic-toml](https://github.com/dtolnay/basic-toml),
@@ -521,7 +524,6 @@ The following text applies to code linked from these dependencies:
 [num-traits](https://github.com/rust-num/num-traits),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
-[once_map](https://github.com/a1phyr/once_map),
 [openssl-macros](https://github.com/sfackler/rust-openssl),
 [openssl-probe](https://github.com/alexcrichton/openssl-probe),
 [openssl-src](https://github.com/alexcrichton/openssl-src-rs),
@@ -546,9 +548,6 @@ The following text applies to code linked from these dependencies:
 [regex-syntax](https://github.com/rust-lang/regex/tree/master/regex-syntax),
 [regex](https://github.com/rust-lang/regex),
 [reqwest](https://github.com/seanmonstar/reqwest),
-[rinja](https://github.com/rinja-rs/rinja),
-[rinja_derive](https://github.com/rinja-rs/rinja),
-[rinja_parser](https://github.com/rinja-rs/rinja),
 [rkv](https://github.com/mozilla/rkv),
 [rustc-hash](https://github.com/rust-lang/rustc-hash),
 [rustix](https://github.com/bytecodealliance/rustix),
@@ -929,10 +928,11 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: cargo_metadata
+## MIT License: cargo_metadata, winnow
 
 The following text applies to code linked from these dependencies:
-[cargo_metadata](https://github.com/oli-obk/cargo_metadata)
+[cargo_metadata](https://github.com/oli-obk/cargo_metadata),
+[winnow](https://github.com/winnow-rs/winnow)
 
 ```
 Permission is hereby granted, free of charge, to any
@@ -1201,37 +1201,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: mime_guess
-
-The following text applies to code linked from these dependencies:
-[mime_guess](https://github.com/abonander/mime_guess)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Austin Bonander
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 ```
 -------------

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.8.21"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.29"
-askama = "0.12"
+askama = "0.13"
 textwrap = "0.14.2"
 heck = "0.3.3"
 unicode-segmentation = "1.8.0"

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -9,13 +9,12 @@ the details of which are reproduced below.
 * [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
-* [MIT License: cargo_metadata](#mit-license-cargo_metadata)
+* [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: caseless](#mit-license-caseless)
 * [MIT License: extend](#mit-license-extend)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: rmp, rmp-serde](#mit-license-rmp-rmp-serde)
@@ -52,6 +51,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_internal_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_pipeline](https://github.com/mozilla/uniffi-rs),
 [uniffi_udl](https://github.com/mozilla/uniffi-rs)
 
 ```
@@ -437,6 +437,9 @@ The following text applies to code linked from these dependencies:
 [android-tzdata](https://github.com/RumovZ/android-tzdata),
 [android_system_properties](https://github.com/nical/android_system_properties),
 [anyhow](https://github.com/dtolnay/anyhow),
+[askama](https://github.com/askama-rs/askama),
+[askama_derive](https://github.com/askama-rs/askama),
+[askama_parser](https://github.com/askama-rs/askama),
 [autocfg](https://github.com/cuviper/autocfg),
 [base64](https://github.com/marshallpierce/rust-base64),
 [basic-toml](https://github.com/dtolnay/basic-toml),
@@ -455,6 +458,7 @@ The following text applies to code linked from these dependencies:
 [dogear](https://github.com/mozilla/dogear),
 [either](https://github.com/bluss/either),
 [env_logger](https://github.com/rust-cli/env_logger),
+[equivalent](https://github.com/cuviper/equivalent),
 [errno](https://github.com/lambda-fairy/rust-errno),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
@@ -472,6 +476,7 @@ The following text applies to code linked from these dependencies:
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
 [idna_adapter](https://github.com/hsivonen/idna_adapter),
+[indexmap](https://github.com/indexmap-rs/indexmap),
 [io-lifetimes](https://github.com/sunfishcode/io-lifetimes),
 [itertools](https://github.com/rust-itertools/itertools),
 [itoa](https://github.com/dtolnay/itoa),
@@ -482,11 +487,9 @@ The following text applies to code linked from these dependencies:
 [linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
-[mime](https://github.com/hyperium/mime),
 [minimal-lexical](https://github.com/Alexhuszagh/minimal-lexical),
 [num-traits](https://github.com/rust-num/num-traits),
 [once_cell](https://github.com/matklad/once_cell),
-[once_map](https://github.com/a1phyr/once_map),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -505,9 +508,6 @@ The following text applies to code linked from these dependencies:
 [regex-automata](https://github.com/rust-lang/regex/tree/master/regex-automata),
 [regex-syntax](https://github.com/rust-lang/regex/tree/master/regex-syntax),
 [regex](https://github.com/rust-lang/regex),
-[rinja](https://github.com/rinja-rs/rinja),
-[rinja_derive](https://github.com/rinja-rs/rinja),
-[rinja_parser](https://github.com/rinja-rs/rinja),
 [rkv](https://github.com/mozilla/rkv),
 [rustc-hash](https://github.com/rust-lang/rustc-hash),
 [rustix](https://github.com/bytecodealliance/rustix),
@@ -851,10 +851,11 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: cargo_metadata
+## MIT License: cargo_metadata, winnow
 
 The following text applies to code linked from these dependencies:
-[cargo_metadata](https://github.com/oli-obk/cargo_metadata)
+[cargo_metadata](https://github.com/oli-obk/cargo_metadata),
+[winnow](https://github.com/winnow-rs/winnow)
 
 ```
 Permission is hereby granted, free of charge, to any
@@ -1027,37 +1028,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: mime_guess
-
-The following text applies to code linked from these dependencies:
-[mime_guess](https://github.com/abonander/mime_guess)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Austin Bonander
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 ```
 -------------

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -57,6 +57,10 @@ the details of which are reproduced below.
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
   <license>
+    <name>Mozilla Public License 2.0: uniffi_pipeline</name>
+    <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
+  </license>
+  <license>
     <name>Mozilla Public License 2.0: uniffi_udl</name>
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
@@ -73,12 +77,24 @@ the details of which are reproduced below.
     <url>https://github.com/dtolnay/anyhow/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: askama</name>
+    <url>https://github.com/askama-rs/askama/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: askama_derive</name>
+    <url>https://github.com/askama-rs/askama/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: askama_parser</name>
+    <url>https://github.com/askama-rs/askama/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: autocfg</name>
     <url>https://github.com/cuviper/autocfg/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: base64</name>
-    <url>https://github.com/marshallpierce/rust-base64/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: basic-toml</name>
@@ -145,12 +161,16 @@ the details of which are reproduced below.
     <url>https://github.com/rust-cli/env_logger/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: equivalent</name>
+    <url>https://github.com/cuviper/equivalent/blob/main/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: errno</name>
     <url>https://github.com/lambda-fairy/rust-errno/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: fallible-iterator</name>
-    <url>https://github.com/sfackler/rust-fallible-iterator/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: fallible-streaming-iterator</name>
@@ -174,7 +194,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: getrandom</name>
-    <url>https://github.com/rust-random/getrandom/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: glob</name>
@@ -211,6 +231,10 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: idna_adapter</name>
     <url>https://github.com/hsivonen/idna_adapter/blob/main/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: indexmap</name>
+    <url>https://github.com/indexmap-rs/indexmap/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: io-lifetimes</name>
@@ -250,11 +274,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: log</name>
-    <url>https://github.com/rust-lang/log/blob/main/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: mime</name>
-    <url>https://github.com/hyperium/mime/blob/v0.3.17/LICENSE-APACHE</url>
+    <url>https://github.com/rust-lang/log/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: minimal-lexical</name>
@@ -262,15 +282,11 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: num-traits</name>
-    <url>https://github.com/rust-num/num-traits/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/rust-num/num-traits/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: once_cell</name>
     <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: once_map</name>
-    <url>https://github.com/a1phyr/once_map/blob/master/LICENCE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: parking_lot</name>
@@ -306,7 +322,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: proc-macro2</name>
-    <url>https://github.com/dtolnay/proc-macro2/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/dtolnay/proc-macro2/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: prost</name>
@@ -345,18 +361,6 @@ the details of which are reproduced below.
     <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: rinja</name>
-    <url>https://github.com/rinja-rs/rinja/blob/main/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: rinja_derive</name>
-    <url>https://github.com/rinja-rs/rinja/blob/main/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: rinja_parser</name>
-    <url>https://github.com/rinja-rs/rinja/blob/main/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: rkv</name>
     <url>https://github.com/mozilla/rkv/blob/main/LICENSE</url>
   </license>
@@ -370,7 +374,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: ryu</name>
-    <url>https://github.com/dtolnay/ryu/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/dtolnay/ryu/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: scopeguard</name>
@@ -398,7 +402,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: sha2</name>
-    <url>https://github.com/RustCrypto/hashes/blob/main/sha2/LICENSE-APACHE</url>
+    <url>https://github.com/RustCrypto/hashes/blob/master/sha2/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: shlex</name>
@@ -442,7 +446,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: thread_local</name>
-    <url>https://github.com/Amanieu/thread_local-rs/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/Amanieu/thread_local-rs/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: tinyvec</name>
@@ -490,7 +494,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: vcpkg</name>
-    <url>https://github.com/mcgoo/vcpkg-rs/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/mcgoo/vcpkg-rs/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: version_check</name>
@@ -526,11 +530,11 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>MIT License: byteorder</name>
-    <url>https://github.com/BurntSushi/byteorder/blob/main/LICENSE-MIT</url>
+    <url>https://github.com/BurntSushi/byteorder/blob/master/LICENSE-MIT</url>
   </license>
   <license>
     <name>MIT License: memchr</name>
-    <url>https://github.com/BurntSushi/memchr/blob/main/LICENSE-MIT</url>
+    <url>https://github.com/BurntSushi/memchr/blob/master/LICENSE-MIT</url>
   </license>
   <license>
     <name>MIT License: bincode</name>
@@ -545,12 +549,16 @@ the details of which are reproduced below.
     <url>https://github.com/oli-obk/cargo_metadata/blob/main/LICENSE-MIT</url>
   </license>
   <license>
+    <name>MIT License: winnow</name>
+    <url>https://github.com/winnow-rs/winnow/blob/main/LICENSE-MIT</url>
+  </license>
+  <license>
     <name>MIT License: caseless</name>
-    <url>https://github.com/SimonSapin/rust-caseless/blob/main/LICENSE</url>
+    <url>https://github.com/SimonSapin/rust-caseless/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: extend</name>
-    <url>https://github.com/davidpdrsn/extend/blob/main/LICENSE</url>
+    <url>https://github.com/davidpdrsn/extend/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: generic-array</name>
@@ -567,10 +575,6 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: rusqlite</name>
     <url>https://github.com/rusqlite/rusqlite/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>MIT License: mime_guess</name>
-    <url>https://github.com/abonander/mime_guess/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: nom</name>
@@ -642,7 +646,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>BSD-2-Clause License: arrayref</name>
-    <url>https://github.com/droundy/arrayref/blob/main/LICENSE</url>
+    <url>https://github.com/droundy/arrayref/blob/master/LICENSE</url>
   </license>
   <license>
     <name>BSD-3-Clause License: protobuf</name>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -10,7 +10,7 @@ the details of which are reproduced below.
 * [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
-* [MIT License: cargo_metadata](#mit-license-cargo_metadata)
+* [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: caseless](#mit-license-caseless)
 * [MIT License: extend](#mit-license-extend)
 * [MIT License: generic-array](#mit-license-generic-array)
@@ -19,7 +19,6 @@ the details of which are reproduced below.
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
@@ -63,6 +62,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_internal_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_pipeline](https://github.com/mozilla/uniffi-rs),
 [uniffi_udl](https://github.com/mozilla/uniffi-rs)
 
 ```
@@ -446,6 +446,9 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 The following text applies to code linked from these dependencies:
 [anyhow](https://github.com/dtolnay/anyhow),
+[askama](https://github.com/askama-rs/askama),
+[askama_derive](https://github.com/askama-rs/askama),
+[askama_parser](https://github.com/askama-rs/askama),
 [autocfg](https://github.com/cuviper/autocfg),
 [base64](https://github.com/marshallpierce/rust-base64),
 [basic-toml](https://github.com/dtolnay/basic-toml),
@@ -510,7 +513,6 @@ The following text applies to code linked from these dependencies:
 [num-traits](https://github.com/rust-num/num-traits),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
-[once_map](https://github.com/a1phyr/once_map),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -531,9 +533,6 @@ The following text applies to code linked from these dependencies:
 [regex-syntax](https://github.com/rust-lang/regex/tree/master/regex-syntax),
 [regex](https://github.com/rust-lang/regex),
 [reqwest](https://github.com/seanmonstar/reqwest),
-[rinja](https://github.com/rinja-rs/rinja),
-[rinja_derive](https://github.com/rinja-rs/rinja),
-[rinja_parser](https://github.com/rinja-rs/rinja),
 [rkv](https://github.com/mozilla/rkv),
 [rustc-hash](https://github.com/rust-lang/rustc-hash),
 [rustix](https://github.com/bytecodealliance/rustix),
@@ -907,10 +906,11 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: cargo_metadata
+## MIT License: cargo_metadata, winnow
 
 The following text applies to code linked from these dependencies:
-[cargo_metadata](https://github.com/oli-obk/cargo_metadata)
+[cargo_metadata](https://github.com/oli-obk/cargo_metadata),
+[winnow](https://github.com/winnow-rs/winnow)
 
 ```
 Permission is hereby granted, free of charge, to any
@@ -1179,37 +1179,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: mime_guess
-
-The following text applies to code linked from these dependencies:
-[mime_guess](https://github.com/abonander/mime_guess)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Austin Bonander
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 ```
 -------------

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -10,14 +10,13 @@ the details of which are reproduced below.
 * [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
-* [MIT License: cargo_metadata](#mit-license-cargo_metadata)
+* [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
@@ -54,6 +53,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_internal_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_pipeline](https://github.com/mozilla/uniffi-rs),
 [uniffi_udl](https://github.com/mozilla/uniffi-rs)
 
 ```
@@ -437,6 +437,9 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 The following text applies to code linked from these dependencies:
 [anyhow](https://github.com/dtolnay/anyhow),
+[askama](https://github.com/askama-rs/askama),
+[askama_derive](https://github.com/askama-rs/askama),
+[askama_parser](https://github.com/askama-rs/askama),
 [autocfg](https://github.com/cuviper/autocfg),
 [base64](https://github.com/marshallpierce/rust-base64),
 [basic-toml](https://github.com/dtolnay/basic-toml),
@@ -492,6 +495,7 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
+[linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -500,7 +504,6 @@ The following text applies to code linked from these dependencies:
 [num-traits](https://github.com/rust-num/num-traits),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
-[once_map](https://github.com/a1phyr/once_map),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -517,9 +520,6 @@ The following text applies to code linked from these dependencies:
 [regex-syntax](https://github.com/rust-lang/regex/tree/master/regex-syntax),
 [regex](https://github.com/rust-lang/regex),
 [reqwest](https://github.com/seanmonstar/reqwest),
-[rinja](https://github.com/rinja-rs/rinja),
-[rinja_derive](https://github.com/rinja-rs/rinja),
-[rinja_parser](https://github.com/rinja-rs/rinja),
 [rkv](https://github.com/mozilla/rkv),
 [rustc-hash](https://github.com/rust-lang/rustc-hash),
 [rustix](https://github.com/bytecodealliance/rustix),
@@ -546,7 +546,6 @@ The following text applies to code linked from these dependencies:
 [thread_local](https://github.com/Amanieu/thread_local-rs),
 [toml](https://github.com/alexcrichton/toml-rs),
 [typenum](https://github.com/paholg/typenum),
-[unicase](https://github.com/seanmonstar/unicase),
 [unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation),
 [url](https://github.com/servo/rust-url),
 [utf16_iter](https://github.com/hsivonen/utf16_iter),
@@ -888,10 +887,11 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: cargo_metadata
+## MIT License: cargo_metadata, winnow
 
 The following text applies to code linked from these dependencies:
-[cargo_metadata](https://github.com/oli-obk/cargo_metadata)
+[cargo_metadata](https://github.com/oli-obk/cargo_metadata),
+[winnow](https://github.com/winnow-rs/winnow)
 
 ```
 Permission is hereby granted, free of charge, to any
@@ -1101,37 +1101,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: mime_guess
-
-The following text applies to code linked from these dependencies:
-[mime_guess](https://github.com/abonander/mime_guess)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Austin Bonander
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 ```
 -------------

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -776,6 +776,16 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
         },
     },
+    "uniffi_pipeline": {
+        "license_url": {
+            "check": None,
+            "fixup": "https://github.com/mozilla/uniffi-rs/blob/main/LICENSE",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
+        },
+    },
     "uniffi_testing": {
         "license_url": {
             "check": None,

--- a/tools/uniffi-bindgen-library-mode/Cargo.toml
+++ b/tools/uniffi-bindgen-library-mode/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uniffi = { version = "0.29.0", features = ["cli"] }
-uniffi_bindgen = { version = "0.29.0" }
+uniffi = { version = "0.29.4", features = ["cli"] }
+uniffi_bindgen = { version = "0.29.4" }
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
-cargo_metadata = "0.15"
+cargo_metadata = "0.19"
 camino = "1"
 anyhow = "1"

--- a/tools/uniffi-bindgen-library-mode/src/main.rs
+++ b/tools/uniffi-bindgen-library-mode/src/main.rs
@@ -127,6 +127,7 @@ fn run_uniffi_bindgen(cli: Cli) -> Result<()> {
                 module_name: Some(module_name),
                 modulemap_filename,
                 metadata_no_deps: false,
+                ..SwiftBindingsOptions::default()
             })?;
         }
         Command::Python { out_dir } => {


### PR DESCRIPTION
We fixed a bug where objects were dropped to early in some cases.  I highly doubt we're hitting it currently, but it seems good to bump the version just to be sure in the future.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
