### PR TITLE
Bug 1983107 - Update to jexl-eval 0.4.0 [ci full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,9 +2362,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jexl-eval"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd8dfc8744f1f59d47f7f3bc1378047ecc15fef5709942fbcc8d0d9f846e506"
+checksum = "c96249d99282a5d9c4f42ed49545eb2256c365f1b658eeb930ad7ca516337111"
 dependencies = [
  "anyhow",
  "jexl-parser",
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "jexl-parser"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cc5fb813f07eceed953a76345a8af76038ee4101c32dc3740e040595013a84"
+checksum = "78569e0a83d98b0ff28fa79f7a7ea9815085f2dc6259d47700bf2fcbbaad4a50"
 dependencies = [
  "lalrpop-util",
  "regex",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1"
 thiserror = "1"
 url = "2.5"
 rkv = { version = "0.19", optional = true }
-jexl-eval = "0.3.0"
+jexl-eval = "0.4.0"
 uuid = { version = "1.3", features = ["serde", "v4"]}
 sha2 = "^0.10"
 hex = "0.4"

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import mozilla.appservices.remotesettings.RemoteSettingsConfig
 import mozilla.appservices.remotesettings.RemoteSettingsServer
@@ -460,6 +461,9 @@ open class Nimbus(
             }
         }
     }
+
+    override fun recordEventSync(count: Long, eventId: String) =
+        nimbusClient.recordEvent(eventId, count)
 
     override fun recordPastEvent(count: Long, eventId: String, secondsAgo: Long) =
         nimbusClient.recordPastEvent(eventId, secondsAgo, count)

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -250,6 +250,13 @@ interface NimbusEventStore {
         recordEvent(1, eventId)
 
     /**
+     * Record an event synchronously on the main thread.
+     *
+     * For testing only.
+     */
+    fun recordEventSync(count: Long = 1, eventId: String) = Unit
+
+    /**
      * Records an event as if it were emitted in the past.
      *
      * This method is only likely useful during testing, and so is by design synchronous.

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/EventStoreTest.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/EventStoreTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.experiments.nimbus
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,7 +45,7 @@ class EventStoreTest {
     @Test
     fun `advancing time into the future`() {
         val helper = createHelper()
-        events.recordEvent(eventId)
+        events.recordEventSync(1, eventId)
 
         assertTrue(helper.evalJexl("'$eventId'|eventLastSeen('Days') == 0"))
 

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -26,7 +26,7 @@ viaduct = { path = "../viaduct" }
 url = "2"
 camino = "1.0"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
-jexl-eval = { version = "0.3.0" }
+jexl-eval = { version = "0.4.0" }
 regex = "1.9"
 anyhow = "1.0"
 firefox-versioning = { path = "../support/firefox-versioning" }


### PR DESCRIPTION
Nimbus now exposes a test only `recordEventSync` method to use in tests becuase `recordEvent` dispatches the event recording to a background thread. Because the new JEXL parser is so fast, our EventStoreTests are now intermittently failing as the event recording hasn't finished by the time we actually evaluate the JEXL expressions. Using `recordEventSync` bypasses this issue entirely.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
