### PR TITLE
Bug 1925091 - [ci full] Make Android FxaAccountManager supply comma-separate list of values for service=sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Glean
 - Updated to v65.0.0 ([#6901](https://github.com/mozilla/application-services/pull/6901))
 
+### Android
+- Added service parameter to fxa-client flow allowing clients to specify the list of services to request. ([bug 1925091](https://bugzilla.mozilla.org/show_bug.cgi?id=1925091))
+
 # v143.0 (_2025-08-18_)
 
 ## 🦊 What's Changed 🦊

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -113,9 +113,10 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
     fun beginOAuthFlow(
         scopes: Array<String>,
         entrypoint: String,
+        services: List<String> = listOf("sync"),
     ): String {
         return withMetrics {
-            this.inner.beginOauthFlow(scopes.toList(), entrypoint)
+            this.inner.beginOauthFlow(scopes.toList(), entrypoint, services)
         }
     }
 
@@ -133,9 +134,10 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
         pairingUrl: String,
         scopes: Array<String>,
         entrypoint: String,
+        services: List<String> = listOf("sync"),
     ): String {
         return withMetrics {
-            this.inner.beginPairingFlow(pairingUrl, scopes.toList(), entrypoint)
+            this.inner.beginPairingFlow(pairingUrl, scopes.toList(), entrypoint, services)
         }
     }
 

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -85,10 +85,10 @@ impl FirefoxAccount {
         // Allow both &[String] and &[&str] since UniFFI can't represent `&[&str]` yet,
         scopes: &[T],
         entrypoint: &str,
-        service: &[String],
+        service: &[T],
     ) -> ApiResult<String> {
         let scopes = scopes.iter().map(T::as_ref).collect::<Vec<_>>();
-        let service = service.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+        let service = service.iter().map(T::as_ref).collect::<Vec<_>>();
         self.internal
             .lock()
             .begin_oauth_flow(&scopes, entrypoint, &service)

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -76,6 +76,7 @@ impl FirefoxAccount {
     ///       - This parameter is used for metrics purposes, to identify the
     ///         UX entrypoint from which the user triggered the signin request.
     ///         For example, the application toolbar, on the onboarding flow.
+    ///   - `service` - list of services to request.
     ///   - `metrics` - optionally, additional metrics tracking parameters.
     ///       - These will be included as query parameters in the resulting URL.
     #[handle_error(Error)]
@@ -84,9 +85,13 @@ impl FirefoxAccount {
         // Allow both &[String] and &[&str] since UniFFI can't represent `&[&str]` yet,
         scopes: &[T],
         entrypoint: &str,
+        service: &[String],
     ) -> ApiResult<String> {
         let scopes = scopes.iter().map(T::as_ref).collect::<Vec<_>>();
-        self.internal.lock().begin_oauth_flow(&scopes, entrypoint)
+        let service = service.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+        self.internal
+            .lock()
+            .begin_oauth_flow(&scopes, entrypoint, &service)
     }
 
     /// Get the URL at which to begin a device-pairing signin flow.
@@ -121,6 +126,7 @@ impl FirefoxAccount {
     ///       - This parameter is used for metrics purposes, to identify the
     ///         UX entrypoint from which the user triggered the signin request.
     ///         For example, the application toolbar, on the onboarding flow.
+    ///   - `service` - list of services to request.
     ///   - `metrics` - optionally, additional metrics tracking parameters.
     ///       - These will be included as query parameters in the resulting URL.
     #[handle_error(Error)]
@@ -129,12 +135,14 @@ impl FirefoxAccount {
         pairing_url: &str,
         scopes: &[String],
         entrypoint: &str,
+        service: &[String],
     ) -> ApiResult<String> {
         // UniFFI can't represent `&[&str]` yet, so convert it internally here.
         let scopes = scopes.iter().map(String::as_str).collect::<Vec<_>>();
+        let service = service.iter().map(String::as_str).collect::<Vec<_>>();
         self.internal
             .lock()
-            .begin_pairing_flow(pairing_url, &scopes, entrypoint)
+            .begin_pairing_flow(pairing_url, &scopes, entrypoint, &service)
     }
 
     /// Complete an OAuth flow.
@@ -263,6 +271,7 @@ pub enum FxaEvent {
     BeginOAuthFlow {
         scopes: Vec<String>,
         entrypoint: String,
+        service: Vec<String>,
     },
     /// Begin an oauth flow using a URL from a pairing code
     ///
@@ -276,6 +285,7 @@ pub enum FxaEvent {
         pairing_url: String,
         scopes: Vec<String>,
         entrypoint: String,
+        service: Vec<String>,
     },
     /// Complete an OAuth flow.
     ///

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -189,13 +189,12 @@ interface FirefoxAccount {
   ///       - This parameter is used for metrics purposes, to identify the
   ///         UX entrypoint from which the user triggered the signin request.
   ///         For example, the application toolbar, on the onboarding flow.
+  ///   - `service` - list of services to request.
   ///   - `metrics` - optionally, additional metrics tracking parameters.
   ///       - These will be included as query parameters in the resulting URL.
   ///
   [Throws=FxaError]
-  string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint);
-  
-
+  string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint, [ByRef] optional sequence<string> service = []);
   /// Get the URL at which to begin a device-pairing signin flow.
   ///
   /// If the user wants to sign in using device pairing, call this method and then
@@ -228,12 +227,13 @@ interface FirefoxAccount {
   ///       - This parameter is used for metrics purposes, to identify the
   ///         UX entrypoint from which the user triggered the signin request.
   ///         For example, the application toolbar, on the onboarding flow.
+  ///   - `service` - list of services to request.
   ///   - `metrics` - optionally, additional metrics tracking parameters.
   ///       - These will be included as query parameters in the resulting URL.
   ///
   [Throws=FxaError]
-  string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint);
-  
+  string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint, [ByRef] optional sequence<string> service = []);
+
 
   /// Complete an OAuth flow.
   ///
@@ -1001,8 +1001,8 @@ interface FxaState {
 [Enum]
 interface FxaEvent {
   Initialize(DeviceConfig device_config);
-  BeginOAuthFlow(sequence<string> scopes, string entrypoint);
-  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint);
+  BeginOAuthFlow(sequence<string> scopes, string entrypoint, optional sequence<string> service);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint, optional sequence<string> service);
   CompleteOAuthFlow(string code, string state);
   CancelOAuthFlow();
   CheckAuthorizationStatus();
@@ -1137,8 +1137,8 @@ interface FxaStateCheckerEvent {
 [Enum]
 interface FxaStateCheckerState {
   GetAuthState();
-  BeginOAuthFlow(sequence<string> scopes, string entrypoint);
-  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint);
+  BeginOAuthFlow(sequence<string> scopes, string entrypoint, optional sequence<string> service);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint, optional sequence<string> service);
   CompleteOAuthFlow(string code, string state);
   InitializeDevice();
   EnsureDeviceCapabilities();

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -1001,8 +1001,8 @@ interface FxaState {
 [Enum]
 interface FxaEvent {
   Initialize(DeviceConfig device_config);
-  BeginOAuthFlow(sequence<string> scopes, string entrypoint, optional sequence<string> service);
-  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint, optional sequence<string> service);
+  BeginOAuthFlow(sequence<string> scopes, string entrypoint, sequence<string> service);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint, sequence<string> service);
   CompleteOAuthFlow(string code, string state);
   CancelOAuthFlow();
   CheckAuthorizationStatus();
@@ -1137,8 +1137,8 @@ interface FxaStateCheckerEvent {
 [Enum]
 interface FxaStateCheckerState {
   GetAuthState();
-  BeginOAuthFlow(sequence<string> scopes, string entrypoint, optional sequence<string> service);
-  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint, optional sequence<string> service);
+  BeginOAuthFlow(sequence<string> scopes, string entrypoint, sequence<string> service);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint, sequence<string> service);
   CompleteOAuthFlow(string code, string state);
   InitializeDevice();
   EnsureDeviceCapabilities();

--- a/components/fxa-client/src/state_machine/checker.rs
+++ b/components/fxa-client/src/state_machine/checker.rs
@@ -23,11 +23,13 @@ pub enum FxaStateCheckerState {
     BeginOAuthFlow {
         scopes: Vec<String>,
         entrypoint: String,
+        service: Vec<String>,
     },
     BeginPairingFlow {
         pairing_url: String,
         scopes: Vec<String>,
         entrypoint: String,
+        service: Vec<String>,
     },
     CompleteOAuthFlow {
         code: String,
@@ -217,17 +219,25 @@ impl From<InternalState> for FxaStateCheckerState {
     fn from(state: InternalState) -> Self {
         match state {
             InternalState::GetAuthState => Self::GetAuthState,
-            InternalState::BeginOAuthFlow { scopes, entrypoint } => {
-                Self::BeginOAuthFlow { scopes, entrypoint }
-            }
+            InternalState::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            } => Self::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            },
             InternalState::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             } => Self::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             },
             InternalState::CompleteOAuthFlow { code, state } => {
                 Self::CompleteOAuthFlow { code, state }
@@ -247,17 +257,25 @@ impl From<FxaStateCheckerState> for InternalState {
     fn from(state: FxaStateCheckerState) -> Self {
         match state {
             FxaStateCheckerState::GetAuthState => Self::GetAuthState,
-            FxaStateCheckerState::BeginOAuthFlow { scopes, entrypoint } => {
-                Self::BeginOAuthFlow { scopes, entrypoint }
-            }
+            FxaStateCheckerState::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            } => Self::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            },
             FxaStateCheckerState::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             } => Self::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             },
             FxaStateCheckerState::CompleteOAuthFlow { code, state } => {
                 Self::CompleteOAuthFlow { code, state }

--- a/components/fxa-client/src/state_machine/internal_machines/auth_issues.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/auth_issues.rs
@@ -14,9 +14,14 @@ use State::*;
 impl InternalStateMachine for AuthIssuesStateMachine {
     fn initial_state(&self, event: FxaEvent) -> Result<State> {
         match event {
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => Ok(BeginOAuthFlow {
+            FxaEvent::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            } => Ok(BeginOAuthFlow {
                 scopes: scopes.clone(),
                 entrypoint: entrypoint.clone(),
+                service: service.clone(),
             }),
             FxaEvent::Disconnect => Ok(Complete(FxaState::Disconnected)),
             e => Err(Error::InvalidStateTransition(format!("AuthIssues -> {e}"))),
@@ -46,6 +51,7 @@ mod test {
             FxaEvent::BeginOAuthFlow {
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             },
         );
 
@@ -53,7 +59,8 @@ mod test {
             tester.state,
             BeginOAuthFlow {
                 scopes: vec!["profile".to_owned()],
-                entrypoint: "test-entrypoint".to_owned()
+                entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             }
         );
         assert_eq!(tester.peek_next_state(CallError), Cancel);

--- a/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
@@ -21,17 +21,19 @@ impl InternalStateMachine for AuthenticatingStateMachine {
             FxaEvent::CancelOAuthFlow => Ok(Complete(FxaState::Disconnected)),
             // These next 2 cases allow apps to begin a new oauth flow when we're already in the
             // middle of an existing one.
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => {
-                Ok(State::BeginOAuthFlow { scopes, entrypoint })
+            FxaEvent::BeginOAuthFlow { scopes, entrypoint, service } => {
+                Ok(State::BeginOAuthFlow { scopes, entrypoint, service })
             }
             FxaEvent::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             } => Ok(State::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             }),
             e => Err(Error::InvalidStateTransition(format!(
                 "Authenticating -> {e}"
@@ -114,6 +116,7 @@ mod test {
             FxaEvent::BeginOAuthFlow {
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             },
         );
         assert_eq!(
@@ -121,6 +124,7 @@ mod test {
             BeginOAuthFlow {
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             }
         );
         assert_eq!(
@@ -146,6 +150,7 @@ mod test {
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             },
         );
         assert_eq!(
@@ -154,6 +159,7 @@ mod test {
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             }
         );
         assert_eq!(

--- a/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
@@ -21,9 +21,15 @@ impl InternalStateMachine for AuthenticatingStateMachine {
             FxaEvent::CancelOAuthFlow => Ok(Complete(FxaState::Disconnected)),
             // These next 2 cases allow apps to begin a new oauth flow when we're already in the
             // middle of an existing one.
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint, service } => {
-                Ok(State::BeginOAuthFlow { scopes, entrypoint, service })
-            }
+            FxaEvent::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            } => Ok(State::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            }),
             FxaEvent::BeginPairingFlow {
                 pairing_url,
                 scopes,

--- a/components/fxa-client/src/state_machine/internal_machines/disconnected.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/disconnected.rs
@@ -14,17 +14,25 @@ use State::*;
 impl InternalStateMachine for DisconnectedStateMachine {
     fn initial_state(&self, event: FxaEvent) -> Result<State> {
         match event {
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => {
-                Ok(State::BeginOAuthFlow { scopes, entrypoint })
-            }
+            FxaEvent::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            } => Ok(State::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            }),
             FxaEvent::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             } => Ok(State::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             }),
             e => Err(Error::InvalidStateTransition(format!(
                 "Disconnected -> {e}"
@@ -59,6 +67,7 @@ mod test {
             FxaEvent::BeginOAuthFlow {
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             },
         );
         assert_eq!(
@@ -66,6 +75,7 @@ mod test {
             BeginOAuthFlow {
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             }
         );
         assert_eq!(tester.peek_next_state(CallError), Cancel);
@@ -87,6 +97,7 @@ mod test {
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             },
         );
         assert_eq!(
@@ -95,6 +106,7 @@ mod test {
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                service: vec!["sync".to_owned()],
             }
         );
         assert_eq!(tester.peek_next_state(CallError), Cancel);

--- a/components/fxa-client/src/state_machine/internal_machines/mod.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/mod.rs
@@ -41,11 +41,13 @@ pub enum State {
     BeginOAuthFlow {
         scopes: Vec<String>,
         entrypoint: String,
+        service: Vec<String>,
     },
     BeginPairingFlow {
         pairing_url: String,
         scopes: Vec<String>,
         entrypoint: String,
+        service: Vec<String>,
     },
     CompleteOAuthFlow {
         code: String,
@@ -124,20 +126,28 @@ impl State {
                 account.ensure_capabilities(&device_config.capabilities)?;
                 Event::EnsureDeviceCapabilitiesSuccess
             }
-            State::BeginOAuthFlow { scopes, entrypoint } => {
+            State::BeginOAuthFlow {
+                scopes,
+                entrypoint,
+                service,
+            } => {
                 account.cancel_existing_oauth_flows();
                 let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
-                let oauth_url = account.begin_oauth_flow(&scopes, entrypoint)?;
+                let service: Vec<&str> = service.iter().map(AsRef::as_ref).collect();
+                let oauth_url = account.begin_oauth_flow(&scopes, entrypoint, &service)?;
                 Event::BeginOAuthFlowSuccess { oauth_url }
             }
             State::BeginPairingFlow {
                 pairing_url,
                 scopes,
                 entrypoint,
+                service,
             } => {
                 account.cancel_existing_oauth_flows();
                 let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
-                let oauth_url = account.begin_pairing_flow(pairing_url, &scopes, entrypoint)?;
+                let service: Vec<&str> = service.iter().map(AsRef::as_ref).collect();
+                let oauth_url =
+                    account.begin_pairing_flow(pairing_url, &scopes, entrypoint, &service)?;
                 Event::BeginPairingFlowSuccess { oauth_url }
             }
             State::CompleteOAuthFlow { code, state } => {

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -52,7 +52,7 @@ fn create_fxa_creds(path: &str, cfg: FxaConfig, scopes: &[&str]) -> Result<Firef
 }
 
 fn handle_oauth_flow(path: &str, acct: &FirefoxAccount, scopes: &[&str]) -> Result<()> {
-    let oauth_uri = acct.begin_oauth_flow(scopes, "fxa_creds", &["sync".to_string()])?;
+    let oauth_uri = acct.begin_oauth_flow(scopes, "fxa_creds", &["sync"])?;
 
     if open::that(&oauth_uri).is_err() {
         log::warn!("Failed to open a web browser D:");

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -52,7 +52,7 @@ fn create_fxa_creds(path: &str, cfg: FxaConfig, scopes: &[&str]) -> Result<Firef
 }
 
 fn handle_oauth_flow(path: &str, acct: &FirefoxAccount, scopes: &[&str]) -> Result<()> {
-    let oauth_uri = acct.begin_oauth_flow(scopes, "fxa_creds")?;
+    let oauth_uri = acct.begin_oauth_flow(scopes, "fxa_creds", &["sync".to_string()])?;
 
     if open::that(&oauth_uri).is_err() {
         log::warn!("Failed to open a web browser D:");


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
