### PR TITLE
Go back to a callback interface for EventSink

### DIFF
--- a/components/support/tracing/src/layer.rs
+++ b/components/support/tracing/src/layer.rs
@@ -24,7 +24,6 @@ static SINKS_BY_TARGET: LazyLock<RwLock<HashMap<String, LogEntry>>> =
 
 static MIN_LEVEL_SINK: RwLock<Option<LogEntry>> = RwLock::new(None);
 
-#[uniffi::export]
 pub fn register_event_sink(target: &str, level: crate::Level, sink: Arc<dyn EventSink>) {
     SINKS_BY_TARGET.write().insert(
         target.to_string(),
@@ -41,7 +40,6 @@ pub fn register_event_sink(target: &str, level: crate::Level, sink: Arc<dyn Even
 /// If so, sinks registered with `register_event_sink` will be skiped.
 ///
 /// There can only be 1 min-level sink registered at once.
-#[uniffi::export]
 pub fn register_min_level_event_sink(level: crate::Level, sink: Arc<dyn EventSink>) {
     *MIN_LEVEL_SINK.write() = Some(LogEntry {
         level: level.into(),
@@ -58,6 +56,18 @@ pub fn unregister_event_sink(target: &str) {
 #[uniffi::export]
 pub fn unregister_min_level_event_sink() {
     *MIN_LEVEL_SINK.write() = None;
+}
+
+// UniFFI versions of the registration functions.  This input a Box to be compatible with callback
+// interfaces
+#[uniffi::export(name = "register_event_sink")]
+pub fn register_event_sink_box(target: &str, level: crate::Level, sink: Box<dyn EventSink>) {
+    register_event_sink(target, level, sink.into())
+}
+
+#[uniffi::export(name = "register_min_level_event_sink")]
+pub fn register_min_level_event_sink_box(level: crate::Level, sink: Box<dyn EventSink>) {
+    register_min_level_event_sink(level, sink.into())
 }
 
 pub fn simple_event_layer<S>() -> impl Layer<S>

--- a/components/support/tracing/src/lib.rs
+++ b/components/support/tracing/src/lib.rs
@@ -154,7 +154,7 @@ pub struct TracingEvent {
     pub fields: serde_json::Value,
 }
 
-#[uniffi::export(with_foreign)]
+#[uniffi::export(callback_interface)]
 pub trait EventSink: Send + Sync {
     fn on_event(&self, event: Event);
 }


### PR DESCRIPTION
I realized there was an issue with moving to a trait interface: we want to use `FireAndForget` on JS for the methods, but that only works on a callback interface.

I think a callback interface should be fine for this.  We can still implement these traits in Rust and use them -- that's what the tests do. The only thing we can't do is pass a trait impl into JS, but I don't think we have a reason to do that (BTW, this use-case is where trying to implement `FireAndForget` for a trait interface gets tricky).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
