### PR TITLE
Bug 1985115 - Change from global rollout opt-out to experiments and rollouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 description = "A rapid experiment library"

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -141,11 +141,21 @@ open class Nimbus(
 
     private val nimbusClient: NimbusClientInterface
 
-    override var globalUserParticipation: Boolean
-        get() = nimbusClient.getGlobalUserParticipation()
+    override var experimentParticipation: Boolean
+        get() = nimbusClient.getExperimentParticipation()
         set(active) {
             dbScope.launch {
-                setGlobalUserParticipationOnThisThread(active)
+                nimbusClient.setExperimentParticipation(active)
+                applyPendingExperimentsOnThisThread()
+            }
+        }
+
+    override var rolloutParticipation: Boolean
+        get() = nimbusClient.getRolloutParticipation()
+        set(active) {
+            dbScope.launch {
+                nimbusClient.setRolloutParticipation(active)
+                applyPendingExperimentsOnThisThread()
             }
         }
 
@@ -400,13 +410,25 @@ open class Nimbus(
 
     @WorkerThread
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun setGlobalUserParticipationOnThisThread(active: Boolean) = withCatchAll("setGlobalUserParticipation") {
-        val enrolmentChanges = nimbusClient.setGlobalUserParticipation(active)
-        if (enrolmentChanges.isNotEmpty()) {
-            recordExperimentTelemetryEvents(enrolmentChanges)
-            postEnrolmentCalculation()
+    internal fun setExperimentParticipationOnThisThread(active: Boolean) =
+        withCatchAll("setExperimentParticipation") {
+            val enrolmentChanges = nimbusClient.setExperimentParticipation(active)
+            if (enrolmentChanges.isNotEmpty()) {
+                recordExperimentTelemetryEvents(enrolmentChanges)
+                postEnrolmentCalculation()
+            }
         }
-    }
+
+    @WorkerThread
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun setRolloutParticipationOnThisThread(active: Boolean) =
+        withCatchAll("setRolloutParticipation") {
+            val enrolmentChanges = nimbusClient.setRolloutParticipation(active)
+            if (enrolmentChanges.isNotEmpty()) {
+                recordExperimentTelemetryEvents(enrolmentChanges)
+                postEnrolmentCalculation()
+            }
+        }
 
     override fun optOut(experimentId: String) {
         dbScope.launch {

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -199,10 +199,19 @@ interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusE
     fun resetTelemetryIdentifiers() = Unit
 
     /**
-     * Control the opt out for all experiments at once. This is likely a user action.
-     */
-    var globalUserParticipation: Boolean
-        get() = false
+    * Control the opt out for experiments. This is likely a user action.
+    * When set to false, the user will be opted out of all experiments but not rollouts.
+    */
+    var experimentParticipation: Boolean
+        get() = true
+        set(_) = Unit
+
+    /**
+    * Control the opt out for rollouts. This is likely a user action.
+    * When set to false, the user will be opted out of all rollouts but not experiments.
+    */
+    var rolloutParticipation: Boolean
+        get() = true
         set(_) = Unit
 
     override val events: NimbusEventStore

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -450,8 +450,8 @@ class NimbusTests {
             NimbusEvents.disqualification.testGetValue(),
         )
 
-        // Opt out of all experiments
-        nimbus.setGlobalUserParticipationOnThisThread(false)
+        // Opt out of experiments but keep rollouts
+        nimbus.setExperimentParticipationOnThisThread(false)
 
         // Use the Glean test API to check that the valid event is present
         assertNotNull("Event must have a value", NimbusEvents.disqualification.testGetValue())

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -75,6 +75,21 @@ impl Display for NotEnrolledReason {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Participation {
+    pub in_experiments: bool,
+    pub in_rollouts: bool,
+}
+
+impl Default for Participation {
+    fn default() -> Self {
+        Self {
+            in_experiments: true,
+            in_rollouts: true,
+        }
+    }
+}
+
 // These are types we use internally for managing disqualifications.
 
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️
@@ -583,7 +598,7 @@ impl<'a> EnrollmentsEvolver<'a> {
 
     pub(crate) fn evolve_enrollments<E>(
         &mut self,
-        is_user_participating: bool,
+        participation: Participation,
         prev_experiments: &[E],
         next_experiments: &[Experiment],
         prev_enrollments: &[ExperimentEnrollment],
@@ -604,7 +619,7 @@ impl<'a> EnrollmentsEvolver<'a> {
         let next_rollouts = filter_experiments(next_experiments, ExperimentMetadata::is_rollout);
 
         let (next_ro_enrollments, ro_events) = self.evolve_enrollment_recipes(
-            is_user_participating,
+            participation.in_rollouts,
             &prev_rollouts,
             &next_rollouts,
             &ro_enrollments,
@@ -628,7 +643,7 @@ impl<'a> EnrollmentsEvolver<'a> {
             .collect();
 
         let (next_exp_enrollments, exp_events) = self.evolve_enrollment_recipes(
-            is_user_participating,
+            participation.in_experiments,
             &prev_experiments,
             &next_experiments,
             &prev_enrollments,

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -239,10 +239,29 @@ interface NimbusClient {
     [Throws=NimbusError]
     sequence<AvailableExperiment> get_available_experiments();
 
-    /// Getter and setter for user's participation in all experiments.
+    /// Getter and setter for user's participation in experiments only.
     /// Possible values are:
-    /// * `true`: the user will not enroll in new experiments, and opt out of all existing ones.
-    /// * `false`: experiments proceed as usual.
+    /// * `true`: the user will enroll in experiments as usual.
+    /// * `false`: the user will not enroll in new experiments, and opt out of all existing ones.
+    [Throws=NimbusError]
+    boolean get_experiment_participation();
+
+    [Throws=NimbusError]
+    sequence<EnrollmentChangeEvent> set_experiment_participation(boolean opt_in);
+
+    /// Getter and setter for user's participation in rollouts.
+    /// Possible values are:
+    /// * `true`: the user will enroll in rollouts as usual.
+    /// * `false`: the user will not enroll in new rollouts, and opt out of all existing ones.
+    [Throws=NimbusError]
+    boolean get_rollout_participation();
+
+    [Throws=NimbusError]
+    sequence<EnrollmentChangeEvent> set_rollout_participation(boolean opt_in);
+
+    /// DEPRECATED: Use set_experiment_participation and set_rollout_participation instead.
+    /// Getter and setter for global user participation (applies to both experiments and rollouts).
+    /// For simplicity, the getter returns the experiment participation value.
     [Throws=NimbusError]
     boolean get_global_user_participation();
 
@@ -258,7 +277,7 @@ interface NimbusClient {
     /// Toggles the enablement of the fetch. If `false`, then calling `fetch_experiments`
     /// returns immediately, having not done any fetching from remote settings.
     /// This is only useful for QA, and should not be used in production: use
-    /// `set_global_user_participation` instead.
+    /// `set_experiment_participation` or `set_rollout_participation` instead.
     [Throws=NimbusError]
     void set_fetch_enabled(boolean flag);
 

--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -26,8 +26,9 @@ use crate::{
         client::{create_client, SettingsClient},
         dbcache::DatabaseCache,
         enrollment::{
-            get_global_user_participation, opt_in_with_branch, opt_out,
-            reset_telemetry_identifiers, set_global_user_participation, unenroll_for_pref,
+            get_experiment_participation, get_rollout_participation, opt_in_with_branch, opt_out,
+            reset_telemetry_identifiers, set_experiment_participation, set_rollout_participation,
+            unenroll_for_pref,
         },
         gecko_prefs::{
             GeckoPref, GeckoPrefHandler, GeckoPrefState, GeckoPrefStore, PrefBranch,
@@ -252,28 +253,71 @@ impl NimbusClient {
             .ok_or(NimbusError::NoSuchExperiment(slug))
     }
 
-    pub fn get_global_user_participation(&self) -> Result<bool> {
+    pub fn get_experiment_participation(&self) -> Result<bool> {
         let db = self.db()?;
         let reader = db.read()?;
-        get_global_user_participation(db, &reader)
+        get_experiment_participation(db, &reader)
     }
 
-    pub fn set_global_user_participation(
+    pub fn get_rollout_participation(&self) -> Result<bool> {
+        let db = self.db()?;
+        let reader = db.read()?;
+        get_rollout_participation(db, &reader)
+    }
+
+    pub fn set_experiment_participation(
         &self,
         user_participating: bool,
     ) -> Result<Vec<EnrollmentChangeEvent>> {
         let db = self.db()?;
         let mut writer = db.write()?;
         let mut state = self.mutable_state.lock().unwrap();
-        set_global_user_participation(db, &mut writer, user_participating)?;
+        set_experiment_participation(db, &mut writer, user_participating)?;
 
         let existing_experiments: Vec<Experiment> =
             db.get_store(StoreId::Experiments).collect_all(&writer)?;
-        // We pass the existing experiments as "updated experiments"
-        // to the evolver.
         let events = self.evolve_experiments(db, &mut writer, &mut state, &existing_experiments)?;
         self.end_initialize(db, writer, &mut state)?;
         Ok(events)
+    }
+
+    pub fn set_rollout_participation(
+        &self,
+        user_participating: bool,
+    ) -> Result<Vec<EnrollmentChangeEvent>> {
+        let db = self.db()?;
+        let mut writer = db.write()?;
+        let mut state = self.mutable_state.lock().unwrap();
+        set_rollout_participation(db, &mut writer, user_participating)?;
+
+        let existing_experiments: Vec<Experiment> =
+            db.get_store(StoreId::Experiments).collect_all(&writer)?;
+        let events = self.evolve_experiments(db, &mut writer, &mut state, &existing_experiments)?;
+        self.end_initialize(db, writer, &mut state)?;
+        Ok(events)
+    }
+
+    // DEPRECATED: Will be removed once Firefox is using the
+    // new get_experiment_participation and get_rollout_participation
+    pub fn get_global_user_participation(&self) -> Result<bool> {
+        // For simplicity, just return the experiment participation value
+        self.get_experiment_participation()
+    }
+
+    // DEPRECATED: Will be removed once Firefox is using the
+    // new set_experiment_participation and set_rollout_participation
+    pub fn set_global_user_participation(
+        &self,
+        user_participating: bool,
+    ) -> Result<Vec<EnrollmentChangeEvent>> {
+        // Call both set_experiment_participation and set_rollout_participation with the same value
+        let experiment_events = self.set_experiment_participation(user_participating)?;
+        let rollout_events = self.set_rollout_participation(user_participating)?;
+
+        // Combine the events from both calls
+        let mut all_events = experiment_events;
+        all_events.extend(rollout_events);
+        Ok(all_events)
     }
 
     pub fn get_active_experiments(&self) -> Result<Vec<EnrolledExperiment>> {

--- a/components/nimbus/src/stateful/persistence.rs
+++ b/components/nimbus/src/stateful/persistence.rs
@@ -24,8 +24,17 @@ use std::path::Path;
 //
 // ⚠️ Warning : Altering the type of `DB_VERSION` would itself require a DB migration. ⚠️
 pub(crate) const DB_KEY_DB_VERSION: &str = "db_version";
-pub(crate) const DB_VERSION: u16 = 2;
+pub(crate) const DB_VERSION: u16 = 3;
 const RKV_MAX_DBS: u32 = 6;
+
+pub(crate) const DB_KEY_EXPERIMENT_PARTICIPATION: &str = "user-opt-in-experiments";
+pub(crate) const DB_KEY_ROLLOUT_PARTICIPATION: &str = "user-opt-in-rollouts";
+
+// Legacy key for migration purposes
+pub(crate) const DB_KEY_GLOBAL_USER_PARTICIPATION: &str = "user-opt-in";
+
+pub(crate) const DEFAULT_EXPERIMENT_PARTICIPATION: bool = true;
+pub(crate) const DEFAULT_ROLLOUT_PARTICIPATION: bool = true;
 
 // Inspired by Glean - use a feature to choose between the backends.
 // Select the LMDB-powered storage backend when the feature is not activated.
@@ -117,8 +126,10 @@ pub enum StoreId {
     ///     applied to this database.
     ///   * "nimbus-id":    String, the randomly-generated identifier for the
     ///     current client instance.
-    ///   * "user-opt-in":  bool, whether the user has explicitly opted in or out
+    ///   * "user-opt-in-experiments":  bool, whether the user has explicitly opted in or out
     ///     of participating in experiments.
+    ///   * "user-opt-in-rollouts":  bool, whether the user has explicitly opted in or out
+    ///     of participating in rollouts.
     ///   * "installation-date": a UTC DateTime string, defining the date the consuming app was
     ///     installed
     ///   * "update-date": a UTC DateTime string, defining the date the consuming app was
@@ -335,50 +346,50 @@ impl Database {
     fn maybe_upgrade(&self) -> Result<()> {
         debug!("entered maybe upgrade");
         let mut writer = self.rkv.write()?;
-        let db_version = self.meta_store.get::<u16, _>(&writer, DB_KEY_DB_VERSION)?;
-        match db_version {
-            Some(DB_VERSION) => {
-                // Already at the current version, no migration required.
-                info!("Already at version {}, no upgrade needed", DB_VERSION);
-                return Ok(());
-            }
-            Some(1) => {
-                info!("Migrating database from v1 to v2");
-                match self.migrate_v1_to_v2(&mut writer) {
-                    Ok(_) => (),
-                    Err(e) => {
-                        // The idea here is that it's better to leave an
-                        // individual install with a clean empty database
-                        // than in an unknown inconsistent state, because it
-                        // allows them to start participating in experiments
-                        // again, rather than potentially repeating the upgrade
-                        // over and over at each embedding client restart.
-                        error_support::report_error!(
-                            "nimbus-database-migration",
-                            "Error migrating database v1 to v2: {:?}.  Wiping experiments and enrollments",
-                            e
-                        );
-                        self.clear_experiments_and_enrollments(&mut writer)?;
-                    }
-                };
-            }
-            None => {
-                info!("maybe_upgrade: no version number; wiping most stores");
-                // The "first" version of the database (= no version number) had un-migratable data
-                // for experiments and enrollments, start anew.
-                // XXX: We can most likely remove this behaviour once enough time has passed,
-                // since nimbus wasn't really shipped to production at the time anyway.
-                self.clear_experiments_and_enrollments(&mut writer)?;
-            }
-            _ => {
+        let current_version = self
+            .meta_store
+            .get::<u16, _>(&writer, DB_KEY_DB_VERSION)?
+            .unwrap_or(0);
+
+        if current_version == DB_VERSION {
+            info!("Already at version {}, no upgrade needed", DB_VERSION);
+            return Ok(());
+        }
+
+        if current_version == 0 || current_version > DB_VERSION {
+            info!("maybe_upgrade: no version number; wiping most stores");
+            self.clear_experiments_and_enrollments(&mut writer)?;
+            self.updates_store.clear(&mut writer)?;
+            self.meta_store
+                .put(&mut writer, DB_KEY_DB_VERSION, &DB_VERSION)?;
+            writer.commit()?;
+            return Ok(());
+        }
+
+        if current_version == 1 {
+            info!("Migrating database from v1 to v2");
+            if let Err(e) = self.migrate_v1_to_v2(&mut writer) {
                 error_support::report_error!(
-                    "nimbus-unknown-database-version",
-                    "Unknown database version. Wiping all stores."
+                    "nimbus-database-migration",
+                    "Error migrating database v1 to v2: {:?}. Wiping experiments and enrollments",
+                    e
                 );
                 self.clear_experiments_and_enrollments(&mut writer)?;
-                self.meta_store.clear(&mut writer)?;
             }
         }
+
+        if current_version == 2 {
+            info!("Migrating database from v2 to v3");
+            if let Err(e) = self.migrate_v2_to_v3(&mut writer) {
+                error_support::report_error!(
+                    "nimbus-database-migration",
+                    "Error migrating database v2 to v3: {:?}. Wiping experiments and enrollments",
+                    e
+                );
+                self.clear_experiments_and_enrollments(&mut writer)?;
+            }
+        }
+
         // It is safe to clear the update store (i.e. the pending experiments) on all schema upgrades
         // as it will be re-filled from the server on the next `fetch_experiments()`.
         // The current contents of the update store may cause experiments to not load, or worse,
@@ -480,6 +491,50 @@ impl Database {
                 .put(writer, &enrollment.slug, &enrollment)?;
         }
         debug!("exiting migrate_v1_to_v2");
+
+        Ok(())
+    }
+
+    /// Migrates a v2 database to v3
+    ///
+    /// Separates global user participation into experiments and rollouts participation.
+    /// For privacy: if user opted out globally, they remain opted out of experiments.
+    fn migrate_v2_to_v3(&self, writer: &mut Writer) -> Result<()> {
+        info!("Upgrading from version 2 to version 3");
+
+        let meta_store = &self.meta_store;
+
+        // Get the old global participation flag
+        let old_global_participation = meta_store
+            .get::<bool, _>(writer, DB_KEY_GLOBAL_USER_PARTICIPATION)?
+            .unwrap_or(true); // Default was true
+
+        // Set new separate flags based on privacy requirements:
+        // - If user opted out globally, they stay opted out of experiments
+        // - If user opted out globally, they stay opted out of rollouts (per requirement #3)
+        meta_store.put(
+            writer,
+            DB_KEY_EXPERIMENT_PARTICIPATION,
+            &old_global_participation,
+        )?;
+        meta_store.put(
+            writer,
+            DB_KEY_ROLLOUT_PARTICIPATION,
+            &old_global_participation,
+        )?;
+
+        // Remove the old global participation key if it exists
+        if meta_store
+            .get::<bool, _>(writer, DB_KEY_GLOBAL_USER_PARTICIPATION)?
+            .is_some()
+        {
+            meta_store.delete(writer, DB_KEY_GLOBAL_USER_PARTICIPATION)?;
+        }
+
+        info!(
+            "Migration v2->v3: experiments_participation={}, rollouts_participation={}",
+            old_global_participation, old_global_participation
+        );
 
         Ok(())
     }

--- a/components/nimbus/src/tests/stateful/test_enrollment.rs
+++ b/components/nimbus/src/tests/stateful/test_enrollment.rs
@@ -13,8 +13,9 @@ use crate::{
     stateful::{
         behavior::EventStore,
         enrollment::{
-            get_enrollments, opt_in_with_branch, opt_out, reset_telemetry_identifiers,
-            set_global_user_participation,
+            get_enrollments, get_experiment_participation, get_rollout_participation,
+            opt_in_with_branch, opt_out, reset_telemetry_identifiers, set_experiment_participation,
+            set_rollout_participation,
         },
         persistence::{Database, Readable, StoreId},
     },
@@ -186,7 +187,7 @@ fn test_global_opt_out() -> Result<()> {
     let exps = get_test_experiments();
 
     // User has opted out of new experiments.
-    set_global_user_participation(&db, &mut writer, false)?;
+    set_experiment_participation(&db, &mut writer, false)?;
 
     let ids = no_coenrolling_features();
     let mut targeting_helper = th.clone();
@@ -212,7 +213,7 @@ fn test_global_opt_out() -> Result<()> {
     assert_eq!(num_not_enrolled_enrollments, 2);
 
     // User opts in, and updating should enroll us in 2 experiments.
-    set_global_user_participation(&db, &mut writer, true)?;
+    set_experiment_participation(&db, &mut writer, true)?;
 
     let mut targeting_helper = th.clone();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_helper, &ids);
@@ -230,7 +231,7 @@ fn test_global_opt_out() -> Result<()> {
     assert_eq!(num_enrolled_enrollments, 2);
 
     // Opting out and updating should give us two disqualified enrollments
-    set_global_user_participation(&db, &mut writer, false)?;
+    set_experiment_participation(&db, &mut writer, false)?;
 
     let mut targeting_helper = th.clone();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_helper, &ids);
@@ -259,7 +260,7 @@ fn test_global_opt_out() -> Result<()> {
     );
 
     // Opting in again and updating SHOULD NOT enroll us again (we've been disqualified).
-    set_global_user_participation(&db, &mut writer, true)?;
+    set_experiment_participation(&db, &mut writer, true)?;
 
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
     let events = evolver.evolve_enrollments_in_db(&db, &mut writer, &exps)?;
@@ -383,5 +384,158 @@ fn test_telemetry_reset() -> Result<()> {
         && *branch_slug == mock_exp1_branch
     ));
 
+    Ok(())
+}
+
+#[test]
+fn test_experiments_opt_out_with_rollouts_opt_in() -> Result<()> {
+    error_support::init_for_tests();
+    let tmp_dir = tempfile::tempdir()?;
+    let db = Database::new(&tmp_dir)?;
+    let mut writer = db.write()?;
+    let nimbus_id = Uuid::new_v4();
+    let mut th = NimbusTargetingHelper::from(AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    });
+    let aru = AvailableRandomizationUnits::with_nimbus_id(&nimbus_id);
+
+    // Create test experiment and rollout
+    let mut experiment = get_test_experiments()[0].clone();
+    experiment.slug = "test-experiment".to_string();
+    experiment.is_rollout = false;
+
+    let mut rollout = get_test_experiments()[0].clone();
+    rollout.slug = "test-rollout".to_string();
+    rollout.is_rollout = true;
+    rollout.bucket_config.namespace = "test-rollout".to_string();
+
+    // User opts out of experiments but stays opted in to rollouts
+    set_experiment_participation(&db, &mut writer, false)?;
+    set_rollout_participation(&db, &mut writer, true)?;
+
+    // Verify flags are set correctly
+    let exp_participation = get_experiment_participation(&db, &writer)?;
+    let rollouts_participation = get_rollout_participation(&db, &writer)?;
+    println!("Experiments participation: {}", exp_participation);
+    println!("Rollouts participation: {}", rollouts_participation);
+
+    let ids = no_coenrolling_features();
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
+    let _ = evolver.evolve_enrollments_in_db(&db, &mut writer, &[experiment, rollout])?;
+
+    let enrollments = get_experiment_enrollments(&db, &writer)?;
+    println!("Total enrollments: {}", enrollments.len());
+    for enrollment in &enrollments {
+        println!(
+            "Enrollment: slug={}, status={:?}",
+            enrollment.slug, enrollment.status
+        );
+    }
+
+    // Should be enrolled in rollout but not experiment
+    let rollout_enrollment = enrollments.iter().find(|e| e.slug == "test-rollout");
+    let experiment_enrollment = enrollments.iter().find(|e| e.slug == "test-experiment");
+
+    assert!(
+        rollout_enrollment.is_some(),
+        "Rollout enrollment should exist"
+    );
+    assert!(matches!(
+        rollout_enrollment.unwrap().status,
+        EnrollmentStatus::Enrolled { .. }
+    ));
+
+    assert!(
+        experiment_enrollment.is_some(),
+        "Experiment enrollment should exist"
+    );
+    assert!(matches!(
+        experiment_enrollment.unwrap().status,
+        EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::OptOut
+        }
+    ));
+
+    writer.commit()?;
+    Ok(())
+}
+
+#[test]
+fn test_rollouts_opt_out_with_experiments_opt_in() -> Result<()> {
+    error_support::init_for_tests();
+    let tmp_dir = tempfile::tempdir()?;
+    let db = Database::new(&tmp_dir)?;
+    let mut writer = db.write()?;
+    let nimbus_id = Uuid::new_v4();
+    let mut th = NimbusTargetingHelper::from(AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    });
+    let aru = AvailableRandomizationUnits::with_nimbus_id(&nimbus_id);
+
+    // Create test experiment and rollout
+    let mut experiment = get_test_experiments()[0].clone();
+    experiment.slug = "test-experiment".to_string();
+    experiment.is_rollout = false;
+
+    let mut rollout = get_test_experiments()[0].clone();
+    rollout.slug = "test-rollout".to_string();
+    rollout.is_rollout = true;
+    rollout.bucket_config.namespace = "test-rollout".to_string();
+
+    // User opts out of rollouts but stays opted in to experiments
+    set_experiment_participation(&db, &mut writer, true)?;
+    set_rollout_participation(&db, &mut writer, false)?;
+
+    // Verify flags are set correctly (using the same writer)
+    let exp_participation = get_experiment_participation(&db, &writer)?;
+    let rollouts_participation = get_rollout_participation(&db, &writer)?;
+    println!("Experiments participation: {}", exp_participation);
+    println!("Rollouts participation: {}", rollouts_participation);
+
+    let ids = no_coenrolling_features();
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
+    let _events = evolver.evolve_enrollments_in_db(&db, &mut writer, &[experiment, rollout])?;
+
+    // Use the same helper function as the working test
+    let enrollments = get_experiment_enrollments(&db, &writer)?;
+    println!("Total enrollments: {}", enrollments.len());
+    for enrollment in &enrollments {
+        println!(
+            "Enrollment: slug={}, status={:?}",
+            enrollment.slug, enrollment.status
+        );
+    }
+
+    // Should be enrolled in experiment but not rollout
+    let experiment_enrollment = enrollments.iter().find(|e| e.slug == "test-experiment");
+    let rollout_enrollment = enrollments.iter().find(|e| e.slug == "test-rollout");
+
+    assert!(
+        experiment_enrollment.is_some(),
+        "Experiment enrollment should exist"
+    );
+    assert!(matches!(
+        experiment_enrollment.unwrap().status,
+        EnrollmentStatus::Enrolled { .. }
+    ));
+
+    assert!(
+        rollout_enrollment.is_some(),
+        "Rollout enrollment should exist"
+    );
+    assert!(matches!(
+        rollout_enrollment.unwrap().status,
+        EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::OptOut
+        }
+    ));
+
+    writer.commit()?;
     Ok(())
 }

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -908,7 +908,7 @@ fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -
 
     client.record_event("app.foregrounded".to_string(), 1)?;
 
-    client.set_global_user_participation(true)?;
+    client.set_experiment_participation(true)?;
 
     // The number of non-zero days in our event store is 2, so the first experiment
     // should be applied, but the second experiment will not be.

--- a/components/nimbus/src/tests/stateful/test_persistence.rs
+++ b/components/nimbus/src/tests/stateful/test_persistence.rs
@@ -5,6 +5,7 @@
 use crate::{
     enrollment::ExperimentEnrollment,
     error::{debug, Result},
+    stateful::enrollment::{get_experiment_participation, get_rollout_participation},
     stateful::persistence::*,
     Experiment,
 };
@@ -769,5 +770,91 @@ fn test_migrate_db_v1_with_valid_and_invalid_records_to_db_v2() -> Result<()> {
     // us with only one.
     assert_eq!(enrollments.len(), 1);
 
+    Ok(())
+}
+
+#[test]
+fn test_migrate_db_v2_to_v3_user_opted_out() -> Result<()> {
+    error_support::init_for_tests();
+    let tmp_dir = tempfile::tempdir()?;
+
+    // Create a v2 database where user opted out globally
+    create_old_database_v2_with_global_participation(&tmp_dir, false)?;
+
+    // Open with new version - should trigger migration
+    let db = Database::new(&tmp_dir)?;
+
+    // Check the database was upgraded to v3
+    assert_eq!(db.get(StoreId::Meta, DB_KEY_DB_VERSION)?, Some(3u16));
+
+    // Check that separate flags were set correctly for opted-out user
+    let reader = db.read()?;
+    assert!(
+        !get_experiment_participation(&db, &reader)?, // Should preserve opt-out choice for experiments
+    );
+    assert!(
+        !get_rollout_participation(&db, &reader)?, // Should preserve opt-out choice for rollouts
+    );
+
+    // Check old key was removed
+    assert_eq!(
+        db.get::<bool>(StoreId::Meta, DB_KEY_GLOBAL_USER_PARTICIPATION)?,
+        None
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_migrate_db_v2_to_v3_user_opted_in() -> Result<()> {
+    error_support::init_for_tests();
+    let tmp_dir = tempfile::tempdir()?;
+
+    // Create a v2 database where user was opted in globally
+    create_old_database_v2_with_global_participation(&tmp_dir, true)?;
+
+    let db = Database::new(&tmp_dir)?;
+
+    // Check the database was upgraded to v3
+    assert_eq!(db.get(StoreId::Meta, DB_KEY_DB_VERSION)?, Some(3u16));
+
+    // Check that separate flags were set correctly for opted-in user
+    let reader = db.read()?;
+    assert!(
+        get_experiment_participation(&db, &reader)?, // Should preserve opt-in choice for experiments
+    );
+    assert!(
+        get_rollout_participation(&db, &reader)?, // Should preserve opt-in choice for rollouts
+    );
+
+    // Check old key was removed
+    assert_eq!(
+        db.get::<bool>(StoreId::Meta, DB_KEY_GLOBAL_USER_PARTICIPATION)?,
+        None
+    );
+
+    Ok(())
+}
+
+// Helper function to create a v2 database with global participation flag
+fn create_old_database_v2_with_global_participation(
+    tmp_dir: &tempfile::TempDir,
+    global_participation: bool,
+) -> Result<()> {
+    let rkv = Database::open_rkv(tmp_dir)?;
+    let meta_store = SingleStore::new(rkv.open_single("meta", StoreOptions::create())?);
+    let mut writer = rkv.write()?;
+
+    // Set version to 2
+    meta_store.put(&mut writer, DB_KEY_DB_VERSION, &2u16)?;
+
+    // Set global participation flag (the old way)
+    meta_store.put(
+        &mut writer,
+        DB_KEY_GLOBAL_USER_PARTICIPATION,
+        &global_participation,
+    )?;
+
+    writer.commit()?;
     Ok(())
 }

--- a/components/nimbus/src/tests/stateless/test_cirrus_client.rs
+++ b/components/nimbus/src/tests/stateless/test_cirrus_client.rs
@@ -4,7 +4,9 @@
 
 use crate::metrics::EnrollmentStatusExtraDef;
 use crate::{
-    enrollment::{EnrollmentChangeEventType, ExperimentEnrollment, NotEnrolledReason},
+    enrollment::{
+        EnrollmentChangeEventType, ExperimentEnrollment, NotEnrolledReason, Participation,
+    },
     tests::{
         helpers::TestMetrics,
         stateless::test_cirrus_client::helpers::get_experiment_with_newtab_feature_branches,
@@ -45,8 +47,12 @@ fn test_can_enroll() -> Result<()> {
         .set_experiments(to_string(&HashMap::from([("data", &[exp.clone()])])).unwrap())
         .unwrap();
 
-    let result = client.enroll("test".to_string(), Default::default(), true, &[])?;
-
+    let result = client.enroll(
+        "test".to_string(),
+        Default::default(),
+        Participation::default(),
+        &[],
+    )?;
     assert_eq!(result.enrolled_feature_config_map.len(), 1);
     assert_eq!(
         result
@@ -81,7 +87,12 @@ fn test_will_not_enroll_if_previously_did_not_enroll() -> Result<()> {
         },
     };
 
-    let result = client.enroll("test".to_string(), Default::default(), true, &[enrollment])?;
+    let result = client.enroll(
+        "test".to_string(),
+        Default::default(),
+        Participation::default(),
+        &[enrollment],
+    )?;
 
     assert_eq!(result.events.len(), 0);
 
@@ -107,6 +118,10 @@ fn test_handle_enrollment_works_with_json() -> Result<()> {
                 Value::String("en-US".to_string()),
             )]))
             .unwrap(),
+        ),
+        (
+            "participation".to_string(),
+            to_value(Participation::default()).unwrap(),
         ),
         (
             "nextExperiments".to_string(),
@@ -196,7 +211,12 @@ fn test_sends_metrics_on_enrollment() -> Result<()> {
     client
         .set_experiments(to_string(&HashMap::from([("data", &[exp.clone()])])).unwrap())
         .unwrap();
-    client.enroll("test".to_string(), Default::default(), true, &[])?;
+    client.enroll(
+        "test".to_string(),
+        Default::default(),
+        Participation::default(),
+        &[],
+    )?;
 
     let metric_records: Vec<EnrollmentStatusExtraDef> = metrics_handler.get_enrollment_statuses();
     assert_eq!(metric_records.len(), 1);

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -836,7 +836,8 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let ro = get_bucketed_rollout(slug, 0);
     let recipes = [ro];
 
-    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(true, &[], &recipes, &[])?;
+    let (enrollments, _) =
+        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], &recipes, &[])?;
 
     assert_eq!(enrollments.len(), 1);
     let enr = enrollments.first().unwrap();
@@ -849,7 +850,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -865,7 +866,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -897,7 +898,8 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let ro = get_bucketed_rollout(slug, 0);
     let recipes = [ro];
 
-    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(true, &[], &recipes, &[])?;
+    let (enrollments, _) =
+        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], &recipes, &[])?;
 
     assert_eq!(enrollments.len(), 1);
     let enr = enrollments.first().unwrap();
@@ -910,7 +912,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -926,7 +928,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -948,7 +950,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -979,7 +981,7 @@ fn test_experiment_does_not_reenroll_from_disqualified_not_selected_or_not_targe
     let recipes = [exp_1, exp_2];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &recipes,
         &recipes,
         &[
@@ -1180,7 +1182,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = vec![];
     let updated_experiments = get_feature_conflict_test_experiments();
     let (enrollments, _events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1220,7 +1222,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments = get_feature_conflict_test_experiments();
     let (enrollments, _events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1247,7 +1249,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments = get_feature_conflict_test_experiments();
     let (enrollments, _events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1270,7 +1272,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments: Vec<Experiment> = vec![];
     let (enrollments, _events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1332,8 +1334,12 @@ fn test_evolver_experiment_not_enrolled_feature_conflict() -> Result<()> {
     let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
-    let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
+    let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
+        Participation::default(),
+        &[],
+        &test_experiments,
+        &[],
+    )?;
 
     assert_eq!(
         enrollments.len(),
@@ -1394,8 +1400,12 @@ fn test_multi_feature_per_branch_conflict() -> Result<()> {
     let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
-    let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
+    let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
+        Participation::default(),
+        &[],
+        &test_experiments,
+        &[],
+    )?;
 
     let enrolled_count = enrollments
         .iter()
@@ -1434,8 +1444,12 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
     let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
-    let (enrollments, _) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
+    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
+        Participation::default(),
+        &[],
+        &test_experiments,
+        &[],
+    )?;
 
     let enrolled_count = enrollments
         .iter()
@@ -1448,7 +1462,7 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
 
     let conflicting_experiment = get_conflicting_experiment();
     let (enrollments, events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &test_experiments,
         &[test_experiments[1].clone(), conflicting_experiment.clone()],
         &enrollments,
@@ -1497,8 +1511,12 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     // 1. we have two experiments that use one feature each. There's no conflicts.
     let next_experiments = vec![aboutwelcome_experiment.clone(), newtab_experiment.clone()];
 
-    let (enrollments, _) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], &next_experiments, &[])?;
+    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
+        Participation::default(),
+        &[],
+        &next_experiments,
+        &[],
+    )?;
 
     let feature_map =
         map_features_by_feature_id(&enrollments, &next_experiments, &no_coenrolling_features());
@@ -1536,7 +1554,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         mixed_experiment.clone(),
     ];
     let (enrollments, events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1580,7 +1598,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![newtab_experiment.clone(), mixed_experiment.clone()];
     let (enrollments, _) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1612,7 +1630,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![mixed_experiment.clone()];
     let (enrollments, _) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1648,7 +1666,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = vec![];
     let next_experiments = vec![mixed_experiment.clone()];
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1663,7 +1681,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         mixed_experiment.clone(),
     ];
     let (enrollments, events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1704,7 +1722,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![mixed_experiment, multi_feature_experiment.clone()];
     let (enrollments, events) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1744,7 +1762,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![multi_feature_experiment];
     let (enrollments, _) = evolver.evolve_enrollments(
-        true,
+        Participation::default(),
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -2271,8 +2289,12 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
     let test_experiments = get_test_experiments();
 
     // this should not return an error
-    let (enrollments, events) =
-        evolver.evolve_enrollments(true, &test_experiments, &test_experiments, &[])?;
+    let (enrollments, events) = evolver.evolve_enrollments(
+        Participation::default(),
+        &test_experiments,
+        &test_experiments,
+        &[],
+    )?;
 
     assert_eq!(
         enrollments.len(),
@@ -2289,7 +2311,7 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
     // Test that evolve_enrollments correctly handles the case where a
     // record with a previous enrollment gets dropped
     let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
-        true,
+        Participation::default(),
         &[],
         &test_experiments,
         &existing_enrollments[..],
@@ -2324,8 +2346,12 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
     let test_experiments = &[test_experiment];
     // The user should get enrolled, since the targeting is OR'ing the app_id == 'org.mozilla.fenix'
     // and the 'is_already_enrolled'
-    let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], test_experiments, &[])?;
+    let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
+        Participation::default(),
+        &[],
+        test_experiments,
+        &[],
+    )?;
     assert_eq!(
         enrollments.len(),
         1,
@@ -2343,8 +2369,12 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
 
     // The user should still be enrolled, since the targeting is OR'ing the app_id == 'org.mozilla.fenix'
     // and the 'is_already_enrolled'
-    let (enrollments, events) =
-        evolver.evolve_enrollments(true, test_experiments, test_experiments, &enrollments)?;
+    let (enrollments, events) = evolver.evolve_enrollments(
+        Participation::default(),
+        test_experiments,
+        test_experiments,
+        &enrollments,
+    )?;
     assert_eq!(
         enrollments.len(),
         1,
@@ -2626,7 +2656,7 @@ fn test_evolver_rollouts_do_not_conflict_with_experiments() -> Result<()> {
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
+        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], recipes, &[])?;
     assert_eq!(enrollments.len(), 2);
     assert_eq!(events.len(), 2);
 
@@ -2687,7 +2717,7 @@ fn test_evolver_rollouts_do_not_conflict_with_rollouts() -> Result<()> {
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
+        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], recipes, &[])?;
     assert_eq!(enrollments.len(), 3);
     assert_eq!(events.len(), 3);
 
@@ -2913,7 +2943,7 @@ fn test_rollouts_end_to_end() -> Result<()> {
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
     let (enrollments, _events) =
-        evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
+        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], recipes, &[])?;
 
     let features = map_features_by_feature_id(&enrollments, recipes, &no_coenrolling_features());
 

--- a/components/nimbus/tests/test_get_experiment_branch_by_id.rs
+++ b/components/nimbus/tests/test_get_experiment_branch_by_id.rs
@@ -81,7 +81,7 @@ fn test_enrolled() -> Result<()> {
             experiment_slug
         );
     }
-    client.set_global_user_participation(false)?;
+    client.set_experiment_participation(false)?;
     for experiment_slug in experiment_slugs {
         assert_eq!(
             client.get_experiment_branch(experiment_slug.to_string())?,

--- a/components/nimbus/uniffi.toml
+++ b/components/nimbus/uniffi.toml
@@ -18,4 +18,4 @@ ffi_module_filename = "nimbusFFI"
 # This can be commented out, and the `--library` argument of `bindgen-uniffi` should be used instead.
 # We won't comment this out until cirrus— which a) does not use `--library` b) is not in this repo— uses the pre-built
 # binaries built by `server-megazord-build.py`. Until then, it comments out the line programmatically.
-cdylib_name = "cirrus"
+# cdylib_name = "cirrus"

--- a/components/support/nimbus-fml/uniffi.toml
+++ b/components/support/nimbus-fml/uniffi.toml
@@ -6,9 +6,9 @@
 # This can be commented out, and the `--library` argument of `bindgen-uniffi` should be used instead.
 # We won't comment this out until cirrus— which a) does not use `--library` b) is not in this repo— uses the pre-built
 # binaries built by `server-megazord-build.py`. Until then, it comments out the line programmatically.
-cdylib_name = "cirrus"
+# cdylib_name = "cirrus"
 
 [bindings.python.custom_types.JsonObject]
-imports = [ "json" ]
+imports = ["json"]
 into_custom = "json.loads({})"
 from_custom = "json.dumps({})"

--- a/megazords/cirrus/tests/python-tests/conftest.py
+++ b/megazords/cirrus/tests/python-tests/conftest.py
@@ -94,6 +94,7 @@ def req(request_context):
             {
                 "clientId": client_id,
                 "requestContext": request_context,
+                "participation": {"in_experiments": True, "in_rollouts": True},
             }
         )
 

--- a/megazords/cirrus/tests/python-tests/test_cirrus_fml_integration.py
+++ b/megazords/cirrus/tests/python-tests/test_cirrus_fml_integration.py
@@ -17,6 +17,7 @@ def test_enroll_and_get_enrolled_feature_json_control(fml_client, cirrus_client)
         {
             "clientId": "jeddai",
             "requestContext": {"username": "jeddai"},
+            "participation": {"in_experiments": True, "in_rollouts": True},
         }
     )
     res = json.loads(cirrus_client.handle_enrollment(req))
@@ -50,6 +51,7 @@ def test_enroll_and_get_enrolled_feature_json_treatment(fml_client, cirrus_clien
         {
             "clientId": "test",
             "requestContext": {"username": "test"},
+            "participation": {"in_experiments": True, "in_rollouts": True},
         }
     )
     res = json.loads(cirrus_client.handle_enrollment(req))

--- a/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
+++ b/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
@@ -222,8 +222,13 @@ private extension Nimbus {
  * Methods split out onto a separate internal extension for testing purposes.
  */
 extension Nimbus {
-    func setGlobalUserParticipationOnThisThread(_ value: Bool) throws {
-        let changes = try nimbusClient.setGlobalUserParticipation(optIn: value)
+    func setExperimentParticipationOnThisThread(_ value: Bool) throws {
+        let changes = try nimbusClient.setExperimentParticipation(optIn: value)
+        postEnrollmentCalculation(changes)
+    }
+
+    func setRolloutParticipationOnThisThread(_ value: Bool) throws {
+        let changes = try nimbusClient.setRolloutParticipation(optIn: value)
         postEnrollmentCalculation(changes)
     }
 
@@ -266,13 +271,24 @@ extension Nimbus {
 }
 
 extension Nimbus: NimbusUserConfiguration {
-    public var globalUserParticipation: Bool {
+    public var experimentParticipation: Bool {
         get {
-            catchAll { try nimbusClient.getGlobalUserParticipation() } ?? false
+            catchAll { try nimbusClient.getExperimentParticipation() } ?? true
         }
         set {
             _ = catchAll(dbQueue) { _ in
-                try self.setGlobalUserParticipationOnThisThread(newValue)
+                try self.setExperimentParticipationOnThisThread(newValue)
+            }
+        }
+    }
+
+    public var rolloutParticipation: Bool {
+        get {
+            catchAll { try nimbusClient.getRolloutParticipation() } ?? true
+        }
+        set {
+            _ = catchAll(dbQueue) { _ in
+                try self.setRolloutParticipationOnThisThread(newValue)
             }
         }
     }
@@ -429,7 +445,8 @@ extension Nimbus: NimbusMessagingProtocol {
 public class NimbusDisabled: NimbusApi {
     public static let shared = NimbusDisabled()
 
-    public var globalUserParticipation: Bool = false
+    public var experimentParticipation: Bool = true
+    public var rolloutParticipation: Bool = true
 }
 
 public extension NimbusDisabled {

--- a/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
+++ b/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
@@ -146,9 +146,12 @@ public protocol NimbusUserConfiguration {
     /// Call this when toggling user preferences about sending analytics.
     func resetTelemetryIdentifiers()
 
-    /// Control the opt out for all experiments at once. This is likely a user action.
+    /// Control the opt out for all experiments. This is likely a user action.
     ///
-    var globalUserParticipation: Bool { get set }
+    var experimentParticipation: Bool { get set }
+    /// Control the opt out for all rollouts at once. This is likely a user action.
+    ///
+    var rolloutParticipation: Bool { get set }
 
     /// Get the list of currently enrolled experiments
     ///

--- a/megazords/ios-rust/tests/MozillaRustComponentsTests/NimbusTests.swift
+++ b/megazords/ios-rust/tests/MozillaRustComponentsTests/NimbusTests.swift
@@ -188,7 +188,7 @@ class NimbusTests: XCTestCase {
             return self.minimalExperimentJSON()
         }
 
-        let finishedNormally = job.joinOrTimeout(timeout: 4.0)
+        let finishedNormally = job.joinOrTimeout(timeout: 10.0)
         XCTAssertTrue(finishedNormally)
 
         let noExperiments = nimbus.getActiveExperiments()
@@ -474,7 +474,7 @@ class NimbusTests: XCTestCase {
 
         // Opt out of all experiments, which should generate a "disqualification" event for the enrolled
         // experiment
-        try nimbus.setGlobalUserParticipationOnThisThread(false)
+        try nimbus.setExperimentParticipationOnThisThread(false)
 
         // Use the Glean test API to check that the valid event is present
         XCTAssertNotNil(GleanMetrics.NimbusEvents.disqualification.testGetValue(), "Event must have a value")


### PR DESCRIPTION
- Adding db migration from v2 to v3 due to the flag change
- Removing the old set_global_rollout function
- Adding set_experiment and set_rollout functions
- Export four new functions via UDL	
    - get_rollouts_user_participation
    - set_rollouts_user_participation
    - get_experiments_user_participation
    - set_experiments_user_participation

- Backwards compatible by leaving `set_global_user_participation` and `get_global_user_participation` accessible, which internally calls the new methods.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
