### PR TITLE
More dependency fixes to avoid moz-central duplicate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "sql-support",
  "sync-guid",
  "sync15",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "types",
  "uniffi",
  "url",
@@ -282,7 +282,7 @@ dependencies = [
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
- "itoa 1.0.11",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -414,18 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata 0.1.10",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,7 +475,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -510,7 +498,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -539,12 +527,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -680,15 +662,15 @@ name = "cli-support"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dialoguer",
  "env_logger",
  "fxa-client",
  "log",
+ "open",
  "remote_settings",
- "rpassword",
  "sync15",
  "sync_manager",
  "url",
- "webbrowser",
 ]
 
 [[package]]
@@ -729,22 +711,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "console"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
- "encode_unicode 0.3.6",
+ "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width 0.1.11",
@@ -768,7 +740,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "uuid",
@@ -820,7 +792,7 @@ name = "crashtest"
 version = "0.1.0"
 dependencies = [
  "log",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
 ]
 
@@ -933,28 +905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctest2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,16 +923,6 @@ checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
  "syn 2.0.89",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
-dependencies = [
- "nix",
- "winapi",
 ]
 
 [[package]]
@@ -1056,10 +996,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
+name = "dialoguer"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror 1.0.69",
+ "zeroize",
+]
 
 [[package]]
 name = "digest"
