### PR TITLE
Added empty storage condition to `test_check_get_keys_impl` and some cleanup for Bug 1978718

### DIFF
--- a/components/webext-storage/src/api.rs
+++ b/components/webext-storage/src/api.rs
@@ -285,10 +285,7 @@ pub fn get_keys(conn: &Connection, ext_id: &str) -> Result<JsonValue> {
         Some(v) => v,
     };
     Ok(JsonValue::Array(
-        existing
-            .keys()
-            .map(|k| JsonValue::String(k.to_string()))
-            .collect(),
+        existing.keys().map(|k| k.to_string().into()).collect(),
     ))
 }
 
@@ -301,7 +298,7 @@ pub fn remove(tx: &Transaction<'_>, ext_id: &str, keys: JsonValue) -> Result<Sto
         Some(v) => v,
     };
 
-    // Note: get_keys parses strings, arrays and objects, but remove()
+    // Note: get_keys_helper parses strings, arrays and objects, but remove()
     // is expected to only be passed a string or array of strings.
     let keys_and_defs = get_keys_helper(keys);
 
@@ -604,6 +601,11 @@ mod tests {
         let db = new_mem_db();
         let conn = db.get_connection().expect("should retrieve connection");
         let tx = conn.unchecked_transaction()?;
+        assert_eq!(
+            get_keys(&tx, ext_id)?,
+            json!([]),
+            "get_keys should return an empty array when storage is uninitialized"
+        );
         set(&tx, ext_id, json!({"foo": "bar", "baz": "qux" }))?;
         let data = get_keys(&tx, ext_id)?;
         assert_eq!(


### PR DESCRIPTION
Changes in this PR (in response to feedback from Rob Wu):
- Corrected the name of the `get_keys_helper` function in a comment
- Made the `get_keys` function more idiomatic Rust
- Added a test condition to ensure that `get_keys` on an empty/uninitialized storage will return an empty array (technically a JSON representation of an empty array, I guess)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
