### PR TITLE
DRAFT - feat: Adding new Mozilla Ads Client component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Mozilla Ads Client (MAC)
 
-- Added `mac`, a new component for integrating with the Mozilla Ads Routing Service (MARS) APIs.
+- Added `mac`, a new component which acts as an SDK for integrating with the Mozilla Ads Routing Service (MARS) APIs.
 
 [Full Changelog](In progress)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Added `SearchEngineUrl::is_new_until` ([bug 1979962](https://bugzilla.mozilla.org/show_bug.cgi?id=1979962))
 - Added `SearchEngineUrl::exclude_partner_code_from_telemetry` ([bug 1980474](https://bugzilla.mozilla.org/show_bug.cgi?id=1980474))
 
+### Mozilla Ads Client (MAC)
+
+- Added `mac`, a new component for integrating with the Mozilla Ads Routing Service (MARS) APIs.
+
 [Full Changelog](In progress)
 
 # v142.0 (_2025-07-21_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.0"
+dependencies = [
+ "error-support",
+ "mockall",
+ "mockito",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.31",
+ "uniffi",
+ "url",
+ "uuid",
+ "viaduct",
+ "viaduct-reqwest",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "components/fxa-client",
     "components/init_rust_components",
     "components/logins",
+    "components/mac",
     "components/merino",
     "components/nimbus",
     "components/places",

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ by the [uniffi](https://github.com/mozilla/uniffi-rs/) library.
   with FxA, access encryption keys for sync, and more.
 * [logins](components/logins) - for storage and syncing of a user's saved login
   credentials
+* [mac](/components/mac) - for fetching ads via UAPI
 * [nimbus](components/nimbus) - for integrating with Mozilla's [experimentation](https://mozilla.github.io/experimenter-docs/) platform for Firefox
 * [places](components/places) - for storage and syncing of a user's saved
   browsing history

--- a/components/mac/Cargo.toml
+++ b/components/mac/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "mac"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
+license = "MPL-2.0"
 
 [dependencies]
 parking_lot = "0.12"

--- a/components/mac/Cargo.toml
+++ b/components/mac/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mac"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+parking_lot = "0.12"
+serde = "1"
+serde_json = "1"
+url = "2"
+uniffi = { version = "0.29.0" }
+uuid = { version = "1.3", features = ["v4"] }
+viaduct = { path = "../viaduct" }
+error-support = { path = "../support/error" }
+thiserror = "1"
+
+[dev-dependencies]
+viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+mockito = "0.31"
+mockall = "0.11"
+
+[build-dependencies]
+uniffi = { version = "0.29.0", features = ["build"] }

--- a/components/mac/README.md
+++ b/components/mac/README.md
@@ -1,0 +1,19 @@
+# MAC
+
+## Overview
+
+Mozilla Ads Client (MAC) is a library that handles integration with the Mozilla Ads Routing Service (MARS). It is primarily intended for use on mobile surfaces, namely Firefox iOS and Android, but can be used by any surface able to ingest components from Application Services.
+
+MAC can request and display standard ad placements, and calls the appropriate callback URLs to send anonymized impressions and clicks back to Mozilla. MAC also provides a facility to report user dissatisfaction with ads so we can take appropriate action as necessary.
+
+Like MARS, MAC is privacy-first. It does not track user information and it does not send sensitive identifiable information to Mozilla. Of the information Mozilla does receive, anything shared with advertisers is aggregated and/or de-identified to preserve user privacy.
+
+While we welcome outside feedback and are committed to open source, this library is intended solely for use on Mozilla properties.
+
+## Tests
+
+Tests are run with
+
+```shell
+cargo test -p mac
+```

--- a/components/mac/src/error.rs
+++ b/components/mac/src/error.rs
@@ -3,7 +3,7 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-use error_support::{ErrorHandling, GetErrorHandling, error};
+use error_support::{error, ErrorHandling, GetErrorHandling};
 use viaduct::Response;
 
 pub type ApiResult<T> = std::result::Result<T, ApiError>;

--- a/components/mac/src/error.rs
+++ b/components/mac/src/error.rs
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use error_support::{ErrorHandling, GetErrorHandling, error};
+use viaduct::Response;
+
+pub type ApiResult<T> = std::result::Result<T, ApiError>;
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum ApiError {
+    #[error("Something unexpected occurred.")]
+    Other { reason: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentError {
+    #[error("Error requesting ads: {0}")]
+    RequestAds(#[from] RequestAdsError),
+
+    #[error("Error recording a click for a placement: {0}")]
+    RecordClick(#[from] RecordClickError),
+
+    #[error("Error recording an impressions for a placement: {0}")]
+    RecordImpression(#[from] RecordImpressionError),
+
+    #[error("Error reporting an ad: {0}")]
+    ReportAd(#[from] ReportAdError),
+}
+
+impl GetErrorHandling for ComponentError {
+    type ExternalError = ApiError;
+
+    fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError> {
+        ErrorHandling::convert(ApiError::Other {
+            reason: self.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RequestAdsError {
+    #[error("Error building ad requests from configs: {0}")]
+    BuildRequest(#[from] BuildRequestError),
+
+    #[error("Error requesting ads from MARS: {0}")]
+    FetchAds(#[from] FetchAdsError),
+
+    #[error("Error building placements from ad response: {0}")]
+    BuildPlacements(#[from] BuildPlacementsError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildRequestError {
+    #[error("Could not build request with empty placement configs")]
+    EmptyConfig,
+
+    #[error("Duplicate placement_id found: {placement_id}. Placement_ids must be unique.")]
+    DuplicatePlacementId { placement_id: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildPlacementsError {
+    #[error("Duplicate placement_id found: {placement_id}. Placement_ids must be unique.")]
+    DuplicatePlacementId { placement_id: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FetchAdsError {
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    #[error("Error sending request: {0}")]
+    Request(#[from] viaduct::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Could not fetch ads, MARS responded with: {0}")]
+    HTTPError(#[from] HTTPError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmitTelemetryError {
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    #[error("Error sending request: {0}")]
+    Request(#[from] viaduct::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Could not fetch ads, MARS responded with: {0}")]
+    HTTPError(#[from] HTTPError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CallbackRequestError {
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    #[error("Error sending request: {0}")]
+    Request(#[from] viaduct::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Could not fetch ads, MARS responded with: {0}")]
+    HTTPError(#[from] HTTPError),
+
+    #[error("Callback URL missing: {message}")]
+    MissingCallback { message: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordImpressionError {
+    #[error("Callback request to MARS failed: {0}")]
+    CallbackRequest(#[from] CallbackRequestError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordClickError {
+    #[error("Callback request to MARS failed: {0}")]
+    CallbackRequest(#[from] CallbackRequestError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReportAdError {
+    #[error("Callback request to MARS failed: {0}")]
+    CallbackRequest(#[from] CallbackRequestError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HTTPError {
+    #[error("Validation error ({code}): {message}")]
+    Validation { code: u16, message: String },
+
+    #[error("Bad request ({code}): {message}")]
+    BadRequest { code: u16, message: String },
+
+    #[error("Server error ({code}): {message}")]
+    Server { code: u16, message: String },
+
+    #[error("Unexpected error ({code}): {message}")]
+    Unexpected { code: u16, message: String },
+}
+
+pub fn check_http_status_for_error(response: &Response) -> Result<(), HTTPError> {
+    let status = response.status;
+    if status >= 400 {
+        let error_message = response.text();
+        let error = match status {
+            400 => HTTPError::BadRequest {
+                code: status,
+                message: error_message.to_string(),
+            },
+            422 => HTTPError::Validation {
+                code: status,
+                message: error_message.to_string(),
+            },
+            500..=599 => HTTPError::Server {
+                code: status,
+                message: error_message.to_string(),
+            },
+            _ => HTTPError::Unexpected {
+                code: status,
+                message: error_message.to_string(),
+            },
+        };
+        return Err(error);
+    }
+    Ok(())
+}

--- a/components/mac/src/instrument.rs
+++ b/components/mac/src/instrument.rs
@@ -1,0 +1,176 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use std::sync::LazyLock;
+
+use crate::error::{ComponentError, EmitTelemetryError};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use url::Url;
+use viaduct::Request;
+
+static DEFAULT_TELEMETRY_ENDPOINT: &str = "https://ads.allizom.org/v1/log";
+static TELEMETRY_ENDPONT: LazyLock<RwLock<String>> =
+    LazyLock::new(|| RwLock::new(DEFAULT_TELEMETRY_ENDPOINT.to_string()));
+
+#[allow(dead_code)]
+pub fn set_telemetry_endpoint(endpoint: String) {
+    let mut telemetry_endpoint_lock = TELEMETRY_ENDPONT.write();
+    *telemetry_endpoint_lock = endpoint;
+}
+
+fn get_telemetry_endpoint() -> String {
+    TELEMETRY_ENDPONT.read().clone()
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TelemetryEvent {
+    Init,
+    RenderError,
+    AdLoadError,
+    FetchError,
+    InvalidUrlError,
+}
+
+#[allow(dead_code)]
+pub trait TrackError<T, ComponentError> {
+    fn emit_telemetry_if_error(self) -> Self;
+    fn emit_telemetry_if_error_conditionally<F>(self, condition: F) -> Self
+    where
+        F: Fn(&ComponentError) -> bool;
+}
+
+impl<T> TrackError<T, ComponentError> for Result<T, ComponentError> {
+    /// Attempts to emit a telemetry event if the Error type can map to an event type.
+    fn emit_telemetry_if_error(self) -> Self {
+        if let Err(ref err) = self {
+            let error_type = map_error_to_event_type(err);
+            let _ = emit_telemetry_event(error_type);
+        }
+        self
+    }
+
+    /// Same as `emit_telemetry_if_error` but also requires the given closure `condition` returns true.
+    fn emit_telemetry_if_error_conditionally<F>(self, condition: F) -> Self
+    where
+        F: Fn(&ComponentError) -> bool,
+    {
+        if let Err(ref err) = self {
+            if condition(err) {
+                let error_type = map_error_to_event_type(err);
+                let _ = emit_telemetry_event(error_type);
+            }
+        }
+        self
+    }
+}
+
+fn map_error_to_event_type(err: &ComponentError) -> Option<TelemetryEvent> {
+    match err {
+        ComponentError::RequestAds(_) => Some(TelemetryEvent::FetchError),
+        ComponentError::RecordImpression(_) => Some(TelemetryEvent::InvalidUrlError),
+        ComponentError::RecordClick(_) => Some(TelemetryEvent::InvalidUrlError),
+        ComponentError::ReportAd(_) => Some(TelemetryEvent::InvalidUrlError),
+    }
+}
+
+pub fn emit_telemetry_event(event_type: Option<TelemetryEvent>) -> Result<(), EmitTelemetryError> {
+    let endpoint = get_telemetry_endpoint();
+    let mut url = Url::parse(&endpoint)?;
+    if let Some(event) = event_type {
+        let event_string = serde_json::to_string(&event)?;
+        url.set_query(Some(&format!("event={}", event_string)));
+        Request::get(url).send()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{CallbackRequestError, ComponentError, RecordClickError};
+    use mockito::mock;
+
+    #[test]
+    fn test_emit_telemetry_emits_telemetry_for_mappable_error() {
+        set_telemetry_endpoint(format!("{}{}", mockito::server_url(), "/v1/log"));
+        let mock = mock("GET", "/v1/log")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "event".into(),
+                "\"invalid_url_error\"".into(),
+            ))
+            .with_status(200)
+            .expect(1)
+            .create();
+
+        let result: Result<(), ComponentError> = Err(ComponentError::RecordClick(
+            RecordClickError::CallbackRequest(CallbackRequestError::MissingCallback {
+                message: "bad url".into(),
+            }),
+        ));
+
+        let res = result.emit_telemetry_if_error();
+
+        mock.assert();
+
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_emit_telemetry_conditionally_emits_only_when_condition_met() {
+        set_telemetry_endpoint(format!("{}{}", mockito::server_url(), "/v1/log"));
+
+        let mock_1 = mock("GET", "/v1/log")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "event".into(),
+                "\"invalid_url_error\"".into(),
+            ))
+            .with_status(200)
+            .expect(0)
+            .create();
+
+        let result_1: Result<(), ComponentError> = Err(ComponentError::RecordClick(
+            RecordClickError::CallbackRequest(CallbackRequestError::MissingCallback {
+                message: "bad url".into(),
+            }),
+        ));
+        let res_1 = result_1.emit_telemetry_if_error_conditionally(|_| false);
+        mock_1.assert();
+        assert!(res_1.is_err());
+
+        let mock_2 = mock("GET", "/v1/log")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "event".into(),
+                "\"invalid_url_error\"".into(),
+            ))
+            .with_status(200)
+            .expect(1)
+            .create();
+
+        let result_2: Result<(), ComponentError> = Err(ComponentError::RecordClick(
+            RecordClickError::CallbackRequest(CallbackRequestError::MissingCallback {
+                message: "bad url".into(),
+            }),
+        ));
+        let res_2 = result_2.emit_telemetry_if_error_conditionally(|_| true);
+        mock_2.assert();
+        assert!(res_2.is_err());
+    }
+
+    #[test]
+    fn test_emit_telemetry_event_on_ok_does_nothing() {
+        set_telemetry_endpoint(format!("{}{}", mockito::server_url(), "/v1/log"));
+
+        let mock = mock("GET", "/v1/log").with_status(200).expect(0).create();
+
+        let result: Result<String, ComponentError> =
+            Ok("All is good".to_string()).emit_telemetry_if_error();
+
+        mock.assert();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "All is good".to_string());
+    }
+}

--- a/components/mac/src/instrument.rs
+++ b/components/mac/src/instrument.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use viaduct::Request;
 
-static DEFAULT_TELEMETRY_ENDPOINT: &str = "https://ads.allizom.org/v1/log";
+static DEFAULT_TELEMETRY_ENDPOINT: &str = "https://ads.mozilla.org/v1/log";
 static TELEMETRY_ENDPONT: LazyLock<RwLock<String>> =
     LazyLock::new(|| RwLock::new(DEFAULT_TELEMETRY_ENDPOINT.to_string()));
 

--- a/components/mac/src/instrument.rs
+++ b/components/mac/src/instrument.rs
@@ -96,6 +96,7 @@ mod tests {
 
     #[test]
     fn test_emit_telemetry_emits_telemetry_for_mappable_error() {
+        viaduct_reqwest::use_reqwest_backend();
         set_telemetry_endpoint(format!("{}{}", mockito::server_url(), "/v1/log"));
         let mock = mock("GET", "/v1/log")
             .match_query(mockito::Matcher::UrlEncoded(
@@ -121,6 +122,7 @@ mod tests {
 
     #[test]
     fn test_emit_telemetry_conditionally_emits_only_when_condition_met() {
+        viaduct_reqwest::use_reqwest_backend();
         set_telemetry_endpoint(format!("{}{}", mockito::server_url(), "/v1/log"));
 
         let mock_1 = mock("GET", "/v1/log")
@@ -162,6 +164,7 @@ mod tests {
 
     #[test]
     fn test_emit_telemetry_event_on_ok_does_nothing() {
+        viaduct_reqwest::use_reqwest_backend();
         set_telemetry_endpoint(format!("{}{}", mockito::server_url(), "/v1/log"));
 
         let mock = mock("GET", "/v1/log").with_status(200).expect(0).create();

--- a/components/mac/src/lib.rs
+++ b/components/mac/src/lib.rs
@@ -606,4 +606,3 @@ mod tests {
         assert!(component.clear_cache().is_ok());
     }
 }
-

--- a/components/mac/src/lib.rs
+++ b/components/mac/src/lib.rs
@@ -1,0 +1,609 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use std::collections::{HashMap, HashSet};
+
+use error::ApiResult;
+use error::{
+    BuildPlacementsError, BuildRequestError, ComponentError, RecordClickError,
+    RecordImpressionError, ReportAdError, RequestAdsError,
+};
+use error_support::handle_error;
+use instrument::TrackError;
+use mars::{DefaultMARSClient, MARSClient};
+use models::{AdContentCategory, AdRequest, AdResponse, IABContentTaxonomy, MozAd};
+use parking_lot::Mutex;
+use uuid::Uuid;
+
+mod error;
+mod instrument;
+mod mars;
+mod models;
+mod test_utils;
+
+uniffi::setup_scaffolding!("MAC");
+
+/// Top-level API for the mac component
+#[derive(uniffi::Object)]
+pub struct MozAdsClient {
+    inner: Mutex<MozAdsClientInner>,
+}
+
+impl Default for MozAdsClient {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(MozAdsClientInner::new()),
+        }
+    }
+}
+
+#[uniffi::export]
+impl MozAdsClient {
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(MozAdsClientInner::new()),
+        }
+    }
+
+    #[handle_error(ComponentError)]
+    pub fn request_ads(
+        &self,
+        moz_ad_configs: Vec<MozAdsPlacementConfig>,
+    ) -> ApiResult<HashMap<String, MozAdsPlacement>> {
+        let inner = self.inner.lock();
+        let placements = inner
+            .request_ads(&moz_ad_configs)
+            .map_err(ComponentError::RequestAds)?;
+        Ok(placements)
+    }
+
+    #[handle_error(ComponentError)]
+    pub fn record_impression(&self, placement: MozAdsPlacement) -> ApiResult<()> {
+        let inner = self.inner.lock();
+        inner
+            .record_impression(&placement)
+            .map_err(ComponentError::RecordImpression)
+            .emit_telemetry_if_error()
+    }
+
+    #[handle_error(ComponentError)]
+    pub fn record_click(&self, placement: MozAdsPlacement) -> ApiResult<()> {
+        let inner = self.inner.lock();
+        inner
+            .record_click(&placement)
+            .map_err(ComponentError::RecordClick)
+            .emit_telemetry_if_error()
+    }
+
+    #[handle_error(ComponentError)]
+    pub fn report_ad(&self, placement: MozAdsPlacement) -> ApiResult<()> {
+        let inner = self.inner.lock();
+        inner
+            .report_ad(&placement)
+            .map_err(ComponentError::ReportAd)
+            .emit_telemetry_if_error()
+    }
+
+    pub fn cycle_context_id(&self) -> ApiResult<String> {
+        let mut inner = self.inner.lock();
+        let previous_context_id = inner.cycle_context_id();
+        Ok(previous_context_id)
+    }
+
+    pub fn clear_cache(&self) -> ApiResult<()> {
+        let mut inner = self.inner.lock();
+        inner.clear_cache();
+        Ok(())
+    }
+}
+
+pub struct MozAdsClientInner {
+    ads_cache: HashMap<String, MozAdsPlacement>, //TODO: implement caching
+    client: Box<dyn MARSClient>,
+}
+
+impl MozAdsClientInner {
+    fn new() -> Self {
+        let context_id = Uuid::new_v4().to_string();
+        let client = Box::new(DefaultMARSClient::new(context_id));
+        let ads_cache = HashMap::new(); //TODO: HashMap is a placeholder.
+        Self { ads_cache, client }
+    }
+
+    fn clear_cache(&mut self) {
+        self.ads_cache.clear();
+    }
+
+    fn request_ads(
+        &self,
+        moz_ad_configs: &Vec<MozAdsPlacementConfig>,
+    ) -> Result<HashMap<String, MozAdsPlacement>, RequestAdsError> {
+        let ad_request = self.build_request_from_placement_configs(moz_ad_configs)?;
+        let response = self.client.fetch_ads(&ad_request)?;
+        let placements = self.build_placements(moz_ad_configs, response)?;
+        Ok(placements)
+    }
+
+    fn record_impression(&self, placement: &MozAdsPlacement) -> Result<(), RecordImpressionError> {
+        let impression_callback = placement
+            .content
+            .callbacks
+            .as_ref()
+            .and_then(|callbacks| callbacks.impression.clone());
+
+        self.client.record_impression(impression_callback)?;
+        Ok(())
+    }
+
+    fn record_click(&self, placement: &MozAdsPlacement) -> Result<(), RecordClickError> {
+        let click_callback = placement
+            .content
+            .callbacks
+            .as_ref()
+            .and_then(|callbacks| callbacks.click.clone());
+
+        self.client.record_click(click_callback)?;
+        Ok(())
+    }
+
+    fn report_ad(&self, placement: &MozAdsPlacement) -> Result<(), ReportAdError> {
+        let report_ad_callback = placement
+            .content
+            .callbacks
+            .as_ref()
+            .and_then(|callbacks| callbacks.report.clone());
+
+        self.client.report_ad(report_ad_callback)?;
+        Ok(())
+    }
+
+    fn cycle_context_id(&mut self) -> String {
+        self.client.cycle_context_id()
+    }
+
+    fn build_request_from_placement_configs(
+        &self,
+        moz_ad_configs: &Vec<MozAdsPlacementConfig>,
+    ) -> Result<AdRequest, BuildRequestError> {
+        if moz_ad_configs.is_empty() {
+            return Err(BuildRequestError::EmptyConfig);
+        }
+
+        let context_id = self.client.get_context_id().to_string();
+        let mut request = AdRequest {
+            placements: vec![],
+            context_id,
+        };
+
+        let mut used_placement_ids: HashSet<&String> = HashSet::new();
+
+        for config in moz_ad_configs {
+            if used_placement_ids.contains(&config.placement_id) {
+                return Err(BuildRequestError::DuplicatePlacementId {
+                    placement_id: config.placement_id.clone(),
+                });
+            }
+
+            request.placements.push(models::AdPlacementRequest {
+                placement: config.placement_id.clone(),
+                count: 1, // Placement_id should be treated as unique, so count is always 1
+                content: config
+                    .iab_content
+                    .clone()
+                    .map(|iab_content| AdContentCategory {
+                        categories: iab_content.category_ids,
+                        taxonomy: iab_content.taxonomy,
+                    }),
+            });
+
+            used_placement_ids.insert(&config.placement_id);
+        }
+
+        Ok(request)
+    }
+
+    fn build_placements(
+        &self,
+        placement_configs: &Vec<MozAdsPlacementConfig>,
+        mut mars_response: AdResponse,
+    ) -> Result<HashMap<String, MozAdsPlacement>, BuildPlacementsError> {
+        let mut moz_ad_placements: HashMap<String, MozAdsPlacement> = HashMap::new();
+
+        for config in placement_configs {
+            let placement_content = mars_response.data.get_mut(&config.placement_id);
+
+            match placement_content {
+                Some(v) => {
+                    let ad_content = v.pop();
+                    match ad_content {
+                        Some(c) => {
+                            let is_updated = moz_ad_placements.insert(
+                                config.placement_id.clone(),
+                                MozAdsPlacement {
+                                    content: c,
+                                    placement_config: config.clone(),
+                                },
+                            );
+                            if let Some(v) = is_updated {
+                                return Err(BuildPlacementsError::DuplicatePlacementId {
+                                    placement_id: v.placement_config.placement_id,
+                                });
+                            }
+                        }
+                        None => continue,
+                    }
+                }
+                None => continue,
+            }
+        }
+
+        Ok(moz_ad_placements)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct IABContent {
+    pub taxonomy: IABContentTaxonomy,
+    pub category_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct MozAdsSize {
+    pub width: u16,
+    pub height: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct MozAdsPlacementConfig {
+    pub placement_id: String,
+    pub fixed_size: Option<MozAdsSize>,
+    pub iab_content: Option<IABContent>,
+}
+
+#[derive(Debug, PartialEq, uniffi::Record)]
+pub struct MozAdsPlacement {
+    pub placement_config: MozAdsPlacementConfig,
+    pub content: MozAd,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use parking_lot::lock_api::Mutex;
+
+    use crate::{
+        mars::MockMARSClient,
+        models::{AdCallbacks, AdContentCategory, AdPlacementRequest},
+        test_utils::{
+            get_example_happy_ad_response, get_example_happy_placement_config,
+            get_example_happy_placements,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_build_ad_request_happy() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let configs: Vec<MozAdsPlacementConfig> = vec![
+            MozAdsPlacementConfig {
+                placement_id: "example_placement_1".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB2_1,
+                    category_ids: vec!["entertainment".to_string()],
+                }),
+                fixed_size: None,
+            },
+            MozAdsPlacementConfig {
+                placement_id: "example_placement_2".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB3_0,
+                    category_ids: vec![],
+                }),
+                fixed_size: None,
+            },
+            MozAdsPlacementConfig {
+                placement_id: "example_placement_3".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB2_1,
+                    category_ids: vec![],
+                }),
+                fixed_size: Some(MozAdsSize {
+                    width: 200,
+                    height: 200,
+                }),
+            },
+        ];
+        let request = inner_component
+            .build_request_from_placement_configs(&configs)
+            .unwrap();
+        let context_id = inner_component.client.get_context_id().to_string();
+
+        let expected_request = AdRequest {
+            context_id,
+            placements: vec![
+                AdPlacementRequest {
+                    placement: "example_placement_1".to_string(),
+                    content: Some(AdContentCategory {
+                        taxonomy: IABContentTaxonomy::IAB2_1,
+                        categories: vec!["entertainment".to_string()],
+                    }),
+                    count: 1,
+                },
+                AdPlacementRequest {
+                    placement: "example_placement_2".to_string(),
+                    content: Some(AdContentCategory {
+                        taxonomy: IABContentTaxonomy::IAB3_0,
+                        categories: vec![],
+                    }),
+                    count: 1,
+                },
+                AdPlacementRequest {
+                    placement: "example_placement_3".to_string(),
+                    content: Some(AdContentCategory {
+                        taxonomy: IABContentTaxonomy::IAB2_1,
+                        categories: vec![],
+                    }),
+                    count: 1,
+                },
+            ],
+        };
+
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_build_ad_request_fails_on_duplicate_placement_id() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let configs: Vec<MozAdsPlacementConfig> = vec![
+            MozAdsPlacementConfig {
+                placement_id: "example_placement_1".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB2_1,
+                    category_ids: vec!["entertainment".to_string()],
+                }),
+                fixed_size: None,
+            },
+            MozAdsPlacementConfig {
+                placement_id: "example_placement_2".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB3_0,
+                    category_ids: vec![],
+                }),
+                fixed_size: None,
+            },
+            MozAdsPlacementConfig {
+                placement_id: "example_placement_2".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB2_1,
+                    category_ids: vec![],
+                }),
+                fixed_size: Some(MozAdsSize {
+                    width: 200,
+                    height: 200,
+                }),
+            },
+        ];
+        let request = inner_component.build_request_from_placement_configs(&configs);
+
+        assert!(request.is_err());
+    }
+
+    #[test]
+    fn test_build_ad_request_fails_on_empty_configs() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let configs: Vec<MozAdsPlacementConfig> = vec![];
+        let request = inner_component.build_request_from_placement_configs(&configs);
+
+        assert!(request.is_err());
+    }
+
+    #[test]
+    fn test_build_placements_happy() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let placements = inner_component
+            .build_placements(
+                &get_example_happy_placement_config(),
+                get_example_happy_ad_response(),
+            )
+            .unwrap();
+
+        assert_eq!(placements, get_example_happy_placements());
+    }
+
+    #[test]
+    fn test_build_placements_with_empty_placement_in_response() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let mut configs = get_example_happy_placement_config();
+        // Adding an extra placement config
+        configs.push(MozAdsPlacementConfig {
+            placement_id: "example_placement_3".to_string(),
+            iab_content: Some(IABContent {
+                taxonomy: IABContentTaxonomy::IAB2_1,
+                category_ids: vec![],
+            }),
+            fixed_size: Some(MozAdsSize {
+                width: 200,
+                height: 200,
+            }),
+        });
+
+        let mut api_resp = get_example_happy_ad_response();
+        api_resp
+            .data
+            .insert("example_placement_3".to_string(), vec![]);
+
+        let placements = inner_component
+            .build_placements(&configs, api_resp)
+            .unwrap();
+
+        assert_eq!(placements, get_example_happy_placements());
+    }
+
+    #[test]
+    fn test_build_placements_with_missing_placement_in_response() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let mut configs = get_example_happy_placement_config();
+        // Adding an extra placement config
+        configs.push(MozAdsPlacementConfig {
+            placement_id: "example_placement_3".to_string(),
+            iab_content: Some(IABContent {
+                taxonomy: IABContentTaxonomy::IAB2_1,
+                category_ids: vec![],
+            }),
+            fixed_size: Some(MozAdsSize {
+                width: 200,
+                height: 200,
+            }),
+        });
+
+        let placements = inner_component
+            .build_placements(&configs, get_example_happy_ad_response())
+            .unwrap();
+
+        assert_eq!(placements, get_example_happy_placements());
+    }
+
+    #[test]
+    fn test_build_placements_fails_with_duplicate_placement() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        let inner_component = MozAdsClientInner {
+            ads_cache: HashMap::new(),
+            client: Box::new(mock),
+        };
+
+        let mut configs = get_example_happy_placement_config();
+        // Adding an extra placement config
+        configs.push(MozAdsPlacementConfig {
+            placement_id: "example_placement_2".to_string(),
+            iab_content: Some(IABContent {
+                taxonomy: IABContentTaxonomy::IAB2_1,
+                category_ids: vec![],
+            }),
+            fixed_size: Some(MozAdsSize {
+                width: 200,
+                height: 200,
+            }),
+        });
+
+        let mut api_resp = get_example_happy_ad_response();
+
+        // Adding an extra placement in response to match extra config
+        api_resp
+            .data
+            .get_mut("example_placement_2")
+            .unwrap()
+            .push(MozAd {
+                url: Some("https://ads.fakeexample.org/example_ad_2_2".to_string()),
+                image_url: Some("https://ads.fakeexample.org/example_image_2_2".to_string()),
+                format: Some("skyscraper".to_string()),
+                block_key: None,
+                alt_text: Some("An ad for a pet dragon".to_string()),
+                callbacks: Some(AdCallbacks {
+                    click: Some("https://ads.fakeexample.org/click/example_ad_2_2".to_string()),
+                    impression: Some(
+                        "https://ads.fakeexample.org/impression/example_ad_2_2".to_string(),
+                    ),
+                    report: Some("https://ads.fakeexample.org/report/example_ad_2_2".to_string()),
+                }),
+            });
+
+        let placements = inner_component.build_placements(&configs, api_resp);
+
+        assert!(placements.is_err());
+    }
+
+    #[test]
+    fn test_request_ads_happy() {
+        let mut mock = MockMARSClient::new();
+        mock.expect_fetch_ads()
+            .returning(|_req| Ok(get_example_happy_ad_response()));
+        mock.expect_get_context_id()
+            .return_const("mock-context-id".to_string());
+
+        mock.expect_get_mars_endpoint()
+            .return_const("https://mock.endpoint/ads".to_string());
+
+        let component = MozAdsClient {
+            inner: Mutex::new(MozAdsClientInner {
+                ads_cache: HashMap::new(),
+                client: Box::new(mock),
+            }),
+        };
+
+        let configs = get_example_happy_placement_config();
+
+        let result = component.request_ads(configs);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_cycle_context_id() {
+        let component = MozAdsClient::new();
+        let old_id = component.cycle_context_id().unwrap();
+        let new_id = component.cycle_context_id().unwrap();
+        assert_ne!(old_id, new_id);
+    }
+
+    #[test]
+    fn test_clear_cache_does_not_panic() {
+        let component = MozAdsClient::new();
+        assert!(component.clear_cache().is_ok());
+    }
+}
+

--- a/components/mac/src/mars.rs
+++ b/components/mac/src/mars.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use url::Url;
 use uuid::Uuid;
-use viaduct::Request; // wherever the trait is defined
+use viaduct::Request;
 
 const DEFAULT_MARS_API_ENDPOINT: &str = "https://ads.allizom.org/v1";
 
@@ -180,6 +180,7 @@ mod tests {
 
     #[test]
     fn test_record_click_with_valid_url_should_succeed() {
+        viaduct_reqwest::use_reqwest_backend();
         let _m = mock("GET", "/click_callback_url").with_status(200).create();
 
         let client = create_test_client(mockito::server_url());
@@ -190,6 +191,7 @@ mod tests {
 
     #[test]
     fn test_report_ad_with_valid_url_should_succeed() {
+        viaduct_reqwest::use_reqwest_backend();
         let _m = mock("GET", "/report_ad_callback_url")
             .with_status(200)
             .create();
@@ -202,6 +204,7 @@ mod tests {
 
     #[test]
     fn test_fetch_ads_success() {
+        viaduct_reqwest::use_reqwest_backend();
         let expected_response = get_example_happy_ad_response();
 
         let _m = mock("POST", "/ads")

--- a/components/mac/src/mars.rs
+++ b/components/mac/src/mars.rs
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use crate::{
+    error::{
+        CallbackRequestError, FetchAdsError, RecordClickError, RecordImpressionError,
+        ReportAdError, check_http_status_for_error,
+    },
+    models::{AdRequest, AdResponse},
+};
+use url::Url;
+use uuid::Uuid;
+use viaduct::Request; // wherever the trait is defined
+
+const DEFAULT_MARS_API_ENDPOINT: &str = "https://ads.allizom.org/v1";
+
+#[cfg_attr(test, mockall::automock)]
+pub trait MARSClient: Sync + Send {
+    fn fetch_ads(&self, request: &AdRequest) -> Result<AdResponse, FetchAdsError>;
+    fn record_impression(
+        &self,
+        url_callback_string: Option<String>,
+    ) -> Result<(), RecordImpressionError>;
+    fn record_click(&self, url_callback_string: Option<String>) -> Result<(), RecordClickError>;
+    fn report_ad(&self, url_callback_string: Option<String>) -> Result<(), ReportAdError>;
+    fn get_context_id(&self) -> &str;
+    fn cycle_context_id(&mut self) -> String;
+    fn get_mars_endpoint(&self) -> &str;
+}
+
+pub struct DefaultMARSClient {
+    context_id: String,
+    endpoint: String,
+}
+
+impl DefaultMARSClient {
+    pub fn new(context_id: String) -> Self {
+        Self {
+            context_id,
+            endpoint: DEFAULT_MARS_API_ENDPOINT.to_string(),
+        }
+    }
+
+    pub fn new_with_endpoint(context_id: String, endpoint: String) -> Self {
+        Self {
+            context_id,
+            endpoint,
+        }
+    }
+
+    fn make_callback_request(&self, url_callback_string: &str) -> Result<(), CallbackRequestError> {
+        let url = Url::parse(url_callback_string)?;
+        let request = Request::get(url);
+        let response = request.send()?;
+        check_http_status_for_error(&response).map_err(Into::into)
+    }
+}
+
+impl MARSClient for DefaultMARSClient {
+    fn get_context_id(&self) -> &str {
+        &self.context_id
+    }
+
+    fn get_mars_endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Updates the client's context_id to the passed value and returns the previous context_id
+    fn cycle_context_id(&mut self) -> String {
+        let old_context_id = self.context_id.clone();
+        self.context_id = Uuid::new_v4().to_string();
+        old_context_id
+    }
+
+    fn fetch_ads(&self, ad_request: &AdRequest) -> Result<AdResponse, FetchAdsError> {
+        let endpoint = self.get_mars_endpoint();
+        let url = Url::parse(&format!("{endpoint}/ads"))?;
+        let request = Request::post(url).json(ad_request);
+        let response = request.send()?;
+
+        check_http_status_for_error(&response)?;
+
+        let response_json: AdResponse = response.json()?;
+
+        Ok(response_json)
+    }
+
+    fn record_impression(
+        &self,
+        url_callback_string: Option<String>,
+    ) -> Result<(), RecordImpressionError> {
+        match url_callback_string {
+            Some(callback) => self.make_callback_request(&callback).map_err(Into::into),
+            None => Err(CallbackRequestError::MissingCallback {
+                message: "Impression callback url empty.".to_string(),
+            }
+            .into()),
+        }
+    }
+
+    fn record_click(&self, url_callback_string: Option<String>) -> Result<(), RecordClickError> {
+        match url_callback_string {
+            Some(callback) => self.make_callback_request(&callback).map_err(Into::into),
+            None => Err(CallbackRequestError::MissingCallback {
+                message: "Click callback url empty.".to_string(),
+            }
+            .into()),
+        }
+    }
+
+    fn report_ad(&self, url_callback_string: Option<String>) -> Result<(), ReportAdError> {
+        match url_callback_string {
+            Some(callback) => self.make_callback_request(&callback).map_err(Into::into),
+            None => Err(CallbackRequestError::MissingCallback {
+                message: "Report callback url empty.".to_string(),
+            }
+            .into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::{
+        models::AdPlacementRequest,
+        test_utils::{TEST_CONTEXT_ID, create_test_client, get_example_happy_ad_response},
+    };
+    use mockito::mock;
+
+    #[test]
+    fn test_get_context_id() {
+        let client = create_test_client(mockito::server_url());
+        assert_eq!(client.get_context_id(), TEST_CONTEXT_ID.to_string());
+    }
+
+    #[test]
+    fn test_cycle_context_id() {
+        let mut client = create_test_client(mockito::server_url());
+        let old_id = client.cycle_context_id();
+        assert_eq!(old_id, TEST_CONTEXT_ID);
+        assert_ne!(client.get_context_id(), TEST_CONTEXT_ID);
+    }
+
+    #[test]
+    fn test_record_impression_with_empty_callback_should_fail() {
+        let client = create_test_client(mockito::server_url());
+        let result = client.record_impression(None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_record_click_with_empty_callback_should_fail() {
+        let client = create_test_client(mockito::server_url());
+        let result = client.record_click(None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_record_report_with_empty_callback_should_fail() {
+        let client = create_test_client(mockito::server_url());
+        let result = client.report_ad(None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_record_impression_with_valid_url_should_succeed() {
+        viaduct_reqwest::use_reqwest_backend();
+        let _m = mock("GET", "/impression_callback_url")
+            .with_status(200)
+            .create();
+        let client = create_test_client(mockito::server_url());
+        let url = format!("{}/impression_callback_url", &mockito::server_url());
+        let result = client.record_impression(Some(url));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_record_click_with_valid_url_should_succeed() {
+        let _m = mock("GET", "/click_callback_url").with_status(200).create();
+
+        let client = create_test_client(mockito::server_url());
+        let url = format!("{}/click_callback_url", &mockito::server_url());
+        let result = client.record_click(Some(url));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_report_ad_with_valid_url_should_succeed() {
+        let _m = mock("GET", "/report_ad_callback_url")
+            .with_status(200)
+            .create();
+
+        let client = create_test_client(mockito::server_url());
+        let url = format!("{}/report_ad_callback_url", &mockito::server_url());
+        let result = client.report_ad(Some(url));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fetch_ads_success() {
+        let expected_response = get_example_happy_ad_response();
+
+        let _m = mock("POST", "/ads")
+            .match_header("content-type", "application/json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&expected_response).unwrap())
+            .create();
+
+        let client = create_test_client(mockito::server_url());
+
+        let ad_request = AdRequest {
+            context_id: client.get_context_id().to_string(),
+            placements: vec![
+                AdPlacementRequest {
+                    placement: "example_placement_1".to_string(),
+                    count: 1,
+                    content: None,
+                },
+                AdPlacementRequest {
+                    placement: "example_placement_2".to_string(),
+                    count: 1,
+                    content: None,
+                },
+            ],
+        };
+
+        let result = client.fetch_ads(&ad_request);
+        assert!(result.is_ok());
+        assert_eq!(expected_response, result.unwrap());
+    }
+}

--- a/components/mac/src/mars.rs
+++ b/components/mac/src/mars.rs
@@ -14,7 +14,7 @@ use url::Url;
 use uuid::Uuid;
 use viaduct::Request;
 
-const DEFAULT_MARS_API_ENDPOINT: &str = "https://ads.allizom.org/v1";
+const DEFAULT_MARS_API_ENDPOINT: &str = "https://ads.mozilla.org/v1";
 
 #[cfg_attr(test, mockall::automock)]
 pub trait MARSClient: Sync + Send {

--- a/components/mac/src/mars.rs
+++ b/components/mac/src/mars.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     error::{
-        CallbackRequestError, FetchAdsError, RecordClickError, RecordImpressionError,
-        ReportAdError, check_http_status_for_error,
+        check_http_status_for_error, CallbackRequestError, FetchAdsError, RecordClickError,
+        RecordImpressionError, ReportAdError,
     },
     models::{AdRequest, AdResponse},
 };
@@ -127,7 +127,7 @@ mod tests {
     use super::*;
     use crate::{
         models::AdPlacementRequest,
-        test_utils::{TEST_CONTEXT_ID, create_test_client, get_example_happy_ad_response},
+        test_utils::{create_test_client, get_example_happy_ad_response, TEST_CONTEXT_ID},
     };
     use mockito::mock;
 

--- a/components/mac/src/models.rs
+++ b/components/mac/src/models.rs
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    Ok(match opt {
+        Some(s) if s.trim().is_empty() => None,
+        other => other,
+    })
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
+pub struct AdPlacementRequest {
+    pub placement: String,
+    pub count: u32,
+    pub content: Option<AdContentCategory>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Deserialize, uniffi::Enum)]
+pub enum IABAdUnitFormat {
+    Billboard,
+    SmartphoneBanner300,
+    SmartphoneBanner320,
+    Leaderboard,
+    SuperLeaderboardPushdown,
+    Portrait,
+    Skyscraper,
+    MediumRectangle,
+    TwentyBySixty,
+    MobilePhoneInterstitial640,
+    MobilePhoneInterstitial750,
+    MobilePhoneInterstitial1080,
+    FeaturePhoneSmallBanner,
+    FeaturePhoneMediumBanner,
+    FeaturePhoneLargeBanner,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Deserialize, uniffi::Enum)]
+pub enum IABContentTaxonomy {
+    #[serde(rename = "IAB-1.0")]
+    IAB1_0,
+
+    #[serde(rename = "IAB-2.0")]
+    IAB2_0,
+
+    #[serde(rename = "IAB-2.1")]
+    IAB2_1,
+
+    #[serde(rename = "IAB-2.2")]
+    IAB2_2,
+
+    #[serde(rename = "IAB-3.0")]
+    IAB3_0,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
+pub struct AdContentCategory {
+    pub taxonomy: IABContentTaxonomy,
+    pub categories: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
+pub struct AdRequest {
+    pub context_id: String,
+    pub placements: Vec<AdPlacementRequest>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
+pub struct AdCallbacks {
+    #[serde(deserialize_with = "empty_string_as_none")]
+    pub click: Option<String>,
+    #[serde(deserialize_with = "empty_string_as_none")]
+    pub impression: Option<String>,
+    #[serde(deserialize_with = "empty_string_as_none")]
+    pub report: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
+pub struct MozAd {
+    pub alt_text: Option<String>,
+    pub block_key: Option<String>,
+    pub callbacks: Option<AdCallbacks>,
+    pub format: Option<String>,
+    pub image_url: Option<String>, //TODO: Consider if we want to load the image locally
+    pub url: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
+pub struct AdResponse {
+    #[serde(flatten)]
+    pub data: HashMap<String, Vec<MozAd>>,
+}

--- a/components/mac/src/test_utils.rs
+++ b/components/mac/src/test_utils.rs
@@ -179,6 +179,6 @@ pub fn get_example_happy_placements() -> HashMap<String, MozAdsPlacement> {
 }
 
 #[allow(dead_code)]
-pub fn create_test_client(test_endpoint: String) -> DefaultMARSClient {
-    DefaultMARSClient::new_with_endpoint(TEST_CONTEXT_ID.to_string(), test_endpoint)
+pub fn create_test_client(mock_server_url: String) -> DefaultMARSClient {
+    DefaultMARSClient::new_with_endpoint(TEST_CONTEXT_ID.to_string(), mock_server_url)
 }

--- a/components/mac/src/test_utils.rs
+++ b/components/mac/src/test_utils.rs
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use std::collections::HashMap;
+
+use crate::{
+    IABContent, MozAdsPlacement, MozAdsPlacementConfig,
+    mars::DefaultMARSClient,
+    models::{AdCallbacks, AdResponse, IABContentTaxonomy, MozAd},
+};
+
+#[allow(dead_code)]
+pub const TEST_CONTEXT_ID: &str = "test-context-id";
+
+#[allow(dead_code)]
+pub fn get_example_happy_placement_config() -> Vec<MozAdsPlacementConfig> {
+    vec![
+        MozAdsPlacementConfig {
+            placement_id: "example_placement_1".to_string(),
+            iab_content: Some(IABContent {
+                taxonomy: IABContentTaxonomy::IAB2_1,
+                category_ids: vec!["entertainment".to_string()],
+            }),
+            fixed_size: None,
+        },
+        MozAdsPlacementConfig {
+            placement_id: "example_placement_2".to_string(),
+            iab_content: Some(IABContent {
+                taxonomy: IABContentTaxonomy::IAB3_0,
+                category_ids: vec![],
+            }),
+            fixed_size: None,
+        },
+    ]
+}
+
+#[allow(dead_code)]
+pub fn get_example_happy_ad_response() -> AdResponse {
+    AdResponse {
+        data: HashMap::from([
+            (
+                "example_placement_1".to_string(),
+                vec![MozAd {
+                    url: Some("https://ads.fakeexample.org/example_ad_1".to_string()),
+                    image_url: Some("https://ads.fakeexample.org/example_image_1".to_string()),
+                    format: Some("billboard".to_string()),
+                    block_key: None,
+                    alt_text: Some("An ad for a puppy".to_string()),
+                    callbacks: Some(AdCallbacks {
+                        click: Some("https://ads.fakeexample.org/click/example_ad_1".to_string()),
+                        impression: Some(
+                            "https://ads.fakeexample.org/impression/example_ad_1".to_string(),
+                        ),
+                        report: Some("https://ads.fakeexample.org/report/example_ad_1".to_string()),
+                    }),
+                }],
+            ),
+            (
+                "example_placement_2".to_string(),
+                vec![MozAd {
+                    url: Some("https://ads.fakeexample.org/example_ad_2".to_string()),
+                    image_url: Some("https://ads.fakeexample.org/example_image_2".to_string()),
+                    format: Some("skyscraper".to_string()),
+                    block_key: None,
+                    alt_text: Some("An ad for a pet duck".to_string()),
+                    callbacks: Some(AdCallbacks {
+                        click: Some("https://ads.fakeexample.org/click/example_ad_2".to_string()),
+                        impression: Some(
+                            "https://ads.fakeexample.org/impression/example_ad_2".to_string(),
+                        ),
+                        report: Some("https://ads.fakeexample.org/report/example_ad_2".to_string()),
+                    }),
+                }],
+            ),
+        ]),
+    }
+}
+
+#[allow(dead_code)]
+pub fn get_example_missing_callback_ad_response() -> AdResponse {
+    AdResponse {
+        data: HashMap::from([
+            (
+                "example_placement_1".to_string(),
+                vec![MozAd {
+                    url: Some("https://ads.fakeexample.org/example_ad_1".to_string()),
+                    image_url: Some("https://ads.fakeexample.org/example_image_1".to_string()),
+                    format: Some("billboard".to_string()),
+                    block_key: None,
+                    alt_text: Some("An ad for a puppy".to_string()),
+                    callbacks: Some(AdCallbacks {
+                        click: Some("https://ads.fakeexample.org/click/example_ad_1".to_string()),
+                        impression: None, // Missing impression callback URL
+                        report: Some("https://ads.fakeexample.org/report/example_ad_1".to_string()),
+                    }),
+                }],
+            ),
+            (
+                "example_placement_2".to_string(),
+                vec![MozAd {
+                    url: Some("https://ads.fakeexample.org/example_ad_2".to_string()),
+                    image_url: Some("https://ads.fakeexample.org/example_image_2".to_string()),
+                    format: Some("skyscraper".to_string()),
+                    block_key: None,
+                    alt_text: Some("An ad for a pet duck".to_string()),
+                    callbacks: Some(AdCallbacks {
+                        click: Some("https://ads.fakeexample.org/click/example_ad_2".to_string()),
+                        impression: Some(
+                            "https://ads.fakeexample.org/impression/example_ad_2".to_string(),
+                        ),
+                        report: Some("https://ads.fakeexample.org/report/example_ad_2".to_string()),
+                    }),
+                }],
+            ),
+        ]),
+    }
+}
+
+#[allow(dead_code)]
+pub fn get_example_happy_placements() -> HashMap<String, MozAdsPlacement> {
+    let mut placements = HashMap::new();
+    placements.insert(
+        "example_placement_1".to_string(),
+        MozAdsPlacement {
+            placement_config: MozAdsPlacementConfig {
+                placement_id: "example_placement_1".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB2_1,
+                    category_ids: vec!["entertainment".to_string()],
+                }),
+                fixed_size: None,
+            },
+            content: MozAd {
+                url: Some("https://ads.fakeexample.org/example_ad_1".to_string()),
+                image_url: Some("https://ads.fakeexample.org/example_image_1".to_string()),
+                format: Some("billboard".to_string()),
+                block_key: None,
+                alt_text: Some("An ad for a puppy".to_string()),
+                callbacks: Some(AdCallbacks {
+                    click: Some("https://ads.fakeexample.org/click/example_ad_1".to_string()),
+                    impression: Some(
+                        "https://ads.fakeexample.org/impression/example_ad_1".to_string(),
+                    ),
+                    report: Some("https://ads.fakeexample.org/report/example_ad_1".to_string()),
+                }),
+            },
+        },
+    );
+    placements.insert(
+        "example_placement_2".to_string(),
+        MozAdsPlacement {
+            placement_config: MozAdsPlacementConfig {
+                placement_id: "example_placement_2".to_string(),
+                iab_content: Some(IABContent {
+                    taxonomy: IABContentTaxonomy::IAB3_0,
+                    category_ids: vec![],
+                }),
+                fixed_size: None,
+            },
+            content: MozAd {
+                url: Some("https://ads.fakeexample.org/example_ad_2".to_string()),
+                image_url: Some("https://ads.fakeexample.org/example_image_2".to_string()),
+                format: Some("skyscraper".to_string()),
+                block_key: None,
+                alt_text: Some("An ad for a pet duck".to_string()),
+                callbacks: Some(AdCallbacks {
+                    click: Some("https://ads.fakeexample.org/click/example_ad_2".to_string()),
+                    impression: Some(
+                        "https://ads.fakeexample.org/impression/example_ad_2".to_string(),
+                    ),
+                    report: Some("https://ads.fakeexample.org/report/example_ad_2".to_string()),
+                }),
+            },
+        },
+    );
+    placements
+}
+
+#[allow(dead_code)]
+pub fn create_test_client(test_endpoint: String) -> DefaultMARSClient {
+    DefaultMARSClient::new_with_endpoint(TEST_CONTEXT_ID.to_string(), test_endpoint)
+}

--- a/components/mac/src/test_utils.rs
+++ b/components/mac/src/test_utils.rs
@@ -6,9 +6,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    IABContent, MozAdsPlacement, MozAdsPlacementConfig,
     mars::DefaultMARSClient,
     models::{AdCallbacks, AdResponse, IABContentTaxonomy, MozAd},
+    IABContent, MozAdsPlacement, MozAdsPlacementConfig,
 };
 
 #[allow(dead_code)]

--- a/components/mac/uniffi.toml
+++ b/components/mac/uniffi.toml
@@ -1,0 +1,6 @@
+[bindings.kotlin]
+package_name = "mozilla.appservices.mac"
+
+[bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "macFFI"


### PR DESCRIPTION
### Adding Mozilla Ads Client Component
#### Overview
This PR creates a new component in the Application-services repo, `MAC` (Mozilla Ads Client). MAC acts as an SDK for Mozilla's internal privacy preserving ads routing service (MARS) and allows for simple integration with MARS' Unified API (UAPI). This component is able to fetch ads and handle logging ad interaction events such as clicks and impressions. In the future, it will also support caching. It is primarily intended for use on mobile surfaces but is extendable to any surface able to integrate with this repo.

This PR only includes the "core" of the library. Additional Swift and Kotlin wrappers still need to be created to handle displaying of ads fetched through `MAC` to the respective surfaces.

#### What was done

- A new component `MAC` was created.
- Functionality was adding which allows for fetching of ads, handling click/impression/report callbacks, and error logging.
- Unit tests were added.

#### Component Feature list

- Fetch ads from MARS given a set of user defined `placement_ids`.
- Provides type definitions for ads, placements, and placement definitions.
- Ability to report back to MARS that a particular placement had a click or impression occur.
- Ability to report back to MARS that a particular placement was reported by a user.
- If errors occur during any of these processes, an attempt is made to emit an event to internal telemetry dashboards for monitoring purposes.

#### Final Notes:

This PR contains no breaking changes and does not affect any components other than the one being created.
This PR includes tests for the new component that pass.
This PR adds no new dependencies to application-services.

Like MARS, MAC is privacy-first. It does not track user information and it does not send clearly identifiable information to Mozilla. Of the information Mozilla does receive, anything shared with advertisers is aggregated and/or de-identified to preserve user privacy.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.