### PR TITLE
gradle tweaks for the monorepo - updated build.gradle for glean.

### DIFF
--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -1,3 +1,23 @@
+buildscript {
+    // in mozilla-central there's no build.gradle suitable for the maven/glean config, so each component gets it.
+    if (gradle.hasProperty("mozconfig")) {
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
+
+        dependencies {
+            classpath libs.glean.gradle.plugin
+        }
+    }
+}
+
 plugins {
     alias libs.plugins.python.envs.plugin
 }

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -1,3 +1,23 @@
+buildscript {
+    // in mozilla-central there's no build.gradle suitable for the maven/glean config, so each component gets it.
+    if (gradle.hasProperty("mozconfig")) {
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
+
+        dependencies {
+            classpath libs.glean.gradle.plugin
+        }
+    }
+}
+
 plugins {
     alias libs.plugins.python.envs.plugin
 }

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -1,3 +1,23 @@
+buildscript {
+    // in mozilla-central there's no build.gradle suitable for the maven/glean config, so each component gets it.
+    if (gradle.hasProperty("mozconfig")) {
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
+
+        dependencies {
+            classpath libs.glean.gradle.plugin
+        }
+    }
+}
+
 plugins {
     alias libs.plugins.python.envs.plugin
 }

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -1,3 +1,23 @@
+buildscript {
+    // in mozilla-central there's no build.gradle suitable for the maven/glean config, so each component gets it.
+    if (gradle.hasProperty("mozconfig")) {
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
+
+        dependencies {
+            classpath libs.glean.gradle.plugin
+        }
+    }
+}
+
 plugins {
     alias libs.plugins.python.envs.plugin
 }

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -1,3 +1,23 @@
+buildscript {
+    // in mozilla-central there's no build.gradle suitable for the maven/glean config, so each component gets it.
+    if (gradle.hasProperty("mozconfig")) {
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
+
+        dependencies {
+            classpath libs.glean.gradle.plugin
+        }
+    }
+}
+
 plugins {
     alias libs.plugins.python.envs.plugin
 }


### PR DESCRIPTION
Because there's no "global" build.gradle in mozilla-firefox where glean plugin
references can live, we use the same approach already used there - each component's
build.gradle duplicates that configuration.

cc @rvandermeulen in case this is of interest for you.