### PR TITLE
Bug 1980758 - Add `SearchEngineUrl::accepted_content_types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Added `SearchEngineUrl::is_new_until` ([bug 1979962](https://bugzilla.mozilla.org/show_bug.cgi?id=1979962))
 - Added `SearchEngineUrl::exclude_partner_code_from_telemetry` ([bug 1980474](https://bugzilla.mozilla.org/show_bug.cgi?id=1980474))
+- Added `SearchEngineUrl::accepted_content_types`
 
 [Full Changelog](In progress)
 

--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -69,6 +69,14 @@ pub(crate) struct JSONEngineUrl {
     /// this URL is visited.
     #[serde(default)]
     pub exclude_partner_code_from_telemetry: bool,
+
+    /// If this URL performs searches only for certain MIME types, they should
+    /// be listed here. If this value is `None`, then it's assumed the content
+    /// type is irrelevant. This field is intended to be used for URLs like
+    /// visual search, which might support certain image types and not others.
+    /// Consumers can use it to determine whether search UI corresponding to the
+    /// URL should be shown to the user in a given context.
+    pub accepted_content_types: Option<Vec<String>>,
 }
 
 /// Reflects `types::SearchEngineUrls`, but using `EngineUrl`.

--- a/components/search/src/filter.rs
+++ b/components/search/src/filter.rs
@@ -26,6 +26,7 @@ impl Default for SearchEngineUrl {
             display_name: Default::default(),
             is_new_until: Default::default(),
             exclude_partner_code_from_telemetry: Default::default(),
+            accepted_content_types: Default::default(),
         }
     }
 }
@@ -52,6 +53,9 @@ impl SearchEngineUrl {
         }
         if let Some(is_new_until) = &preferred.is_new_until {
             self.is_new_until = Some(is_new_until.clone());
+        }
+        if let Some(accepted_content_types) = &preferred.accepted_content_types {
+            self.accepted_content_types = Some(accepted_content_types.clone());
         }
         self.exclude_partner_code_from_telemetry = preferred.exclude_partner_code_from_telemetry;
     }
@@ -501,6 +505,7 @@ mod tests {
                 display_name: None,
                 is_new_until: None,
                 exclude_partner_code_from_telemetry: false,
+                accepted_content_types: None,
             },
         );
     }
@@ -764,6 +769,10 @@ mod tests {
                 ])),
                 is_new_until: Some("2095-01-01".to_string()),
                 exclude_partner_code_from_telemetry: true,
+                accepted_content_types: Some(vec![
+                    "image/gif".to_string(),
+                    "image/jpeg".to_string(),
+                ]),
             }),
         },
     });
@@ -873,6 +882,10 @@ mod tests {
                         display_name: Some("Visual Search".to_string()),
                         is_new_until: Some("2095-01-01".to_string()),
                         exclude_partner_code_from_telemetry: true,
+                        accepted_content_types: Some(vec![
+                            "image/gif".to_string(),
+                            "image/jpeg".to_string(),
+                        ]),
                     }),
                 },
                 click_url: None
@@ -988,6 +1001,10 @@ mod tests {
                         display_name: Some("Visual Search en-GB".to_string()),
                         is_new_until: Some("2095-01-01".to_string()),
                         exclude_partner_code_from_telemetry: true,
+                        accepted_content_types: Some(vec![
+                            "image/gif".to_string(),
+                            "image/jpeg".to_string(),
+                        ]),
                     }),
                 },
                 click_url: None
@@ -1072,6 +1089,10 @@ mod tests {
                     ),
                 ])),
                 is_new_until: Some("2096-02-02".to_string()),
+                accepted_content_types: Some(vec![
+                    "image/png".to_string(),
+                    "image/jpeg".to_string(),
+                ]),
                 ..Default::default()
             }),
         }),
@@ -1168,6 +1189,10 @@ mod tests {
                         display_name: Some("Visual Search Variant".to_string()),
                         is_new_until: Some("2096-02-02".to_string()),
                         exclude_partner_code_from_telemetry: false,
+                        accepted_content_types: Some(vec![
+                            "image/png".to_string(),
+                            "image/jpeg".to_string(),
+                        ]),
                     }),
                 },
                 click_url: None
@@ -1266,6 +1291,10 @@ mod tests {
                         display_name: Some("Visual Search Variant en-GB".to_string()),
                         is_new_until: Some("2096-02-02".to_string()),
                         exclude_partner_code_from_telemetry: false,
+                        accepted_content_types: Some(vec![
+                            "image/png".to_string(),
+                            "image/jpeg".to_string(),
+                        ]),
                     }),
                 },
                 click_url: None
@@ -1353,6 +1382,10 @@ mod tests {
                     ),
                 ])),
                 is_new_until: Some("2097-03-03".to_string()),
+                accepted_content_types: Some(vec![
+                    "image/jpeg".to_string(),
+                    "image/webp".to_string(),
+                ]),
                 ..Default::default()
             }),
         }),
@@ -1449,6 +1482,10 @@ mod tests {
                         display_name: Some("Visual Search Subvariant".to_string()),
                         is_new_until: Some("2097-03-03".to_string()),
                         exclude_partner_code_from_telemetry: false,
+                        accepted_content_types: Some(vec![
+                            "image/jpeg".to_string(),
+                            "image/webp".to_string(),
+                        ]),
                     }),
                 },
                 click_url: None
@@ -1547,6 +1584,10 @@ mod tests {
                         display_name: Some("Visual Search Subvariant en-GB".to_string()),
                         is_new_until: Some("2097-03-03".to_string()),
                         exclude_partner_code_from_telemetry: false,
+                        accepted_content_types: Some(vec![
+                            "image/jpeg".to_string(),
+                            "image/webp".to_string(),
+                        ]),
                     }),
                 },
                 click_url: None

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -141,6 +141,15 @@ pub struct SearchEngineUrl {
     /// this URL is visited.
     #[uniffi(default = false)]
     pub exclude_partner_code_from_telemetry: bool,
+
+    /// If this URL performs searches only for certain MIME types, they should
+    /// be listed here. If `None`, it's assumed the content type is text or not
+    /// relevant. This field is intended to be used for URLs like visual search,
+    /// which might support certain image types and not others. Consumers can
+    /// use it to determine whether search UI corresponding to the URL should be
+    /// shown to the user in a given context.
+    #[uniffi(default = None)]
+    pub accepted_content_types: Option<Vec<String>>,
 }
 
 /// The URLs associated with the search engine.


### PR DESCRIPTION
This adds `SearchEngineUrl::accepted_content_types` so consumers can know which image types are supported by a visual search URL.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
