### PR TITLE
`start-bindings` fix for Rust crates with hyphens.

### DIFF
--- a/docs/howtos/adding-a-new-component.md
+++ b/docs/howtos/adding-a-new-component.md
@@ -73,6 +73,16 @@ dependencies {
 }
 ```
 
+### Async dependencies
+
+If your components exports async functions, add the following to your `android/build.gradle` file:
+
+```
+dependencies {
+    implementation libs.kotlin.coroutines
+}
+```
+
 ### Hand-written code
 
 You can include hand-written Kotlin code alongside the automatically

--- a/tools/start-bindings/templates/build.gradle
+++ b/tools/start-bindings/templates/build.gradle
@@ -2,7 +2,7 @@ apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
 apply from: "$appServicesRootDir/publish.gradle"
 
 android {
-    namespace 'org.mozilla.appservices.{{ crate_name }}'
+    namespace 'org.mozilla.appservices.{{ kotlin_module_name }}'
 }
 
 ext.configureUniFFIBindgen("{{ crate_name }}")


### PR DESCRIPTION
I noticed this when I tried to create bindings for `fairy-bridge`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
