### PR TITLE
Bug 1985109 - Use termcolor in nimbus-fml and nimbus-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2923,9 +2923,9 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
+ "cfg-if 1.0.0",
  "chrono",
  "clap 4.5.39",
- "console",
  "copypasta",
  "glob",
  "heck 0.4.1",
@@ -2937,6 +2937,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.21",
+ "termcolor",
  "thiserror 1.0.69",
  "tokio",
  "tower",
@@ -2965,7 +2966,6 @@ dependencies = [
  "askama",
  "cfg-if 1.0.0",
  "clap 4.5.39",
- "console",
  "email_address",
  "glob",
  "heck 0.3.3",
@@ -2978,6 +2978,7 @@ dependencies = [
  "serde_yaml 0.8.24",
  "sha2",
  "tempfile",
+ "termcolor",
  "textwrap 0.14.2",
  "thiserror 1.0.69",
  "unicode-segmentation",
@@ -4721,9 +4722,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]

--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -21,7 +21,6 @@ thiserror = "1.0.29"
 unicode-segmentation = "1.8.0"
 viaduct = { path = "../../viaduct" }
 viaduct-dev = { path = "../viaduct-dev" }
-console = "0.15.5"
 glob = "0.3.1"
 heck = "0.4.1"
 whoami = "1.4.0"
@@ -37,3 +36,5 @@ tower-http = { version = "0.4.1", optional = true, features = ["fs", "set-header
 tower-livereload = { version = "0.8.0", optional = true }
 hyper = { version = "0.14.27", optional = true, features = ["server"] }
 local-ip-address = { version = "0.5.4", optional = true }
+cfg-if = "1.0.0"
+termcolor = "1.4.1"

--- a/components/support/nimbus-cli/src/updater/taskcluster.rs
+++ b/components/support/nimbus-cli/src/updater/taskcluster.rs
@@ -49,10 +49,7 @@ impl HttpClient for GunzippingHttpClient {
 
 /// Check the specifically crafted JSON file for this package to see if there has been a change in version.
 /// This is done every hour.
-pub(crate) fn check_taskcluster_for_update<F>(message: F)
-where
-    F: Fn(&str, &str),
-{
+pub(crate) fn check_taskcluster_for_update() -> Option<(String, String)> {
     let name = env!("CARGO_PKG_NAME");
     let version = env!("CARGO_PKG_VERSION");
     let interval = Duration::from_secs(60 * 60);
@@ -67,6 +64,8 @@ where
         update_informer::fake(TaskClusterRegistry, name, version, "1.0.0").interval(interval);
 
     if let Ok(Some(new_version)) = informer.check_version() {
-        message(&format!("v{version}"), &new_version.to_string());
+        Some((format!("v{version}"), new_version.to_string()))
+    } else {
+        None
     }
 }

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -28,13 +28,13 @@ url = { version = "2", features = ["serde"] }
 glob = "0.3.0"
 uniffi = { version = "0.29.0", optional = true }
 cfg-if = "1.0.0"
-console = "0.15.5"
 lazy_static = "1.4"
 email_address = { version = "0.2.4", features = ["serde"] }
 sha2 = "^0.10"
 itertools = "0"
 regex = "1.9"
 viaduct = { path = "../../viaduct/" }
+termcolor = "1.4.1"
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features = ["build"], optional = true }


### PR DESCRIPTION
A small refactoring change was made in taskcluster.rs so that it now returns an `Option<(old_verison, new_version)>` if there is a pending update (instead of calling a provided function with the same).

Additionally, printing experiments or lists of experiments will now return `Err(..)` if we fail to write to stdout, instead of ignoring those errors and continuing to try to write lines to stdout.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
