### PR TITLE
Fix dependencies task now that bincode has moved away from github

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -538,7 +538,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>MIT License: bincode</name>
-    <url>https://github.com/servo/bincode/blob/master/LICENSE.md</url>
+    <url>https://git.sr.ht/~stygianentity/bincode/blob/trunk/LICENSE.md</url>
   </license>
   <license>
     <name>MIT License: bytes</name>

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -495,7 +495,6 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
-[linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -210,6 +210,12 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/remram44/adler32-rs/master/LICENSE",
         }
     },
+    "bincode": {
+        "license_file": {
+            "check": None,
+            "fixup": "https://git.sr.ht/~stygianentity/bincode/blob/trunk/LICENSE.md",
+        }
+    },
     # These packages are a part of a workspace, the workspace has the licensing file,
     # but the crates themselves do not; we link to the workspace's LICENSE
     "tracing": {


### PR DESCRIPTION
No idea why this also wants to change a dep for focus.