@@ -1101,16 +1047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,17 +1067,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1203,7 +1128,7 @@ dependencies = [
  "hex",
  "once_cell",
  "serde",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1233,12 +1158,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1329,7 +1248,7 @@ name = "error-support-tests"
 version = "0.1.0"
 dependencies = [
  "error-support",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "trybuild",
 ]
 
@@ -1364,7 +1283,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sql-support",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "viaduct",
@@ -1395,7 +1314,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cli-support",
- "ctrlc",
  "error-support",
  "fxa-client",
  "interrupt-support",
@@ -1439,13 +1357,13 @@ dependencies = [
  "init_rust_components",
  "log",
  "logins",
- "prettytable-rs",
  "rusqlite",
  "serde_json",
  "sql-support",
  "sync-guid",
  "sync15",
  "tempfile",
+ "text-table",
  "url",
  "viaduct-reqwest",
 ]
@@ -1489,7 +1407,7 @@ dependencies = [
  "cli-support",
  "fxa-client",
  "log",
- "simple_logger",
+ "nss",
  "sync15",
  "url",
  "viaduct-reqwest",
@@ -1541,7 +1459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "tokio",
  "viaduct-reqwest",
  "walkdir",
@@ -1634,7 +1552,7 @@ dependencies = [
  "error-support",
  "md-5",
  "regex",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
 ]
 
@@ -1652,7 +1570,7 @@ name = "firefox-versioning"
 version = "0.1.0"
 dependencies = [
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1669,15 +1587,6 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1850,7 +1759,7 @@ dependencies = [
  "serde_json",
  "sync-guid",
  "sync15",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "viaduct",
@@ -1866,7 +1775,7 @@ dependencies = [
  "garando_pos",
  "libc",
  "serde",
- "term 0.6.1",
+ "term",
  "unicode-xid",
 ]
 
@@ -2048,7 +1957,7 @@ dependencies = [
  "base64 0.21.2",
  "log",
  "once_cell",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -2111,7 +2020,7 @@ checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.11",
+ "itoa",
 ]
 
 [[package]]
@@ -2122,7 +2031,7 @@ checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.11",
+ "itoa",
 ]
 
 [[package]]
@@ -2207,7 +2116,7 @@ dependencies = [
  "http-body 0.4.5",
  "httparse",
  "httpdate",
- "itoa 1.0.11",
+ "itoa",
  "pin-project-lite",
  "socket2 0.4.9",
  "tokio",
@@ -2229,7 +2138,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
- "itoa 1.0.11",
+ "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -2541,6 +2450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2468,16 @@ dependencies = [
  "io-lifetimes",
  "rustix 0.37.11",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2596,12 +2524,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
@@ -2616,7 +2538,7 @@ dependencies = [
  "jexl-parser",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2628,26 +2550,6 @@ dependencies = [
  "lalrpop-util",
  "regex",
 ]
-
-[[package]]
-name = "jni"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.31",
- "walkdir",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -2682,7 +2584,7 @@ dependencies = [
  "fraction",
  "getrandom 0.2.7",
  "iso8601",
- "itoa 1.0.11",
+ "itoa",
  "memchr",
  "num-cmp",
  "once_cell",
@@ -2707,7 +2609,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2752,6 +2654,17 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "redox_syscall 0.5.17",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2805,7 +2718,7 @@ checksum = "885efb07efcd6ae1c6af70be7565544121424fa9e5b1c3e4b58bbbf141a58cef"
 dependencies = [
  "libc",
  "neli",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "windows-sys 0.48.0",
 ]
 
@@ -2853,7 +2766,7 @@ dependencies = [
  "sync-guid",
  "sync15",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
 ]
@@ -3001,7 +2914,7 @@ dependencies = [
  "error-support",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "viaduct",
@@ -3062,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -3077,14 +2990,14 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3136,12 +3049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "neli"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,7 +3094,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.21",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tower-http",
@@ -3229,7 +3136,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "textwrap 0.14.2",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "unicode-segmentation",
  "uniffi",
  "url",
@@ -3257,7 +3164,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "unicode-segmentation",
  "uniffi",
  "url",
@@ -3288,12 +3195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "nss"
 version = "0.1.0"
 dependencies = [
@@ -3303,7 +3204,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_derive",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3418,15 +3319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,9 +3326,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numtoa"
-version = "0.1.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "objc"
@@ -3505,6 +3397,17 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "open"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "openssl"
@@ -3605,6 +3508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "payload-support"
 version = "0.1.0"
 dependencies = [
@@ -3700,7 +3609,7 @@ dependencies = [
  "sync-guid",
  "sync15",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "types",
  "uniffi",
  "url",
@@ -3792,16 +3701,12 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.3",
- "normalize-line-endings",
+ "anstyle",
  "predicates-core",
- "regex",
 ]
 
 [[package]]
@@ -3828,20 +3733,6 @@ checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
  "syn 2.0.89",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode 1.0.0",
- "is-terminal",
- "lazy_static",
- "term 0.7.0",
- "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -3960,7 +3851,7 @@ dependencies = [
  "serde_json",
  "sql-support",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "types",
  "uniffi",
  "url",
@@ -4031,12 +3922,6 @@ name = "rate-limiter"
 version = "0.1.0"
 
 [[package]]
-name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,7 +3955,7 @@ dependencies = [
  "hawk",
  "hex",
  "nss",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4092,13 +3977,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.2"
+name = "redox_syscall"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "redox_syscall 0.2.13",
+ "bitflags 2.8.0",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -4108,7 +3999,7 @@ checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.7",
  "redox_syscall 0.2.13",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4119,15 +4010,9 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
@@ -4157,7 +4042,7 @@ dependencies = [
  "mockito",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "viaduct",
@@ -4182,7 +4067,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sql-support",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
 ]
@@ -4209,7 +4094,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sql-support",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "viaduct",
@@ -4303,7 +4188,7 @@ version = "0.1.0"
 dependencies = [
  "error-support",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "url",
  "viaduct",
 ]
@@ -4315,7 +4200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28580fecce391f3c0e65a692e5f2b5db258ba2346ee04f355ae56473ab973dc"
 dependencies = [
  "humansize",
- "itoa 1.0.11",
+ "itoa",
  "num-traits",
  "percent-encoding",
  "rinja_derive",
@@ -4368,7 +4253,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_derive",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "url",
  "uuid",
 ]
@@ -4393,27 +4278,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4587,7 +4451,7 @@ dependencies = [
  "remote_settings",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "viaduct-reqwest",
 ]
@@ -4651,7 +4515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.5.0",
- "itoa 1.0.11",
+ "itoa",
  "memchr",
  "ryu",
  "serde",
@@ -4682,7 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.11",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -4706,7 +4570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap 1.9.1",
- "itoa 1.0.11",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -4744,6 +4608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,18 +4639,6 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
-
-[[package]]
-name = "simple_logger"
-version = "4.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
-dependencies = [
- "colored",
- "log",
- "time",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "siphasher"
@@ -4870,7 +4728,8 @@ dependencies = [
  "parking_lot",
  "rusqlite",
  "tempfile",
- "thiserror 1.0.31",
+ "text-table",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4964,7 +4823,7 @@ dependencies = [
  "serde_json",
  "sql-support",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "unicase",
  "unicode-normalization",
  "uniffi",
@@ -5061,7 +4920,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sync-guid",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
  "viaduct",
@@ -5085,7 +4944,7 @@ dependencies = [
  "sql-support",
  "sync15",
  "tabs",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
 ]
@@ -5154,7 +5013,7 @@ dependencies = [
  "sync-guid",
  "sync15",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "types",
  "uniffi",
  "url",
@@ -5184,17 +5043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5205,13 +5053,13 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.6"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
 dependencies = [
  "libc",
+ "libredox",
  "numtoa",
- "redox_syscall 0.2.13",
  "redox_termios",
 ]
 
@@ -5220,6 +5068,13 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "text-table"
+version = "0.1.0"
+dependencies = [
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "textwrap"
@@ -5252,11 +5107,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.31",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -5270,13 +5125,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5307,10 +5162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
- "itoa 1.0.11",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5875,7 +5727,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -6094,23 +5946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webbrowser"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d1fa1e5c829b2bf9eb1e28fb950248b797cd6a04866fbdfa8bc31e5eef4c78"
-dependencies = [
- "core-foundation",
- "dirs 4.0.0",
- "jni",
- "log",
- "ndk-context",
- "objc",
- "raw-window-handle",
- "url",
- "web-sys",
-]
-
-[[package]]
 name = "webext-storage"
 version = "0.1.0"
 dependencies = [
@@ -6128,7 +5963,7 @@ dependencies = [
  "sync-guid",
  "sync15",
  "tempfile",
- "thiserror 1.0.31",
+ "thiserror 1.0.69",
  "uniffi",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "components/support/rc_crypto/nss/systest",
     "components/support/rust-log-forwarder",
     "components/support/sql",
+    "components/support/text-table",
     "components/support/tracing",
     "components/support/types",
     "components/support/viaduct-reqwest",

--- a/components/filter_adult/Cargo.toml
+++ b/components/filter_adult/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 base64 = "0.22.1"
-clap = { version = "4.5.36", features = ["derive"], optional = true }
+clap = { version = "4.5.36", default-features = false, features = ["std", "derive"], optional = true }
 error-support = { path = "../support/error" }
 md-5 = "0.10"
 regex = "1"

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -34,7 +34,7 @@ uniffi = { version = "0.29.0", features = ["build"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
-mockall = "0.11"
+mockall = "0.12"
 mockito = "0.31"
 
 [features]

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -30,6 +30,6 @@ error-support = { path = "../support/error", features = ["testing"] }
 mockito = "0.31"
 hex = "0.4"
 tempfile = "3.1.0"
-mockall = "0.11"
+mockall = "0.12"
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
 nss = { path = "../support/rc_crypto/nss" }

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -40,7 +40,7 @@ uniffi = { version = "0.29.0", features = ["build"] }
 [dev-dependencies]
 expect-test = "1.4"
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
-mockall = "0.11"
+mockall = "0.12"
 mockito = "0.31"
 # We add the perserve_order feature to guarantee ordering of the keys in our
 # JSON objects as they get serialized/deserialized.

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -28,7 +28,7 @@ pub fn init_for_tests_with_level(level: Level) {
 }
 
 #[cfg(all(feature = "testing", feature = "tracing-logging"))]
-pub use tracing_support::init_for_tests;
+pub use tracing_support::{init_for_tests, init_for_tests_with_level};
 
 mod macros;
 

--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -11,7 +11,7 @@ default = ["server"]
 server = ["dep:axum", "dep:tokio", "dep:tower", "dep:tower-http", "dep:tower-livereload", "dep:hyper", "dep:local-ip-address"]
 
 [dependencies]
-clap = {version = "4.2.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive", "error-context"]}
 anyhow = "1.0.44"
 remote_settings = { path = "../../remote_settings" }
 nimbus-fml = { path = "../nimbus-fml", features = ["client-lib"] }

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -7,9 +7,8 @@ license = "MPL-2.0"
 
 [features]
 default = []
-### The debug-tools feature brings in utilities to help with debugging.
-# "dep:prettytable-rs" temp removed for moz-central integration.
-debug-tools = ["rusqlite/column_decltype"]
+# The debug-tools feature brings in utilities to help with debugging.
+debug-tools = ["dep:text-table", "rusqlite/column_decltype"]
 
 [dependencies]
 error-support = { path = "../error" }
@@ -17,9 +16,8 @@ lazy_static = "1.4"
 interrupt-support = { path = "../interrupt" }
 thiserror = "1.0"
 tempfile = "3.1.0"
+text-table = { path = "../text-table", optional = true }
 parking_lot = ">=0.11,<=0.12"
-# disable for m-c :(
-# prettytable-rs = { version = "0.10", optional = true }
 rusqlite = { version = "0.37.0", features = ["functions", "limits", "bundled", "unlock_notify"] }
 
 [dev-dependencies]

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -8,15 +8,7 @@
 //! A crate with various sql/sqlcipher helpers.
 
 mod conn_ext;
-
-// XXX - temporarily disable our debug_tools, to avoid pulling in:
-// prettytable-rs = { version = "0.10", optional = true }
-// while vendoring into m-c :(
-pub mod debug_tools {
-    pub fn define_debug_functions(_c: &rusqlite::Connection) -> rusqlite::Result<()> {
-        Ok(())
-    }
-}
+pub mod debug_tools;
 
 mod each_chunk;
 mod lazy;

--- a/components/support/text-table/Cargo.toml
+++ b/components/support/text-table/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "text-table"
+edition = "2021"
+version = "0.1.0"
+license = "MPL-2.0"
+
+[dependencies]
+unicode-width = "0.2"

--- a/components/support/text-table/src/lib.rs
+++ b/components/support/text-table/src/lib.rs
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Utility to format and print text tables to console.
+//!
+//! Has an API similar to prettytable-rs, but simplified. The goal is to provide enough
+//! functionality to format tables, but with less dependencies.
+
+use std::{cmp::max, fmt::Display};
+
+use unicode_width::UnicodeWidthStr;
+
+#[macro_export]
+macro_rules! row {
+    ($($value:expr),* $(,)?) => {
+        $crate::Row::new(vec![$(Cell::new($value.to_string())),*])
+    };
+}
+
+pub struct Cell {
+    text: String,
+    alignment: Alignment,
+}
+
+#[derive(Default)]
+pub struct Row {
+    cells: Vec<Cell>,
+}
+
+#[derive(Default)]
+pub struct Table {
+    rows: Vec<Row>,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum Alignment {
+    Left,
+    Center,
+    Right,
+}
+
+impl Cell {
+    pub fn new(value: impl Display) -> Self {
+        Self {
+            text: value.to_string(),
+            alignment: Alignment::Left,
+        }
+    }
+
+    pub fn align_right(self) -> Self {
+        Self {
+            alignment: Alignment::Right,
+            ..self
+        }
+    }
+
+    pub fn align_center(self) -> Self {
+        Self {
+            alignment: Alignment::Center,
+            ..self
+        }
+    }
+
+    pub fn align_left(self) -> Self {
+        Self {
+            alignment: Alignment::Left,
+            ..self
+        }
+    }
+}
+
+impl Row {
+    pub fn new(cells: Vec<Cell>) -> Self {
+        Self { cells }
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn add_cell(mut self, cell_data: impl Display) -> Self {
+        self.cells.push(Cell::new(cell_data));
+        self
+    }
+
+    pub fn add_center(mut self, cell_data: impl Display) -> Self {
+        self.cells.push(Cell::new(cell_data).align_center());
+        self
+    }
+
+    pub fn add_right(mut self, cell_data: impl Display) -> Self {
+        self.cells.push(Cell::new(cell_data).align_right());
+        self
+    }
+}
+
+impl Table {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_row(&mut self, row: Row) {
+        self.rows.push(row);
+    }
+
+    pub fn printstd(&self) {
+        let mut row_widths = vec![];
+        for row in self.rows.iter() {
+            for (i, cell) in row.cells.iter().enumerate() {
+                let width = UnicodeWidthStr::width(cell.text.as_str());
+                if i >= row_widths.len() {
+                    row_widths.push(width);
+                } else {
+                    row_widths[i] = max(row_widths[i], width);
+                }
+            }
+        }
+        let row_separator = self.make_row_separator(&row_widths);
+        println!("{row_separator}");
+        for row in self.rows.iter() {
+            for (cell, row_width) in row.cells.iter().zip(row_widths.iter()) {
+                print!("|");
+                print!("{}", self.format_cell(cell, *row_width));
+            }
+            println!("|");
+            println!("{row_separator}");
+        }
+    }
+
+    fn make_row_separator(&self, row_widths: &[usize]) -> String {
+        let mut text = String::from("+");
+        for width in row_widths {
+            text.push_str(&"-".repeat(width + 2));
+            text.push('+');
+        }
+        text
+    }
+
+    fn format_cell(&self, cell: &Cell, row_width: usize) -> String {
+        let text = &cell.text;
+        match cell.alignment {
+            Alignment::Left => {
+                format!(" {text}{} ", " ".repeat(row_width - text.len()))
+            }
+            Alignment::Center => {
+                let left_pad = (row_width - text.len()) / 2;
+                format!(
+                    " {}{text}{} ",
+                    " ".repeat(left_pad),
+                    " ".repeat(row_width - text.len() - left_pad)
+                )
+            }
+            Alignment::Right => {
+                format!(" {}{text} ", " ".repeat(row_width - text.len()))
+            }
+        }
+    }
+}

--- a/examples/cli-support/Cargo.toml
+++ b/examples/cli-support/Cargo.toml
@@ -13,8 +13,8 @@ sync_manager = { path = "../../components/sync_manager" }
 log = "0.4"
 sync15 = { path = "../../components/sync15", features=["sync-client"] }
 url = "2"
-webbrowser = "0.8"
-rpassword = "7.3.1"
+open = "5"
+dialoguer = { version = "0.11", default-features = false, features = ["password"] }
 # disable regex feature, as it's very costly for compile time and very rarely
 # used.
 

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -54,7 +54,7 @@ fn create_fxa_creds(path: &str, cfg: FxaConfig, scopes: &[&str]) -> Result<Firef
 fn handle_oauth_flow(path: &str, acct: &FirefoxAccount, scopes: &[&str]) -> Result<()> {
     let oauth_uri = acct.begin_oauth_flow(scopes, "fxa_creds")?;
 
-    if webbrowser::open(oauth_uri.as_ref()).is_err() {
+    if open::that(&oauth_uri).is_err() {
         log::warn!("Failed to open a web browser D:");
         println!("Please visit this URL, sign in, and then copy-paste the final URL below.");
         println!("\n    {}\n", oauth_uri);

--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prompt;
 pub use env_logger;
 
 pub fn init_logging_with(s: &str) {
-    let noisy = "tokio_threadpool=warn,tokio_reactor=warn,tokio_core=warn,tokio=warn,hyper=warn,want=warn,mio=warn,reqwest=warn";
+    let noisy = "tokio_threadpool=warn,tokio_reactor=warn,tokio_core=warn,tokio=warn,hyper=warn,want=warn,mio=warn";
     let spec = format!("{},{}", s, noisy);
     env_logger::init_from_env(env_logger::Env::default().filter_or("RUST_LOG", spec));
 }

--- a/examples/cli-support/src/prompt.rs
+++ b/examples/cli-support/src/prompt.rs
@@ -24,7 +24,17 @@ pub fn prompt_string<S: AsRef<str>>(prompt: S) -> Option<String> {
 }
 
 pub fn prompt_password<S: AsRef<str>>(prompt: S) -> Option<String> {
-    rpassword::prompt_password(format!("{}: ", prompt.as_ref())).ok()
+    let result = dialoguer::Password::new()
+        .with_prompt(prompt.as_ref().to_string())
+        .with_confirmation("Confirm password", "Passwords mismatching")
+        .interact();
+    match result {
+        Ok(p) => Some(p),
+        Err(e) => {
+            log::warn!("Error getting password: {e}");
+            None
+        }
+    }
 }
 
 pub fn prompt_char(msg: &str) -> Option<char> {

--- a/examples/example-cli/Cargo.toml
+++ b/examples/example-cli/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 cli-support = { path = "../cli-support" }
 example-component = { path = "../../components/example" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
-clap = {version = "4.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0"
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 
 [dependencies]
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+nss = { path = "../../components/support/rc_crypto/nss" }
 log = "0.4"
-simple_logger = "4"
-clap = {version = "4.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }
 anyhow = "1.0"

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -8,7 +8,7 @@ mod send_tab;
 use std::fs;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use cli_support::fxa_creds;
+use cli_support::{fxa_creds, init_logging_with};
 use fxa_client::{FirefoxAccount, FxaConfig, FxaServer};
 
 static CREDENTIALS_FILENAME: &str = "credentials.json";
@@ -67,14 +67,15 @@ enum Command {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    nss::ensure_initialized();
     viaduct_reqwest::use_reqwest_backend();
     if cli.log {
         if cli.debug {
-            simple_logger::init_with_level(log::Level::Debug).unwrap();
+            init_logging_with("debug");
         } else if cli.info {
-            simple_logger::init_with_level(log::Level::Info).unwrap();
+            init_logging_with("info");
         } else {
-            simple_logger::init_with_level(log::Level::Warn).unwrap();
+            init_logging_with("warn");
         }
     }
 

--- a/examples/merino-cli/Cargo.toml
+++ b/examples/merino-cli/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 
 [dependencies]
-clap = { version = "4.2", features = ["derive"] }
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0"
 serde_json = "1.0"
 merino = { path = "../../components/merino" }

--- a/examples/places-autocomplete/Cargo.toml
+++ b/examples/places-autocomplete/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 interrupt-support = { path = "../../components/support/interrupt" }
 sql-support = { path = "../../components/support/sql" }
 types = { path = "../../components/support/types" }
-clap = "4"
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 tempfile = "3.1"
 rand = "0.8"
 find-places-db = { path = "../../components/support/find-places-db" }
@@ -28,4 +28,4 @@ rusqlite = { version = "0.37.0", features = ["functions", "bundled"] }
 # our example doesn't work on Windows), it does get further in the compilation
 # such that "cargo test" etc shows errors in our code rather than in termion.
 [target.'cfg(not(windows))'.dev-dependencies]
-termion = "1.5"
+termion = "4"

--- a/examples/places-autocomplete/src/autocomplete.rs
+++ b/examples/places-autocomplete/src/autocomplete.rs
@@ -13,6 +13,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use termion::screen::IntoAlternateScreen;
 use url::Url;
 
 #[derive(Default, Clone, Debug)]
@@ -465,7 +466,7 @@ mod autocomplete {
 
         let mut stdin = termion::async_stdin();
         let stdout = std::io::stdout().into_raw_mode()?;
-        let mut stdout = termion::screen::AlternateScreen::from(stdout);
+        let mut stdout = stdout.into_alternate_screen()?;
         write!(
             stdout,
             "{}{}Autocomplete demo (press escape to exit){}> ",

--- a/examples/places-utils/Cargo.toml
+++ b/examples/places-utils/Cargo.toml
@@ -29,4 +29,3 @@ structopt = "0.3"
 fxa-client = { path = "../../components/fxa-client" }
 tempfile = "3"
 anyhow = "1.0"
-ctrlc = "3.2.1"

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -217,14 +217,11 @@ fn delete_history(db: &PlacesDb) -> Result<()> {
     Ok(())
 }
 
-fn show_stats(_db: &PlacesDb) -> Result<()> {
-    println!(
-        "Sorry - this has been temporarily enabled to avoid bringing our pretty-printer into m-c"
-    );
-    // db.execute("ANALYZE;", [])?;
-    // println!("Left most column in `stat` is the record count in the table/index");
-    // println!("See the sqlite docs for `sqlite_stat1` for more info.");
-    // sql_support::debug_tools::print_query(db, "SELECT * from sqlite_stat1")?;
+fn show_stats(db: &PlacesDb) -> Result<()> {
+    db.execute("ANALYZE;", [])?;
+    println!("Left most column in `stat` is the record count in the table/index");
+    println!("See the sqlite docs for `sqlite_stat1` for more info.");
+    sql_support::debug_tools::print_query(db, "SELECT * from sqlite_stat1")?;
     Ok(())
 }
 
@@ -465,12 +462,6 @@ fn main() -> Result<()> {
     let db = api.open_connection(ConnectionType::ReadWrite)?;
     // Needed to make the get_registered_sync_engine() calls work.
     std::sync::Arc::clone(&api).register_with_sync_manager();
-
-    ctrlc::set_handler(move || {
-        println!("\nCTRL-C detected, enabling shutdown mode\n");
-        interrupt_support::shutdown();
-    })
-    .unwrap();
 
     match opts.cmd {
         Command::Sync {

--- a/examples/relay-cli/Cargo.toml
+++ b/examples/relay-cli/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-clap = {version = "4.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
 log = "0.4"
 relay = { path = "../../components/relay" }

--- a/examples/relevancy-cli/Cargo.toml
+++ b/examples/relevancy-cli/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 log = "0.4"
 env_logger = { version = "0.10", default-features = false }
-clap = {version = "4.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 cli-support = { path = "../cli-support" }
 interrupt-support = { path = "../../components/support/interrupt" }
 places = { path = "../../components/places" }

--- a/examples/remote-settings-cli/Cargo.toml
+++ b/examples/remote-settings-cli/Cargo.toml
@@ -15,7 +15,7 @@ remote_settings = { features = ["signatures"], path = "../../components/remote_s
 nss = { path = "../../components/support/rc_crypto/nss" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 log = "0.4"
-clap = {version = "4.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0"
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/examples/suggest-cli/Cargo.toml
+++ b/examples/suggest-cli/Cargo.toml
@@ -10,7 +10,7 @@ cli-support = { path = "../cli-support" }
 remote_settings = { path = "../../components/remote_settings" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 log = "0.4"
-clap = {version = "4.2", features = ["derive"]}
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 suggest = { path = "../../components/suggest" }
 anyhow = "1.0"
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }

--- a/examples/sync-pass/Cargo.toml
+++ b/examples/sync-pass/Cargo.toml
@@ -18,10 +18,10 @@ sync-guid = { path = "../../components/support/guid" }
 log = "0.4"
 sql-support = { path = "../../components/support/sql" }
 anyhow = "1.0"
-prettytable-rs = "0.10"
+text-table = { path = "../../components/support/text-table" }
 fxa-client = { path = "../../components/fxa-client" }
 chrono = "0.4"
-clap = "4"
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 cli-support = { path = "../cli-support" }
 tempfile = "3"
 serde_json = "1.0"

--- a/tools/start-bindings/Cargo.toml
+++ b/tools/start-bindings/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1"
 camino = "1"
 cargo_metadata = "0.15"
-clap = { version = "4.2", features = ["derive"] }
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 rinja = "0.3.3"
 serde_yaml = "0.8"
 toml = "0.5"

--- a/tools/uniffi-bindgen-library-mode/Cargo.toml
+++ b/tools/uniffi-bindgen-library-mode/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 uniffi = { version = "0.29.0", features = ["cli"] }
 uniffi_bindgen = { version = "0.29.0" }
-clap = "4"
+clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 cargo_metadata = "0.15"
 camino = "1"
 anyhow = "1"


### PR DESCRIPTION
Upgrade mockall to 0.12.  This removes the duplicate float-cmp package and avoids bringing in `syn` v1 as a dupe.

Don't use `clap` default features.  The `color` feature depends on `anstream`, which would bring in a duplicate `windows-sys` version.

Replace `webbrowser` with `open` and `rpassword` with `dialoguer`.  This also avoids duplicate `windows-sys` versions.

Remove `simple_logger` dependency and use `tracing_support` instead.

Replace `prettytable-rs` with our own table-formatting code.  In addition to bringing in duplicate dependency, it also raises license warnings when building into libxul and I don't want to figure that one out.  The new code supports less than `prettytable-rs`, but the output looks good enough to me.

Update `termion` to avoid the redox-sys dupe.

Remove `ctrlc` dependency to avoid the `windows-sys` dupe.

Combining this change, my other PRs, and a couple build hacks in   moz-central, will reduce the duplicate crates to just the  `foreign-types` crate (and `foreign-types-shared`).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
