### PR TITLE
Remove pretty_assertions dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,15 +74,6 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -634,7 +625,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "atty",
  "bitflags 1.3.2",
  "strsim 0.8.0",
@@ -979,16 +970,6 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ctor"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
@@ -1076,12 +1057,6 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
-
-[[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "difflib"
@@ -3271,7 +3246,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "clap 2.34.0",
- "ctor 0.2.8",
+ "ctor",
  "error-support",
  "firefox-versioning",
  "hex",
@@ -3604,15 +3579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,7 +3695,6 @@ dependencies = [
  "memchr",
  "parking_lot",
  "percent-encoding",
- "pretty_assertions",
  "rusqlite",
  "serde",
  "serde_derive",
@@ -3856,18 +3821,6 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-dependencies = [
- "ansi_term 0.11.0",
- "ctor 0.1.22",
- "difference",
- "output_vt100",
 ]
 
 [[package]]
@@ -4644,7 +4597,6 @@ dependencies = [
  "mockito",
  "once_cell",
  "parking_lot",
- "pretty_assertions",
  "remote_settings",
  "serde",
  "serde_json",

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -37,7 +37,6 @@ uniffi = { version = "0.29.0" }
 
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }
-pretty_assertions = "0.6"
 tempfile = "3.1"
 sql-support = { path = "../support/sql" }
 

--- a/components/places/src/bookmark_sync/engine.rs
+++ b/components/places/src/bookmark_sync/engine.rs
@@ -1883,7 +1883,6 @@ mod tests {
         assert_json_tree as assert_local_json_tree, insert_json_tree as insert_local_json_tree,
     };
     use dogear::{Store as DogearStore, Validity};
-    use pretty_assertions::assert_eq;
     use rusqlite::{Error as RusqlError, ErrorCode};
     use serde_json::{json, Value};
     use std::{

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -622,7 +622,6 @@ mod tests {
     use crate::bookmark_sync::tests::SyncedBookmarkItem;
     use crate::storage::bookmarks::BookmarkRootGuid;
     use crate::types::UnknownFields;
-    use pretty_assertions::assert_eq;
     use serde_json::{json, Value};
 
     fn apply_incoming(api: &PlacesApi, records_json: Value) {

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1032,7 +1032,6 @@ mod tests {
     use crate::storage::get_meta;
     use crate::tests::{append_invalid_bookmark, assert_json_tree, insert_json_tree};
     use json_tree::*;
-    use pretty_assertions::assert_eq;
     use serde_json::Value;
     use std::collections::HashSet;
 

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -1548,7 +1548,6 @@ mod tests {
     use crate::storage::bookmarks::{insert_bookmark, InsertableItem};
     use crate::types::VisitTransitionSet;
     use crate::{api::places_api::ConnectionType, storage::bookmarks::BookmarkRootGuid};
-    use pretty_assertions::assert_eq;
     use std::time::{Duration, SystemTime};
     use sync15::engine::CollSyncIds;
     use types::Timestamp;

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -797,7 +797,6 @@ mod tests {
     };
     use crate::types::VisitType;
     use crate::VisitTransitionSet;
-    use pretty_assertions::assert_eq;
     use std::{thread, time};
 
     macro_rules! assert_table_size {

--- a/components/places/src/tests.rs
+++ b/components/places/src/tests.rs
@@ -15,8 +15,6 @@ use sql_support::ConnExt;
 use sync_guid::Guid as SyncGuid;
 use types::Timestamp;
 
-use pretty_assertions::assert_eq;
-
 pub fn insert_json_tree(conn: &PlacesDb, jtree: Value) {
     let tree: BookmarkTreeNode = serde_json::from_value(jtree).expect("should be valid");
     let folder_node = match tree {

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -24,5 +24,4 @@ uniffi = { version = "0.29.0", features = ["build"] }
 error-support = { path = "../support/error", features = ["testing"] }
 once_cell = "1.18.0"
 mockito = "0.31"
-pretty_assertions = "0.6"
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/search/src/filter.rs
+++ b/components/search/src/filter.rs
@@ -482,7 +482,6 @@ mod tests {
     use super::*;
     use crate::*;
     use once_cell::sync::Lazy;
-    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_default_search_engine_url() {

--- a/components/search/src/selector.rs
+++ b/components/search/src/selector.rs
@@ -160,7 +160,6 @@ mod tests {
     use super::*;
     use crate::{types::*, SearchApiError};
     use mockito::mock;
-    use pretty_assertions::assert_eq;
     use remote_settings::{RemoteSettingsConfig2, RemoteSettingsContext, RemoteSettingsServer};
     use serde_json::json;
 

--- a/components/search/src/sort_helpers.rs
+++ b/components/search/src/sort_helpers.rs
@@ -74,7 +74,6 @@ fn get_priority(
 mod tests {
     use super::*;
     use crate::types::*;
-    use pretty_assertions::assert_eq;
 
     fn create_engine(
         engine_id: &str,


### PR DESCRIPTION
This would create a couple duplicate dependencies with the monorepo migration and I'd rather not handle them (ctor, ansi_term).  Can we just use the built-in assert_eq?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
