### PR TITLE
Bug 1980205 - Avoid env-filter feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,15 +2883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4123,7 +4114,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4131,9 +4122,6 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
 
 [[package]]
 name = "regex-automata"
@@ -4143,14 +4131,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5567,12 +5549,8 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers",
- "once_cell",
- "regex",
  "sharded-slab",
  "thread_local",
- "tracing",
  "tracing-core",
 ]
 

--- a/components/support/tracing/Cargo.toml
+++ b/components/support/tracing/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [features]
-testing = [ "tracing-subscriber/env-filter" ]
+testing = []
 
 [dependencies]
 parking_lot = "0.12"
@@ -15,7 +15,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["f
 uniffi = { version = "0.29.0" }
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", default-features = false }
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features = ["build"] }

--- a/components/support/tracing/src/testing.rs
+++ b/components/support/tracing/src/testing.rs
@@ -2,13 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::sync::Once;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use std::{env, sync::Once};
+use tracing_subscriber::{
+    filter::{targets::Targets, LevelFilter},
+    fmt,
+    prelude::*,
+};
 
 static TESTING_SUBSCRIBER: Once = Once::new();
 
-/// Initialize a logging environment suitable for testing. Logging can be configured in the
-/// environment (eg, via the `RUST_LOG_LEVEL` variable), and if not so configured, will
+/// Initialize a logging environment suitable for testing. Logging can be configured using the
+/// `RUST_LOG` env variable, using a syntax that more-or-less matches the `env_logger` behavior.
+/// See `build_targets_from_env` for the exact behavior.  If not so configured, the filter will
 /// default to the `Level::Error` level.
 pub fn init_for_tests() {
     // This is intended to be equivalent to `env_logger::try_init().ok();`
@@ -16,7 +21,7 @@ pub fn init_for_tests() {
     TESTING_SUBSCRIBER.call_once(|| {
         tracing_subscriber::registry()
             .with(fmt::layer())
-            .with(EnvFilter::from_default_env())
+            .with(build_targets_from_env(LevelFilter::ERROR))
             .init();
     });
 }
@@ -25,15 +30,55 @@ pub fn init_for_tests() {
 pub fn init_for_tests_with_level(level: crate::Level) {
     // This is intended to be equivalent to `env_logger::try_init().ok();`
     // `debug!()` output is seen. We could maybe add logging for `#[tracing::instrument]`?
-    let level: tracing::Level = level.into();
     TESTING_SUBSCRIBER.call_once(|| {
         tracing_subscriber::registry()
             .with(fmt::layer())
-            .with(
-                EnvFilter::builder()
-                    .with_default_directive(level.into())
-                    .from_env_lossy(),
-            )
+            .with(build_targets_from_env(LevelFilter::from_level(
+                level.into(),
+            )))
             .init();
     });
+}
+
+fn build_targets_from_env(default: LevelFilter) -> Targets {
+    let mut targets = Targets::new().with_default(default);
+    let Ok(env) = env::var("RUST_LOG") else {
+        return targets;
+    };
+    for item in env.split(",") {
+        let item = item.trim();
+        match item.split_once("=") {
+            Some((target, level)) => {
+                let level = match try_parse_level(level) {
+                    Some(level) => level,
+                    None => {
+                        println!("Invalid logging level, defaulting to error: {level}");
+                        LevelFilter::ERROR
+                    }
+                };
+                targets = targets.with_target(target, level);
+            }
+            None => match try_parse_level(item) {
+                Some(level) => {
+                    targets = targets.with_default(level);
+                }
+                None => {
+                    targets = targets.with_target(item, LevelFilter::TRACE);
+                }
+            },
+        }
+    }
+    targets
+}
+
+fn try_parse_level(env_part: &str) -> Option<LevelFilter> {
+    match env_part.to_lowercase().as_str() {
+        "error" => Some(LevelFilter::ERROR),
+        "warn" | "warning" => Some(LevelFilter::WARN),
+        "info" => Some(LevelFilter::INFO),
+        "debug" => Some(LevelFilter::DEBUG),
+        "trace" => Some(LevelFilter::TRACE),
+        "off" => Some(LevelFilter::OFF),
+        _ => None,
+    }
 }


### PR DESCRIPTION
Instead use the `Targets` filter, with some basic ENV parsing.  This avoids a dependency on `matchers`, which will prevent duplicate dependencies when we move into moz-central (`regex-autonoma` and `regex-syntax`).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
