### PR TITLE
Bug 1982929 - Revert Update to jexl-eval 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,9 +2362,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jexl-eval"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96249d99282a5d9c4f42ed49545eb2256c365f1b658eeb930ad7ca516337111"
+checksum = "fdd8dfc8744f1f59d47f7f3bc1378047ecc15fef5709942fbcc8d0d9f846e506"
 dependencies = [
  "anyhow",
  "jexl-parser",
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "jexl-parser"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78569e0a83d98b0ff28fa79f7a7ea9815085f2dc6259d47700bf2fcbbaad4a50"
+checksum = "07cc5fb813f07eceed953a76345a8af76038ee4101c32dc3740e040595013a84"
 dependencies = [
  "lalrpop-util",
  "regex",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1"
 thiserror = "1"
 url = "2.5"
 rkv = { version = "0.19", optional = true }
-jexl-eval = "0.4.0"
+jexl-eval = "0.3.0"
 uuid = { version = "1.3", features = ["serde", "v4"]}
 sha2 = "^0.10"
 hex = "0.4"

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -26,7 +26,7 @@ viaduct = { path = "../viaduct" }
 url = "2"
 camino = "1.0"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
-jexl-eval = { version = "0.4.0" }
+jexl-eval = { version = "0.3.0" }
 regex = "1.9"
 anyhow = "1.0"
 firefox-versioning = { path = "../support/firefox-versioning" }


### PR DESCRIPTION
This reverts commit 99864a13049ff605671e4d84b292c93f4322ce9a.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
