### PR TITLE
Bug 1980208 - Add viaduct-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,19 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,12 +207,6 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -279,9 +260,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http",
+ "http-body",
+ "hyper",
  "itoa",
  "matchit",
  "memchr",
@@ -309,8 +290,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "mime",
  "rustversion",
  "tower-layer",
@@ -744,7 +725,7 @@ dependencies = [
  "url",
  "uuid",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1263,12 +1244,13 @@ dependencies = [
  "fxa-client",
  "interrupt-support",
  "log",
+ "nss",
  "rusqlite",
  "serde_json",
  "sql-support",
  "sync-guid",
  "sync15",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1318,6 +1300,7 @@ dependencies = [
  "fxa-client",
  "interrupt-support",
  "log",
+ "nss",
  "places",
  "serde",
  "serde_derive",
@@ -1328,7 +1311,7 @@ dependencies = [
  "tempfile",
  "types",
  "url",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1339,7 +1322,7 @@ dependencies = [
  "push",
  "tempfile",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1364,7 +1347,7 @@ dependencies = [
  "tempfile",
  "text-table",
  "url",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1378,11 +1361,12 @@ dependencies = [
  "cli-support",
  "interrupt-support",
  "log",
+ "nss",
  "serde_json",
  "sync15",
  "tabs",
  "url",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1394,7 +1378,7 @@ dependencies = [
  "cli-support",
  "env_logger",
  "example-component",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1409,7 +1393,7 @@ dependencies = [
  "nss",
  "sync15",
  "url",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1421,7 +1405,7 @@ dependencies = [
  "env_logger",
  "log",
  "relay",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1438,7 +1422,7 @@ dependencies = [
  "places",
  "relevancy",
  "sync15",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1454,13 +1438,13 @@ dependencies = [
  "log",
  "nss",
  "remote_settings",
- "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",
- "tokio",
- "viaduct-reqwest",
+ "url",
+ "viaduct",
+ "viaduct-dev",
  "walkdir",
  "zip",
 ]
@@ -1477,7 +1461,7 @@ dependencies = [
  "nss",
  "remote_settings",
  "suggest",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1756,7 +1740,7 @@ dependencies = [
  "uniffi",
  "url",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -1877,26 +1861,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.9",
- "indexmap 2.5.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.5.0",
  "slab",
  "tokio",
@@ -2017,47 +1982,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http 0.2.9",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.1.0",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
-dependencies = [
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
  "pin-project-lite",
 ]
 
@@ -2104,37 +2035,17 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
- "http 0.2.9",
- "http-body 0.4.5",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
  "want",
 ]
 
@@ -2145,46 +2056,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.27",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.5.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.5.0",
- "pin-project-lite",
- "socket2 0.5.7",
- "tokio",
- "tower",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2921,7 +2796,7 @@ dependencies = [
  "clap 4.5.39",
  "merino",
  "serde_json",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -3072,12 +2947,11 @@ dependencies = [
  "copypasta",
  "glob",
  "heck 0.4.1",
- "hyper 0.14.27",
+ "hyper",
  "local-ip-address",
  "nimbus-fml",
  "percent-encoding",
  "remote_settings",
- "reqwest 0.11.18",
  "serde",
  "serde_json",
  "serde_yaml 0.9.21",
@@ -3088,7 +2962,8 @@ dependencies = [
  "tower-livereload",
  "unicode-segmentation",
  "update-informer",
- "viaduct-reqwest",
+ "viaduct",
+ "viaduct-dev",
  "whoami",
 ]
 
@@ -3116,7 +2991,6 @@ dependencies = [
  "jsonschema",
  "lazy_static",
  "regex",
- "reqwest 0.11.18",
  "serde",
  "serde_json",
  "serde_yaml 0.8.24",
@@ -3127,6 +3001,7 @@ dependencies = [
  "unicode-segmentation",
  "uniffi",
  "url",
+ "viaduct",
 ]
 
 [[package]]
@@ -3156,7 +3031,7 @@ dependencies = [
  "uniffi",
  "url",
  "uuid",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -3781,7 +3656,7 @@ dependencies = [
  "uniffi",
  "url",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -3971,7 +3846,7 @@ dependencies = [
  "uniffi",
  "url",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -4023,7 +3898,7 @@ dependencies = [
  "uniffi",
  "url",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -4032,17 +3907,16 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "async-compression",
  "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper 0.14.27",
- "hyper-tls 0.5.0",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
@@ -4056,55 +3930,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.10.1",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.0",
- "hyper-tls 0.6.0",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -4281,21 +4112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
-
-[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4378,7 +4194,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "uniffi",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -4545,15 +4361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,16 +4438,6 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4754,7 +4551,7 @@ dependencies = [
  "uniffi",
  "url",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -4824,7 +4621,7 @@ dependencies = [
  "tabs",
  "url",
  "viaduct",
- "viaduct-reqwest",
+ "viaduct-dev",
 ]
 
 [[package]]
@@ -4889,27 +4686,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5157,10 +4933,8 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -5252,8 +5026,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "http-range-header",
  "httpdate",
  "mime",
@@ -5280,8 +5054,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e90e6da0427c5e111e03c764d49c4e970f5a9f6569fe408e5a1cbe257f48388"
 dependencies = [
  "bytes",
- "http 0.2.9",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tokio",
  "tower",
@@ -5657,12 +5431,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "viaduct-dev"
+version = "0.2.0"
+dependencies = [
+ "clap 4.5.39",
+ "error-support",
+ "hyper",
+ "hyper-tls",
+ "once_cell",
+ "tokio",
+ "url",
+ "viaduct",
+]
+
+[[package]]
 name = "viaduct-reqwest"
 version = "0.2.0"
 dependencies = [
  "error-support",
  "once_cell",
- "reqwest 0.11.18",
+ "reqwest",
  "viaduct",
 ]
 
@@ -6009,15 +5797,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -6234,16 +6013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "components/support/text-table",
     "components/support/tracing",
     "components/support/types",
+    "components/support/viaduct-dev",
     "components/support/viaduct-reqwest",
     "components/sync_manager",
     "components/sync15",

--- a/components/context_id/Cargo.toml
+++ b/components/context_id/Cargo.toml
@@ -22,4 +22,4 @@ viaduct = { path = "../viaduct" }
 
 [dev-dependencies]
 mockito = "0.31"
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }

--- a/components/context_id/src/mars.rs
+++ b/components/context_id/src/mars.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn test_delete() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let expected_context_id = "some-fake-context-id";
         let expected_body = format!(r#"{{"context_id":"{}"}}"#, expected_context_id);

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -33,7 +33,7 @@ nss = { path = "../support/rc_crypto/nss" }
 uniffi = { version = "0.29.0", features = ["build"] }
 
 [dev-dependencies]
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }
 mockall = "0.12"
 mockito = "0.31"
 

--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -1043,7 +1043,7 @@ mod tests {
 
     #[test]
     fn test_backoff() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock("POST", "/v1/account/devices/invoke_command")
             .with_status(429)
             .with_header("Content-Type", "application/json")
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[test]
     fn test_backoff_then_ok() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock("POST", "/v1/account/devices/invoke_command")
             .with_status(429)
             .with_header("Content-Type", "application/json")
@@ -1140,7 +1140,7 @@ mod tests {
 
     #[test]
     fn test_backoff_per_path() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m1 = mock("POST", "/v1/account/devices/invoke_command")
             .with_status(429)
             .with_header("Content-Type", "application/json")

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -570,6 +570,7 @@ mod tests {
 
     #[test]
     fn test_get_auth_state() {
+        viaduct_dev::use_dev_backend();
         let config = Config::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
 

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -608,7 +608,7 @@ mod tests {
     fn test_oauth_flow_url() {
         nss::ensure_initialized();
         // FIXME: this test shouldn't make network requests.
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let config = Config::new(
             "https://accounts.firefox.com",
             "12345678",
@@ -702,7 +702,7 @@ mod tests {
     fn test_webchannel_context_url() {
         nss::ensure_initialized();
         // FIXME: this test shouldn't make network requests.
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
         let config = Config::new(
             "https://accounts.firefox.com",
@@ -1086,6 +1086,7 @@ mod tests {
     #[test]
     fn test_oauth_request_sent_with_session_when_available() {
         nss::ensure_initialized();
+        viaduct_dev::use_dev_backend();
         let config = Config::new(
             "https://accounts.firefox.com",
             "12345678",

--- a/components/fxa-client/src/internal/push.rs
+++ b/components/fxa-client/src/internal/push.rs
@@ -168,6 +168,7 @@ mod tests {
 
     #[test]
     fn test_push_device_disconnected_local() {
+        viaduct_dev::use_dev_backend();
         let mut fxa =
             FirefoxAccount::with_config(Config::stable_dev("12345678", "https://foo.bar"));
         let refresh_token_scopes = std::collections::HashSet::new();

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -46,7 +46,7 @@ uniffi = { version = "0.29.0", features = ["build"] }
 
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }
 clap = { version = "4.2", default-features = false, features = ["std", "derive"] }
 tempfile = "3"
 ctor = "0.2.2"

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
     // Possible values are "info", "debug", "warn" and "error"
     // Check [`env_logger`](https://docs.rs/env_logger/) for more details
     error_support::init_for_tests_with_level(error_support::Level::Info);
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
 
     // Initiate the matches for the command line arguments
     let args = Args::parse();

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -31,5 +31,5 @@ mockito = "0.31"
 hex = "0.4"
 tempfile = "3.1.0"
 mockall = "0.12"
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }
 nss = { path = "../support/rc_crypto/nss" }

--- a/components/push/src/internal/communications.rs
+++ b/components/push/src/internal/communications.rs
@@ -399,7 +399,7 @@ mod test {
 
     #[test]
     fn test_communications() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         // mockito forces task serialization, so for now, we test everything in one go.
         let config = PushConfiguration {
             http_protocol: Protocol::Http,

--- a/components/relay/Cargo.toml
+++ b/components/relay/Cargo.toml
@@ -17,7 +17,7 @@ uniffi = "0.29.0"
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
 expect-test = "1.4"
 mockito = "0.31"
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features=["build"]}

--- a/components/relay/src/lib.rs
+++ b/components/relay/src/lib.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_fetch_addresses() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let addresses_json = base_addresses_json(
             r#""used_on": "example.com", "last_used_at": "2021-01-03T00:00:00Z", "#,
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_fetch_addresses_used_on_null() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let addresses_json =
             base_addresses_json(r#""used_on": null,"last_used_at": "2021-01-03T00:00:00Z","#);
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_fetch_addresses_last_used_at_null() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let addresses_json =
             base_addresses_json(r#""used_on": "example.com","last_used_at": null,"#);
@@ -255,7 +255,7 @@ mod tests {
         token: Option<&str>,
         expect_error: bool,
     ) {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let mut mock = mock("POST", "/api/v1/terms-accepted-user/").with_status(status_code);
 
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_create_address() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let address_json = r#"
         {

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -39,7 +39,7 @@ uniffi = { version = "0.29.0", features = ["build"] }
 
 [dev-dependencies]
 expect-test = "1.4"
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }
 mockall = "0.12"
 mockito = "0.31"
 # We add the perserve_order feature to guarantee ordering of the keys in our

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -1277,7 +1277,7 @@ mod test {
 
     #[test]
     fn test_attachment_can_be_downloaded() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let server_info_m = mock("GET", "/v1/")
             .with_body(attachment_metadata(mockito::server_url()))
             .with_status(200)
@@ -1316,7 +1316,7 @@ mod test {
 
     #[test]
     fn test_attachment_errors_if_server_not_configured_for_attachments() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let server_info_m = mock("GET", "/v1/")
             .with_body(NO_ATTACHMENTS_METADATA)
             .with_status(200)
@@ -1352,7 +1352,7 @@ mod test {
 
     #[test]
     fn test_backoff() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -1381,7 +1381,7 @@ mod test {
 
     #[test]
     fn test_500_retry_after() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -1407,7 +1407,7 @@ mod test {
 
     #[test]
     fn test_options() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -1531,7 +1531,7 @@ mod test {
 
     #[test]
     fn test_backoff_recovery() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -1574,7 +1574,7 @@ mod test {
 
     #[test]
     fn test_record_fields() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -1662,7 +1662,7 @@ mod test {
 
     #[test]
     fn test_missing_etag() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -1693,7 +1693,7 @@ mod test {
 
     #[test]
     fn test_invalid_etag() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -270,7 +270,7 @@ mod test {
 
     #[test]
     fn test_get_records() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -300,7 +300,7 @@ mod test {
 
     #[test]
     fn test_get_records_since() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let m = mock(
             "GET",
             "/v1/buckets/the-bucket/collections/the-collection/records",
@@ -335,7 +335,7 @@ mod test {
     // #[test]
     #[allow(dead_code)]
     fn test_download() {
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
         let config = RemoteSettingsConfig {
             server: Some(RemoteSettingsServer::Custom {
                 url: "http://localhost:8888".into(),

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -24,4 +24,4 @@ uniffi = { version = "0.29.0", features = ["build"] }
 error-support = { path = "../support/error", features = ["testing"] }
 once_cell = "1.18.0"
 mockito = "0.31"
-viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+viaduct-dev = { path = "../support/viaduct-dev" }

--- a/components/search/src/selector.rs
+++ b/components/search/src/selector.rs
@@ -1964,7 +1964,7 @@ mod tests {
         expect_sync_successful: bool,
     ) -> Arc<SearchEngineSelector> {
         error_support::init_for_tests();
-        viaduct_reqwest::use_reqwest_backend();
+        viaduct_dev::use_dev_backend();
 
         let config = RemoteSettingsConfig2 {
             server: Some(RemoteSettingsServer::Custom {

--- a/components/suggest/Cargo.toml
+++ b/components/suggest/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1"
 error-support = { path = "../support/error" }
 sql-support = { path = "../support/sql" }
 viaduct = { path = "../viaduct" }
-viaduct-reqwest = { path = "../support/viaduct-reqwest", optional=true }
+viaduct-dev = { path = "../support/viaduct-dev", optional=true }
 tempfile = { version = "3.2.0", optional = true }
 thiserror = "1"
 # This is an old version of `unicase` but it's the one mozilla-central uses.
@@ -44,7 +44,7 @@ uniffi = { version = "0.29.0", features = ["build"] }
 
 [features]
 # Required for the benchmarks to work, wasted bytes otherwise.
-benchmark_api = ["tempfile", "viaduct-reqwest"]
+benchmark_api = ["tempfile", "viaduct-dev"]
 
 [lib]
 bench = false

--- a/components/suggest/benches/benchmark_all.rs
+++ b/components/suggest/benches/benchmark_all.rs
@@ -49,7 +49,7 @@ fn run_benchmarks<B: BenchmarkWithInput, M: Measurement>(
 
 fn setup_viaduct() {
     static INIT: Once = Once::new();
-    INIT.call_once(viaduct_reqwest::use_reqwest_backend);
+    INIT.call_once(viaduct_dev::use_dev_backend);
 }
 
 criterion_group!(benches, geoname, ingest, query);

--- a/components/suggest/src/benchmarks/ingest.rs
+++ b/components/suggest/src/benchmarks/ingest.rs
@@ -184,7 +184,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, IngestBenchmark)> {
 }
 
 pub fn print_debug_ingestion_sizes() {
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     let store = SuggestStoreInner::new(
         "file:debug_ingestion_sizes?mode=memory&cache=shared",
         vec![],

--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -19,19 +19,19 @@ serde_json = "1"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.29"
 unicode-segmentation = "1.8.0"
-viaduct-reqwest = { path = "../viaduct-reqwest" }
+viaduct = { path = "../../viaduct" }
+viaduct-dev = { path = "../viaduct-dev" }
 console = "0.15.5"
 glob = "0.3.1"
 heck = "0.4.1"
 whoami = "1.4.0"
 update-informer = { version = "1.0.0", default-features = false }
-reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "native-tls-vendored", "gzip", "json"] }
 serde_yaml = "0.9.21"
 percent-encoding = "2.3.0"
 copypasta = "0.8.2"
 chrono = "0.4.26"
 axum = { version = "0.6.18", optional = true }
-tokio = { version = "1.29.1", optional = true, features = ["sync", "rt", "macros"] }
+tokio = { version = "1.29.1", optional = true, features = ["sync", "rt", "macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4.1", optional = true, features = ["fs", "set-header"] }
 tower-livereload = { version = "0.8.0", optional = true }

--- a/components/support/nimbus-cli/src/output/server.rs
+++ b/components/support/nimbus-cli/src/output/server.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 use std::{
@@ -186,14 +186,13 @@ impl StartAppPostPayload {
 fn post_payload<T: Serialize>(payload: &T, addr: &str) -> Result<String> {
     let url = format!("http://{addr}/post");
     let body = serde_json::to_string(payload)?;
-    let req = reqwest::blocking::Client::new()
-        .post(url)
-        .header("Content-type", "application/json; charset=UTF-8")
-        .header("accept", "application/json")
+    let req = viaduct::Request::post(viaduct::parse_url(&url)?)
+        .header("Content-type", "application/json; charset=UTF-8")?
+        .header("accept", "application/json")?
         .body(body);
     let resp = req.send()?;
 
-    Ok(resp.text()?)
+    Ok(resp.text().to_string())
 }
 
 struct InMemoryDb {

--- a/components/support/nimbus-cli/src/sources/experiment.rs
+++ b/components/support/nimbus-cli/src/sources/experiment.rs
@@ -215,12 +215,8 @@ impl TryFrom<&ExperimentSource> for Value {
             }
             ExperimentSource::FromApiV6 { slug, endpoint } => {
                 let url = format!("{endpoint}/api/v6/experiments/{slug}/");
-                let req = reqwest::blocking::Client::builder()
-                    .user_agent(USER_AGENT)
-                    .gzip(true)
-                    .build()?
-                    .get(url);
-
+                let req = viaduct::Request::get(viaduct::parse_url(&url)?)
+                    .header("User-Agent", USER_AGENT)?;
                 req.send()?.json()?
             }
             ExperimentSource::FromFeatureFiles {

--- a/components/support/nimbus-cli/src/sources/experiment_list.rs
+++ b/components/support/nimbus-cli/src/sources/experiment_list.rs
@@ -220,7 +220,7 @@ impl TryFrom<&ExperimentListSource> for Value {
                 is_preview,
             } => {
                 use remote_settings::{RemoteSettings, RemoteSettingsConfig, RemoteSettingsServer};
-                viaduct_reqwest::use_reqwest_backend();
+                viaduct_dev::use_dev_backend();
                 let collection_name = if *is_preview {
                     "nimbus-preview".to_string()
                 } else {
@@ -257,11 +257,8 @@ impl TryFrom<&ExperimentListSource> for Value {
             ExperimentListSource::FromApiV6 { endpoint } => {
                 let url = format!("{endpoint}/api/v6/experiments/");
 
-                let req = reqwest::blocking::Client::builder()
-                    .user_agent(USER_AGENT)
-                    .gzip(true)
-                    .build()?
-                    .get(url);
+                let req = viaduct::Request::get(viaduct::parse_url(&url)?)
+                    .header("User-Agent", USER_AGENT)?;
 
                 let resp = req.send()?;
                 let data: Value = resp.json()?;

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -25,7 +25,6 @@ textwrap = "0.14.2"
 heck = "0.3.3"
 unicode-segmentation = "1.8.0"
 url = { version = "2", features = ["serde"] }
-reqwest = { version = "0.11", features = ["blocking", "json", "native-tls-vendored"] }
 glob = "0.3.0"
 uniffi = { version = "0.29.0", optional = true }
 cfg-if = "1.0.0"
@@ -35,6 +34,7 @@ email_address = { version = "0.2.4", features = ["serde"] }
 sha2 = "^0.10"
 itertools = "0"
 regex = "1.9"
+viaduct = { path = "../../viaduct/" }
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features = ["build"], optional = true }

--- a/components/support/nimbus-fml/src/error.rs
+++ b/components/support/nimbus-fml/src/error.rs
@@ -21,7 +21,12 @@ pub enum FMLError {
     RegexError(#[from] regex::Error),
 
     #[error("Fetch Error: {0}")]
-    FetchError(#[from] reqwest::Error),
+    FetchError(#[from] viaduct::Error),
+    #[error("Invalid Response Status: {0}")]
+    ResponseStatusError(#[from] viaduct::UnexpectedStatus),
+    #[error("UTF8 Decoding Error: {0}")]
+    Utf8DecodingError(#[from] std::string::FromUtf8Error),
+
     #[error("Can't find file: {0}")]
     InvalidPath(String),
 

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -9,7 +9,8 @@ typedef string EmailAddress;
 
 [Error]
 enum FMLError {
-    "IOError", "JSONError", "YAMLError", "UrlError", "EmailError", "RegexError", "FetchError", "InvalidPath",
+    "IOError", "JSONError", "YAMLError", "UrlError", "EmailError", "RegexError", "FetchError",
+    "ResponseStatusError", "Utf8DecodingError", "InvalidPath",
     "TemplateProblem", "Fatal", "InternalError", "ValidationError", "TypeParsingError",
     "InvalidChannelError", "FMLModuleError", "CliError", "ClientError", "InvalidFeatureError",
     "InvalidApiToken",

--- a/components/support/viaduct-dev/Cargo.toml
+++ b/components/support/viaduct-dev/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "viaduct-dev"
+version = "0.2.0"
+authors = ["Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+error-support = { path = "../error" }
+viaduct = { path = "../../viaduct" }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
+hyper-tls = { version = "0.5", features = ["vendored"] }
+tokio = { version = "1", features = ["rt"] }
+once_cell = "1.5"
+url = "2"
+
+[dev-dependencies]
+clap = { version = "4.2", default-features = false, features = ["std", "derive"]}

--- a/components/support/viaduct-dev/examples/client.rs
+++ b/components/support/viaduct-dev/examples/client.rs
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use clap::Parser;
+use url::Url;
+use viaduct::Request;
+use viaduct_dev::{use_dev_backend, Result};
+
+#[derive(Parser)]
+struct Args {
+    url: String,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let url = Url::parse(&args.url)?;
+    use_dev_backend();
+    let resp = Request::get(url.clone()).send()?;
+    if resp.url != url {
+        println!("Redirected URL: {}", resp.url);
+    }
+    println!("status: {}", resp.status);
+    for header in resp.headers.into_vec() {
+        println!("{}: {}", header.name(), header.value());
+    }
+    println!();
+    println!("{}", String::from_utf8_lossy(&resp.body));
+
+    Ok(())
+}

--- a/components/support/viaduct-dev/src/errors.rs
+++ b/components/support/viaduct-dev/src/errors.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub trait MapError {
+    type Ok;
+
+    fn map_to_viaduct_error(self) -> Result<Self::Ok, viaduct::Error>;
+}
+
+impl<T, E: ToString> MapError for Result<T, E> {
+    type Ok = T;
+
+    fn map_to_viaduct_error(self) -> Result<T, viaduct::Error> {
+        self.map_err(|e| viaduct::Error::BackendError(e.to_string()))
+    }
+}
+
+pub fn backend_error<T>(msg: impl Into<String>) -> Result<T, viaduct::Error> {
+    Err(viaduct::Error::BackendError(msg.into()))
+}

--- a/components/support/viaduct-dev/src/lib.rs
+++ b/components/support/viaduct-dev/src/lib.rs
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod errors;
+
+use error_support::warn;
+use errors::{backend_error, MapError};
+use std::sync::Once;
+use url::Url;
+use viaduct::Backend;
+
+pub type Result<T, E = viaduct::Error> = std::result::Result<T, E>;
+
+type Connector = hyper_tls::HttpsConnector<hyper::client::connect::HttpConnector>;
+type Client = hyper::client::Client<Connector, hyper::Body>;
+
+fn make_request(
+    runtime: &tokio::runtime::Runtime,
+    client: &Client,
+    request: viaduct::Request,
+) -> Result<hyper::Response<Vec<u8>>, viaduct::Error> {
+    let mut builder = hyper::Request::builder()
+        .uri(url_into_hyper_uri(request.url)?)
+        .method(match request.method {
+            viaduct::Method::Get => hyper::Method::GET,
+            viaduct::Method::Head => hyper::Method::HEAD,
+            viaduct::Method::Post => hyper::Method::POST,
+            viaduct::Method::Put => hyper::Method::PUT,
+            viaduct::Method::Delete => hyper::Method::DELETE,
+            viaduct::Method::Connect => hyper::Method::CONNECT,
+            viaduct::Method::Options => hyper::Method::OPTIONS,
+            viaduct::Method::Trace => hyper::Method::TRACE,
+            viaduct::Method::Patch => hyper::Method::PATCH,
+        });
+    for h in request.headers {
+        let name =
+            hyper::http::HeaderName::from_bytes(h.name().as_bytes()).map_to_viaduct_error()?;
+        let value = hyper::http::HeaderValue::from_str(h.value()).map_to_viaduct_error()?;
+        builder.headers_mut().unwrap().insert(name, value);
+    }
+    let req = builder
+        .body(hyper::Body::from(request.body.unwrap_or_default()))
+        .map_to_viaduct_error()?;
+    runtime
+        .block_on(async move {
+            let (parts, body) = client.request(req).await?.into_parts();
+            let body = hyper::body::to_bytes(body).await?;
+            hyper::Result::Ok(hyper::Response::from_parts(parts, body.to_vec()))
+        })
+        .map_to_viaduct_error()
+}
+
+pub struct DevBackend {
+    runtime: tokio::runtime::Runtime,
+    client: Client,
+}
+
+impl DevBackend {
+    fn new() -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .enable_io()
+            .build()
+            .unwrap();
+        let client = hyper::Client::<()>::builder().build(hyper_tls::HttpsConnector::new());
+        Self { runtime, client }
+    }
+}
+
+impl Backend for DevBackend {
+    fn send(&self, request: viaduct::Request) -> Result<viaduct::Response, viaduct::Error> {
+        viaduct::note_backend("dev");
+        let request_method = request.method;
+        let mut url = request.url.clone();
+        let mut resp = make_request(&self.runtime, &self.client, request.clone())?;
+        let mut redirect_count = 0;
+        while resp.status().is_redirection() {
+            redirect_count += 1;
+            if redirect_count > 10 {
+                return backend_error("Too many redirections");
+            }
+            let Some(location) = resp.headers().get("location") else {
+                return backend_error("location header missing");
+            };
+            url = Url::parse(location.to_str().map_to_viaduct_error()?)?;
+            let new_request = viaduct::Request {
+                method: request.method,
+                url: url.clone(),
+                headers: request.headers.clone(),
+                body: None,
+            };
+            resp = make_request(&self.runtime, &self.client, new_request)?;
+        }
+
+        let status = resp.status().as_u16();
+
+        let mut headers = viaduct::Headers::with_capacity(resp.headers().len());
+        for (k, v) in resp.headers() {
+            let val = String::from_utf8_lossy(v.as_bytes()).to_string();
+            let hname = match viaduct::HeaderName::new(k.as_str().to_owned()) {
+                Ok(name) => name,
+                Err(e) => {
+                    // Ignore headers with invalid names, since nobody can look for them anyway.
+                    warn!("Server sent back invalid header name: '{}'", e);
+                    continue;
+                }
+            };
+            // Not using Header::new since the error it returns is for request headers.
+            headers.insert_header(viaduct::Header::new_unchecked(hname, val));
+        }
+        Ok(viaduct::Response {
+            request_method,
+            url,
+            status,
+            headers,
+            body: resp.into_body(),
+        })
+    }
+}
+
+fn url_into_hyper_uri(url: url::Url) -> Result<hyper::Uri> {
+    hyper::Uri::builder()
+        .scheme(url.scheme())
+        .authority(url.authority())
+        .path_and_query(match url.query() {
+            None => url.path().to_string(),
+            Some(query) => format!("{}?{}", url.path(), query),
+        })
+        .build()
+        .map_to_viaduct_error()
+}
+
+static INIT_DEV_BACKEND: Once = Once::new();
+
+pub fn use_dev_backend() {
+    INIT_DEV_BACKEND.call_once(|| {
+        viaduct::set_backend(Box::leak(Box::new(DevBackend::new())))
+            .expect("Backend already set (FFI)");
+    })
+}

--- a/components/viaduct/src/lib.rs
+++ b/components/viaduct/src/lib.rs
@@ -369,3 +369,7 @@ pub mod status_codes {
         (505, HTTP_VERSION_NOT_SUPPORTED),
     ];
 }
+
+pub fn parse_url(url: &str) -> Result<Url, Error> {
+    Ok(Url::parse(url)?)
+}

--- a/examples/autofill-utils/Cargo.toml
+++ b/examples/autofill-utils/Cargo.toml
@@ -18,10 +18,11 @@ cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }
 error-support = { path = "../../components/support/error" }
 interrupt-support = { path = "../../components/support/interrupt" } # XXX - should be removed once we do interrupts correctly!
+nss = { path = "../../components/support/rc_crypto/nss" }
 log = "0.4"
 rusqlite = { version = "0.37.0", features = ["functions", "bundled", "serde_json", "unlock_notify"]}
 serde_json = "1"
 sql-support = { path = "../../components/support/sql" }
 sync-guid = { path = "../../components/support/guid", features = ["rusqlite_support", "random"] }
 sync15 = { path = "../../components/sync15" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -474,7 +474,8 @@ fn get_encryption_key(store: &Store, db_path: &str, opts: &Opts) -> Result<Strin
 }
 
 fn main() -> Result<()> {
-    viaduct_reqwest::use_reqwest_backend();
+    nss::ensure_initialized();
+    viaduct_dev::use_dev_backend();
 
     let opts = Opts::parse();
     if !opts.no_logging {

--- a/examples/example-cli/Cargo.toml
+++ b/examples/example-cli/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cli-support = { path = "../cli-support" }
 example-component = { path = "../../components/example" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0"
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }

--- a/examples/example-cli/src/main.rs
+++ b/examples/example-cli/src/main.rs
@@ -92,8 +92,8 @@ fn main() -> ApiResult<()> {
     let cli = Cli::parse();
     init_logging(&cli);
     // Applications must initialize viaduct for the HTTP client to work.
-    // This example uses the `reqwest` backend because it's easy to setup.
-    viaduct_reqwest::use_reqwest_backend();
+    // This example uses the `dev` backend because it's easy to setup.
+    viaduct_dev::use_dev_backend();
     let component = build_example_component()?;
     println!();
     match cli.command {

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 nss = { path = "../../components/support/rc_crypto/nss" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 log = "0.4"
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 cli-support = { path = "../cli-support" }

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -68,7 +68,7 @@ enum Command {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     nss::ensure_initialized();
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     if cli.log {
         if cli.debug {
             init_logging_with("debug");

--- a/examples/fxa-client/src/oauth-flow.rs
+++ b/examples/fxa-client/src/oauth-flow.rs
@@ -11,7 +11,7 @@ const REDIRECT_URI: &str = "https://mozilla.github.io/notes/fxa/android-redirect
 const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
 
 fn main() {
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     let config = FxaConfig::dev(CLIENT_ID, REDIRECT_URI);
     let fxa = FirefoxAccount::new(config);
     let url = fxa

--- a/examples/merino-cli/Cargo.toml
+++ b/examples/merino-cli/Cargo.toml
@@ -11,4 +11,4 @@ clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0"
 serde_json = "1.0"
 merino = { path = "../../components/merino" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }

--- a/examples/merino-cli/src/main.rs
+++ b/examples/merino-cli/src/main.rs
@@ -38,7 +38,7 @@ enum Commands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     let config = CuratedRecommendationsConfig {
         base_host: cli.base_host.clone(),
         user_agent_header: cli.user_agent.clone(),

--- a/examples/places-utils/Cargo.toml
+++ b/examples/places-utils/Cargo.toml
@@ -16,9 +16,10 @@ sync-guid = { path = "../../components/support/guid" }
 types = { path = "../../components/support/types" }
 error-support = { path = "../../components/support/error" }
 interrupt-support = { path = "../../components/support/interrupt" }
+nss = { path = "../../components/support/rc_crypto/nss" }
 sql-support = { path = "../../components/support/sql", features = ["debug-tools"] }
 sync15 = { path = "../../components/sync15" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -25,7 +25,7 @@ use sync15::engine::{EngineSyncAssociation, SyncEngine, SyncEngineId};
 use sync_guid::Guid as SyncGuid;
 use types::Timestamp;
 use url::Url;
-use viaduct_reqwest::use_reqwest_backend;
+use viaduct_dev::use_dev_backend;
 
 use anyhow::Result;
 
@@ -235,7 +235,7 @@ fn sync(
     nsyncs: u32,
     wait: u64,
 ) -> Result<()> {
-    use_reqwest_backend();
+    use_dev_backend();
 
     let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
 
@@ -444,6 +444,7 @@ enum Command {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+    nss::ensure_initialized();
     if !opts.no_logging {
         cli_support::init_trace_logging();
     }

--- a/examples/push-livetest/Cargo.toml
+++ b/examples/push-livetest/Cargo.toml
@@ -12,7 +12,7 @@ name = "push-livetest"
 
 [dev-dependencies]
 push = { path = "../../components/push" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 viaduct = { path = "../../components/viaduct" }
 hex = "0.4"
 tempfile = "3"

--- a/examples/push-livetest/src/livetest.rs
+++ b/examples/push-livetest/src/livetest.rs
@@ -14,7 +14,7 @@ use push::{BridgeType, PushConfiguration, PushManager};
  */
 fn test_live_server() {
     let tempdir = tempfile::tempdir().unwrap();
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
 
     let push_config = PushConfiguration {
         server_host: "localhost:8082".to_string(),

--- a/examples/relay-cli/Cargo.toml
+++ b/examples/relay-cli/Cargo.toml
@@ -11,4 +11,4 @@ clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
 log = "0.4"
 relay = { path = "../../components/relay" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }

--- a/examples/relay-cli/src/main.rs
+++ b/examples/relay-cli/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     init_logging(&cli);
 
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
 
     let token = prompt_token()?;
     let client = RelayClient::new("https://relay.firefox.com".to_string(), Some(token));

--- a/examples/relevancy-cli/Cargo.toml
+++ b/examples/relevancy-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 log = "0.4"
 env_logger = { version = "0.10", default-features = false }
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}

--- a/examples/relevancy-cli/src/main.rs
+++ b/examples/relevancy-cli/src/main.rs
@@ -37,7 +37,7 @@ struct Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     nss::ensure_initialized();
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     if let Some(dir) = std::path::PathBuf::from(CREDENTIALS_PATH).parent() {
         std::fs::create_dir_all(dir)?;
     }

--- a/examples/remote-settings-cli/Cargo.toml
+++ b/examples/remote-settings-cli/Cargo.toml
@@ -13,18 +13,18 @@ path = "src/dump/lib.rs"
 cli-support = { path = "../cli-support" }
 remote_settings = { features = ["signatures"], path = "../../components/remote_settings" }
 nss = { path = "../../components/support/rc_crypto/nss" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct = { path = "../../components/viaduct" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 log = "0.4"
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0"
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
-reqwest = { version = "0.12", features = ["json"] }
 serde_json = "1"
 futures = "0.3"
 indicatif = "0.17"
-tokio = { version = "1.29.1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.31"
+url = "2"
 walkdir = "2.4.0"
 zip = "2.1"
 sha2 = "^0.10"

--- a/examples/remote-settings-cli/src/dump/error.rs
+++ b/examples/remote-settings-cli/src/dump/error.rs
@@ -9,7 +9,7 @@ pub type Result<T> = anyhow::Result<T>;
 #[derive(Error, Debug)]
 pub enum RemoteSettingsError {
     #[error("Network error: {0}")]
-    Network(#[from] reqwest::Error),
+    Network(#[from] viaduct::Error),
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),
     #[error("JSON error: {0}")]

--- a/examples/remote-settings-cli/src/main.rs
+++ b/examples/remote-settings-cli/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
         },
     ));
     nss::ensure_initialized();
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     let service = build_service(&cli)?;
     match cli.command {
         Commands::Sync { collections } => sync(service, collections),
@@ -97,8 +97,7 @@ fn main() -> Result<()> {
         }
         Commands::DumpSync { path, dry_run } => {
             let downloader = CollectionDownloader::new(path);
-            let runtime = tokio::runtime::Runtime::new()?;
-            runtime.block_on(downloader.run(dry_run))
+            downloader.run(dry_run)
         }
         Commands::DumpGet {
             bucket,
@@ -106,8 +105,7 @@ fn main() -> Result<()> {
             path,
         } => {
             let downloader = CollectionDownloader::new(path);
-            let runtime = tokio::runtime::Runtime::new()?;
-            runtime.block_on(downloader.download_single(&bucket, &collection_name))
+            downloader.download_single(&bucket, &collection_name)
         }
     }
 }

--- a/examples/suggest-cli/Cargo.toml
+++ b/examples/suggest-cli/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cli-support = { path = "../cli-support" }
 remote_settings = { path = "../../components/remote_settings" }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 log = "0.4"
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 suggest = { path = "../../components/suggest" }

--- a/examples/suggest-cli/src/main.rs
+++ b/examples/suggest-cli/src/main.rs
@@ -117,7 +117,7 @@ fn main() -> Result<()> {
         },
     ));
     nss::ensure_initialized();
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     let store = build_store(&cli)?;
     match cli.command {
         Commands::Ingest {

--- a/examples/sync-pass/Cargo.toml
+++ b/examples/sync-pass/Cargo.toml
@@ -26,7 +26,7 @@ cli-support = { path = "../cli-support" }
 tempfile = "3"
 serde_json = "1.0"
 url = "2.2"
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 rusqlite = { version = "0.37.0", features = ["limits"] }
 init_rust_components = { path = "../../components/init_rust_components", features = ["keydb"] }
 

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -364,7 +364,7 @@ fn do_sync(
 #[allow(clippy::cognitive_complexity)] // FIXME
 fn main() -> Result<()> {
     cli_support::init_trace_logging();
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
 
     let matches = clap::Command::new("sync_pass_sql")
         .about("CLI login syncing tool")

--- a/examples/tabs-sync/Cargo.toml
+++ b/examples/tabs-sync/Cargo.toml
@@ -21,5 +21,6 @@ clap = { version = "4.2", default-features = false, features = ["std", "derive"]
 cli-support = { path = "../cli-support" }
 url = "2.2"
 interrupt-support = { path = "../../components/support/interrupt" }
+nss = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }
 sync15 = { path = "../../components/sync15", features = ["sync-engine"] }
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -98,7 +98,8 @@ fn do_sync(
 }
 
 fn main() -> Result<()> {
-    viaduct_reqwest::use_reqwest_backend();
+    nss::ensure_initialized();
+    viaduct_dev::use_dev_backend();
     cli_support::init_logging();
     let opts = Opts::parse();
 

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -78,7 +78,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: base64</name>
-    <url>https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/marshallpierce/rust-base64/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: basic-toml</name>
@@ -150,7 +150,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: fallible-iterator</name>
-    <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/sfackler/rust-fallible-iterator/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: fallible-streaming-iterator</name>
@@ -174,7 +174,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: getrandom</name>
-    <url>https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rust-random/getrandom/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: glob</name>
@@ -250,7 +250,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: log</name>
-    <url>https://github.com/rust-lang/log/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rust-lang/log/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: mime</name>
@@ -262,7 +262,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: num-traits</name>
-    <url>https://github.com/rust-num/num-traits/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rust-num/num-traits/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: once_cell</name>
@@ -306,7 +306,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: proc-macro2</name>
-    <url>https://github.com/dtolnay/proc-macro2/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/dtolnay/proc-macro2/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: prost</name>
@@ -346,15 +346,15 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: rinja</name>
-    <url>https://github.com/rinja-rs/rinja/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rinja-rs/rinja/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: rinja_derive</name>
-    <url>https://github.com/rinja-rs/rinja/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rinja-rs/rinja/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: rinja_parser</name>
-    <url>https://github.com/rinja-rs/rinja/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rinja-rs/rinja/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: rkv</name>
@@ -370,7 +370,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: ryu</name>
-    <url>https://github.com/dtolnay/ryu/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/dtolnay/ryu/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: scopeguard</name>
@@ -398,7 +398,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: sha2</name>
-    <url>https://github.com/RustCrypto/hashes/blob/master/sha2/LICENSE-APACHE</url>
+    <url>https://github.com/RustCrypto/hashes/blob/main/sha2/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: shlex</name>
@@ -442,7 +442,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: thread_local</name>
-    <url>https://github.com/Amanieu/thread_local-rs/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/Amanieu/thread_local-rs/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: tinyvec</name>
@@ -490,7 +490,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: vcpkg</name>
-    <url>https://github.com/mcgoo/vcpkg-rs/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/mcgoo/vcpkg-rs/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: version_check</name>
@@ -526,11 +526,11 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>MIT License: byteorder</name>
-    <url>https://github.com/BurntSushi/byteorder/blob/master/LICENSE-MIT</url>
+    <url>https://github.com/BurntSushi/byteorder/blob/main/LICENSE-MIT</url>
   </license>
   <license>
     <name>MIT License: memchr</name>
-    <url>https://github.com/BurntSushi/memchr/blob/master/LICENSE-MIT</url>
+    <url>https://github.com/BurntSushi/memchr/blob/main/LICENSE-MIT</url>
   </license>
   <license>
     <name>MIT License: bincode</name>
@@ -546,11 +546,11 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>MIT License: caseless</name>
-    <url>https://github.com/SimonSapin/rust-caseless/blob/master/LICENSE</url>
+    <url>https://github.com/SimonSapin/rust-caseless/blob/main/LICENSE</url>
   </license>
   <license>
     <name>MIT License: extend</name>
-    <url>https://github.com/davidpdrsn/extend/blob/master/LICENSE</url>
+    <url>https://github.com/davidpdrsn/extend/blob/main/LICENSE</url>
   </license>
   <license>
     <name>MIT License: generic-array</name>
@@ -642,7 +642,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>BSD-2-Clause License: arrayref</name>
-    <url>https://github.com/droundy/arrayref/blob/master/LICENSE</url>
+    <url>https://github.com/droundy/arrayref/blob/main/LICENSE</url>
   </license>
   <license>
     <name>BSD-3-Clause License: protobuf</name>

--- a/pkcs11.txt
+++ b/pkcs11.txt
@@ -1,0 +1,5 @@
+library=
+name=NSS Internal PKCS #11 Module
+parameters=configdir='./' certPrefix='' keyPrefix='' secmod='' flags=forceOpen,optimizeSpace updatedir='' updateCertPrefix='' updateKeyPrefix='' updateid='' updateTokenDescription='' 
+NSS=Flags=internal,critical trustOrder=75 cipherOrder=100 slotParams=(1={slotFlags=[ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] askpw=any timeout=30})
+

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+viaduct-dev = { path = "../../components/support/viaduct-dev" }
 viaduct = { path = "../../components/viaduct"}
 autofill = { path = "../../components/autofill" }
 logins = { path = "../../components/logins" }

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -28,7 +28,7 @@ macro_rules! cleanup_clients {
 }
 
 pub fn init_testing() {
-    viaduct_reqwest::use_reqwest_backend();
+    viaduct_dev::use_dev_backend();
     ensure_initialized();
 
     // Enable backtraces.
@@ -38,7 +38,7 @@ pub fn init_testing() {
     // level), which get turned on at the warn level. This can still be
     // overridden with RUST_LOG, however.
     let log_filter = "trace,tokio_threadpool=warn,tokio_reactor=warn,tokio_core=warn,tokio=warn,\
-         hyper=warn,want=warn,mio=warn,reqwest=warn,trust_dns_proto=warn,trust_dns_resolver=warn";
+         hyper=warn,want=warn,mio=warn,trust_dns_proto=warn,trust_dns_resolver=warn";
     env_logger::init_from_env(env_logger::Env::default().filter_or("RUST_LOG", log_filter));
 }
 


### PR DESCRIPTION
This is somewhat hacked together, but it seems to be working okay.  I named it "viaduct-dev" to signal that it's probably not ready for real usage.

Most of the usage were just example CLIs and unit tests and I think it should work fine for that.  The only crates I'm not sure of are `nimbus-cli` and `nimbus-fml`.  @freshstrangemusic how critical is the HTTP functionality to these crates?  If I introduced a bug, is it something that would just result in some CI failures, or would it be worse that that?

I think this gets us close to eliminating any dupe-dependencies from moz-central, but after I had this together I realized there were several more loose ends to take care of.  I'll try to look into those more next week.

Also:
 - Updated `tokio` to 1.29 -> 1.45 to match the Desktop version.
 - Added `nss::ensure_initialized` call to some examples.
 - Removed `reqwest` dependency from `remote-settings-cli`.  It now just uses `viaduct` directly.  This means it's async rather than sync now, which is too bad, but maybe we can implement an async viaduct soon.
 - `sync-test` is failing for me, but it was also failing before.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
