### PR TITLE
Removing mockall dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,7 +4213,6 @@ dependencies = [
  "error-support",
  "expect-test",
  "log",
- "mockall",
  "mockito",
  "serde",
  "serde_json",

--- a/components/relay/Cargo.toml
+++ b/components/relay/Cargo.toml
@@ -16,7 +16,6 @@ uniffi = "0.29.0"
 [dev-dependencies]
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
 expect-test = "1.4"
-mockall = "0.11"
 mockito = "0.31"
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
 


### PR DESCRIPTION
This will make the monorepo migration easier since vendoring it in will create duplicate dependency versions in moz-central (float-cmp).  I'm thinking this won't be too disruptive because `mockall` isn't being used.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
