### PR TITLE
Call viaduct_dev::use_dev_backend unconditionally

### DIFF
--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -23,6 +23,7 @@ pub(crate) static USER_AGENT: &str =
     concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 fn main() -> Result<()> {
+    viaduct_dev::use_dev_backend();
     let cmds = get_commands_from_cli(std::env::args_os())?;
     for c in cmds {
         let success = cmd::process_cmd(&c)?;

--- a/components/support/nimbus-cli/src/sources/experiment_list.rs
+++ b/components/support/nimbus-cli/src/sources/experiment_list.rs
@@ -220,7 +220,6 @@ impl TryFrom<&ExperimentListSource> for Value {
                 is_preview,
             } => {
                 use remote_settings::{RemoteSettings, RemoteSettingsConfig, RemoteSettingsServer};
-                viaduct_dev::use_dev_backend();
                 let collection_name = if *is_preview {
                     "nimbus-preview".to_string()
                 } else {


### PR DESCRIPTION
This makes the `enroll` command work for me, where it was failing before.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
