### PR TITLE
Bug 1980474 - Add `SearchEngineUrl::exclude_partner_code_from_telemetry` to search config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Search
 
 - Added `SearchEngineUrl::is_new_until` ([bug 1979962](https://bugzilla.mozilla.org/show_bug.cgi?id=1979962))
+- Added `SearchEngineUrl::exclude_partner_code_from_telemetry` ([bug 1980474](https://bugzilla.mozilla.org/show_bug.cgi?id=1980474))
 
 [Full Changelog](In progress)
 

--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -64,6 +64,11 @@ pub(crate) struct JSONEngineUrl {
     /// Indicates the date until which the URL is considered new
     /// (format: YYYY-MM-DD).
     pub is_new_until: Option<String>,
+
+    /// Whether the engine's partner code should be excluded from telemetry when
+    /// this URL is visited.
+    #[serde(default)]
+    pub exclude_partner_code_from_telemetry: bool,
 }
 
 /// Reflects `types::SearchEngineUrls`, but using `EngineUrl`.

--- a/components/search/src/filter.rs
+++ b/components/search/src/filter.rs
@@ -25,6 +25,7 @@ impl Default for SearchEngineUrl {
             search_term_param_name: Default::default(),
             display_name: Default::default(),
             is_new_until: Default::default(),
+            exclude_partner_code_from_telemetry: Default::default(),
         }
     }
 }
@@ -52,6 +53,7 @@ impl SearchEngineUrl {
         if let Some(is_new_until) = &preferred.is_new_until {
             self.is_new_until = Some(is_new_until.clone());
         }
+        self.exclude_partner_code_from_telemetry = preferred.exclude_partner_code_from_telemetry;
     }
 }
 
@@ -498,6 +500,7 @@ mod tests {
                 search_term_param_name: None,
                 display_name: None,
                 is_new_until: None,
+                exclude_partner_code_from_telemetry: false,
             },
         );
     }
@@ -760,6 +763,7 @@ mod tests {
                     ("en-GB".to_string(), "Visual Search en-GB".to_string()),
                 ])),
                 is_new_until: Some("2095-01-01".to_string()),
+                exclude_partner_code_from_telemetry: true,
             }),
         },
     });
@@ -868,6 +872,7 @@ mod tests {
                         search_term_param_name: Some("url".to_string()),
                         display_name: Some("Visual Search".to_string()),
                         is_new_until: Some("2095-01-01".to_string()),
+                        exclude_partner_code_from_telemetry: true,
                     }),
                 },
                 click_url: None
@@ -982,6 +987,7 @@ mod tests {
                         // locale is present in `display_name_map`.
                         display_name: Some("Visual Search en-GB".to_string()),
                         is_new_until: Some("2095-01-01".to_string()),
+                        exclude_partner_code_from_telemetry: true,
                     }),
                 },
                 click_url: None
@@ -1033,6 +1039,7 @@ mod tests {
                     experiment_config: None,
                 }]),
                 search_term_param_name: Some("trend".to_string()),
+                exclude_partner_code_from_telemetry: true,
                 ..Default::default()
             }),
             search_form: Some(JSONEngineUrl {
@@ -1065,6 +1072,7 @@ mod tests {
                     ),
                 ])),
                 is_new_until: Some("2096-02-02".to_string()),
+                ..Default::default()
             }),
         }),
         sub_variants: vec![],
@@ -1131,6 +1139,7 @@ mod tests {
                             experiment_config: None,
                         }],
                         search_term_param_name: Some("trend".to_string()),
+                        exclude_partner_code_from_telemetry: true,
                         ..Default::default()
                     }),
                     search_form: Some(SearchEngineUrl {
@@ -1158,6 +1167,7 @@ mod tests {
                         // locale isn't present in `display_name_map`.
                         display_name: Some("Visual Search Variant".to_string()),
                         is_new_until: Some("2096-02-02".to_string()),
+                        exclude_partner_code_from_telemetry: false,
                     }),
                 },
                 click_url: None
@@ -1227,6 +1237,7 @@ mod tests {
                             experiment_config: None,
                         }],
                         search_term_param_name: Some("trend".to_string()),
+                        exclude_partner_code_from_telemetry: true,
                         ..Default::default()
                     }),
                     search_form: Some(SearchEngineUrl {
@@ -1254,6 +1265,7 @@ mod tests {
                         // locale is present in `display_name_map`.
                         display_name: Some("Visual Search Variant en-GB".to_string()),
                         is_new_until: Some("2096-02-02".to_string()),
+                        exclude_partner_code_from_telemetry: false,
                     }),
                 },
                 click_url: None
@@ -1293,6 +1305,7 @@ mod tests {
                     experiment_config: None,
                 }]),
                 search_term_param_name: Some("subvariant".to_string()),
+                exclude_partner_code_from_telemetry: true,
                 ..Default::default()
             }),
             trending: Some(JSONEngineUrl {
@@ -1340,6 +1353,7 @@ mod tests {
                     ),
                 ])),
                 is_new_until: Some("2097-03-03".to_string()),
+                ..Default::default()
             }),
         }),
         sub_variants: vec![],
@@ -1394,6 +1408,7 @@ mod tests {
                             experiment_config: None,
                         }],
                         search_term_param_name: Some("subvariant".to_string()),
+                        exclude_partner_code_from_telemetry: true,
                         ..Default::default()
                     }),
                     trending: Some(SearchEngineUrl {
@@ -1433,6 +1448,7 @@ mod tests {
                         // locale isn't present in `display_name_map`.
                         display_name: Some("Visual Search Subvariant".to_string()),
                         is_new_until: Some("2097-03-03".to_string()),
+                        exclude_partner_code_from_telemetry: false,
                     }),
                 },
                 click_url: None
@@ -1490,6 +1506,7 @@ mod tests {
                             experiment_config: None,
                         }],
                         search_term_param_name: Some("subvariant".to_string()),
+                        exclude_partner_code_from_telemetry: true,
                         ..Default::default()
                     }),
                     trending: Some(SearchEngineUrl {
@@ -1529,6 +1546,7 @@ mod tests {
                         // locale is present in `display_name_map`.
                         display_name: Some("Visual Search Subvariant en-GB".to_string()),
                         is_new_until: Some("2097-03-03".to_string()),
+                        exclude_partner_code_from_telemetry: false,
                     }),
                 },
                 click_url: None

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -136,6 +136,11 @@ pub struct SearchEngineUrl {
     /// (format: YYYY-MM-DD).
     #[uniffi(default = None)]
     pub is_new_until: Option<String>,
+
+    /// Whether the engine's partner code should be excluded from telemetry when
+    /// this URL is visited.
+    #[uniffi(default = false)]
+    pub exclude_partner_code_from_telemetry: bool,
 }
 
 /// The URLs associated with the search engine.


### PR DESCRIPTION
This is a speculative PR that adds `SearchEngineUrl::exclude_partner_code_from_telemetry` so that `BrowserSearchTelemetry` can know it should exclude the partner code for Google Lens from `sap.counts`. It's based on #6854.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
