### PR TITLE
Add an explicit import for XmlSlurper

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import groovy.xml.XmlSlurper
+
 def libLicense = properties.libLicense
 def libLicenseUrl = properties.libLicenseUrl
 def libRepositoryName = properties.libRepositoryName


### PR DESCRIPTION
Gradle 9 updates the Groovy runtime to version 4, which requires an explicit import for this now.