### PR TITLE
feat: Reintroduce as-ohttp-client component [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Glean
 - Updated to v65.0.0 ([#6901](https://github.com/mozilla/application-services/pull/6901))
 
+### OHTTP Client
+- The `as-ohttp-client` component is being reintroduced to allos firefox-ios to
+  optionally submit Glean pings over OHTTP.
+
 [Full Changelog](In progress)
 
 # v143.0 (_2025-08-18_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "as-ohttp-client"
+version = "0.1.0"
+dependencies = [
+ "bhttp",
+ "ohttp",
+ "parking_lot",
+ "rusqlite",
+ "thiserror 1.0.69",
+ "uniffi",
+]
+
+[[package]]
 name = "askama"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,12 +334,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "bhttp"
+version = "0.6.1"
+source = "git+https://github.com/martinthomson/ohttp.git?rev=c6131ace4e4e82a4269afac3cb0524541d2cd315#c6131ace4e4e82a4269afac3cb0524541d2cd315"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -505,6 +543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +622,17 @@ dependencies = [
  "lazy_static",
  "nimbus-fml",
  "nimbus-sdk",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2709,6 +2767,7 @@ dependencies = [
 name = "megazord_ios"
 version = "0.1.0"
 dependencies = [
+ "as-ohttp-client",
  "autofill",
  "context_id",
  "crashtest",
@@ -3211,6 +3270,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ohttp"
+version = "0.6.1"
+source = "git+https://github.com/martinthomson/ohttp.git?rev=c6131ace4e4e82a4269afac3cb0524541d2cd315#c6131ace4e4e82a4269afac3cb0524541d2cd315"
+dependencies = [
+ "bindgen",
+ "byteorder",
+ "hex",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -4047,9 +4121,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -4244,6 +4318,15 @@ name = "serde_path_to_error"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -4447,7 +4530,7 @@ dependencies = [
  "clap 4.5.39",
  "rinja",
  "serde_yaml 0.8.24",
- "toml",
+ "toml 0.5.9",
  "toml_edit",
 ]
 
@@ -4961,10 +5044,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.5.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4973,9 +5080,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
- "toml_datetime",
+ "toml_datetime 0.6.8",
  "winnow 0.6.19",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -5118,7 +5240,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -5239,7 +5361,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap 0.16.1",
- "toml",
+ "toml 0.5.9",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -5295,7 +5417,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.89",
- "toml",
+ "toml 0.5.9",
  "uniffi_meta",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 # Note: Any additions here should be repeated in default-members below.
 members = [
     "components/ads-client",
+    "components/as-ohttp-client",
     "components/autofill",
     "components/context_id",
     "components/crashtest",
@@ -99,6 +100,7 @@ exclude = [
 # use the full member set.
 default-members = [
     "components/ads-client",
+    "components/as-ohttp-client",
     "components/autofill",
     "components/context_id",
     "components/crashtest",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -41,8 +41,10 @@ the details of which are reproduced below.
 * [MIT License: weedle2](#mit-license-weedle2)
 * [MIT License: winreg](#mit-license-winreg)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
+* [ISC License: libloading](#isc-license-libloading)
 * [ISC License: ring](#isc-license-ring)
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
+* [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
 * [Zlib License: foldhash](#zlib-license-foldhash)
 * [Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-litemap-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerovec-zerovec-derive)
@@ -459,13 +461,16 @@ The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [base64](https://github.com/marshallpierce/rust-base64),
 [basic-toml](https://github.com/dtolnay/basic-toml),
+[bhttp](https://github.com/martinthomson/ohttp),
 [bitflags](https://github.com/bitflags/bitflags),
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
 [cc](https://github.com/rust-lang/cc-rs),
+[cexpr](https://github.com/jethrogb/rust-cexpr),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
+[clang-sys](https://github.com/KyleMayes/clang-sys),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
@@ -523,6 +528,7 @@ The following text applies to code linked from these dependencies:
 [native-tls](https://github.com/sfackler/rust-native-tls),
 [num-traits](https://github.com/rust-num/num-traits),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
+[ohttp](https://github.com/martinthomson/ohttp),
 [once_cell](https://github.com/matklad/once_cell),
 [openssl-macros](https://github.com/sfackler/rust-openssl),
 [openssl-probe](https://github.com/alexcrichton/openssl-probe),
@@ -560,6 +566,7 @@ The following text applies to code linked from these dependencies:
 [serde_derive](https://github.com/serde-rs/serde),
 [serde_json](https://github.com/serde-rs/json),
 [serde_path_to_error](https://github.com/dtolnay/path-to-error),
+[serde_spanned](https://github.com/toml-rs/toml),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
 [shlex](https://github.com/comex/rust-shlex),
@@ -577,6 +584,10 @@ The following text applies to code linked from these dependencies:
 [tinyvec](https://github.com/Lokathor/tinyvec),
 [tinyvec_macros](https://github.com/Soveu/tinyvec_macros),
 [toml](https://github.com/alexcrichton/toml-rs),
+[toml](https://github.com/toml-rs/toml),
+[toml_datetime](https://github.com/toml-rs/toml),
+[toml_parser](https://github.com/toml-rs/toml),
+[toml_writer](https://github.com/toml-rs/toml),
 [typenum](https://github.com/paholg/typenum),
 [unicase](https://github.com/seanmonstar/unicase),
 [unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
@@ -2037,6 +2048,27 @@ limitations under the License.
 
 ```
 -------------
+## ISC License: libloading
+
+The following text applies to code linked from these dependencies:
+[libloading](https://github.com/nagisa/rust_libloading/)
+
+```
+Copyright © 2015, Simonas Kazlauskas
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+fee is hereby granted, provided that the above copyright notice and this permission notice appear
+in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+```
+-------------
 ## ISC License: ring
 
 The following text applies to code linked from these dependencies:
@@ -2091,6 +2123,44 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+-------------
+## BSD-3-Clause License: bindgen
+
+The following text applies to code linked from these dependencies:
+[bindgen](https://github.com/rust-lang/rust-bindgen)
+
+```
+BSD 3-Clause License
+
+Copyright (c) 2013, Jyun-Yan You
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```

--- a/components/as-ohttp-client/Cargo.toml
+++ b/components/as-ohttp-client/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "as-ohttp-client"
+version = "0.1.0"
+edition = "2021"
+authors = ["Ted Campbell <tcampbell@mozilla.com>"]
+description = "An Oblivious HTTP client for iOS applications"
+license = "MPL-2.0"
+exclude = ["/ios"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+uniffi = { version = "0.29.0" }
+thiserror = "1.0"
+parking_lot = "0.12"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+
+[dependencies.bhttp]
+git = "https://github.com/martinthomson/ohttp.git"
+rev = "c6131ace4e4e82a4269afac3cb0524541d2cd315"
+
+[dependencies.ohttp]
+default-features = false
+git = "https://github.com/martinthomson/ohttp.git"
+rev = "c6131ace4e4e82a4269afac3cb0524541d2cd315"
+features = ["client", "server", "app-svc", "external-sqlite"]
+
+[build-dependencies]
+uniffi = { version = "0.29.0", features=["build"]}

--- a/components/as-ohttp-client/build.rs
+++ b/components/as-ohttp-client/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/as_ohttp_client.udl").unwrap();
+}

--- a/components/as-ohttp-client/src/as_ohttp_client.udl
+++ b/components/as-ohttp-client/src/as_ohttp_client.udl
@@ -1,0 +1,70 @@
+namespace as_ohttp_client {
+};
+
+[Error]
+enum OhttpError {
+    "KeyFetchFailed",
+    "MalformedKeyConfig",
+    "UnsupportedKeyConfig",
+    "InvalidSession",
+    "RelayFailed",
+    "CannotEncodeMessage",
+    "MalformedMessage",
+    "DuplicateHeaders",
+};
+
+/// The decrypted response from the Gateway/Target
+dictionary OhttpResponse {
+    u16 status_code;
+    record<string, string> headers;
+    sequence<u8> payload;
+};
+
+/// Each OHTTP request-reply exchange needs to create an OhttpSession
+/// object to manage encryption state.
+interface OhttpSession {
+    /// Initialize encryption state based on specific Gateway key config
+    [Throws=OhttpError]
+    constructor([ByRef] sequence<u8> config);
+
+    /// Encapsulate an HTTP request as Binary HTTP and then encrypt that
+    /// payload using HPKE. The caller is responsible for sending the
+    /// resulting message to the Relay.
+    [Throws=OhttpError]
+    sequence<u8> encapsulate([ByRef] string method,
+                             [ByRef] string scheme,
+                             [ByRef] string server,
+                             [ByRef] string endpoint,
+                             record<string, string> headers,
+                             [ByRef] sequence<u8> payload);
+
+    /// Decypt and unpack the response from the Relay for the previously
+    /// encapsulated request. You must use the same OhttpSession that
+    /// generated the request message.
+    [Throws=OhttpError]
+    OhttpResponse decapsulate([ByRef] sequence<u8> encoded);
+};
+
+dictionary TestServerRequest {
+    string method;
+    string scheme;
+    string server;
+    string endpoint;
+    record<string, string> headers;
+    sequence<u8> payload;
+};
+
+/// A testing interface for decrypting and responding to OHTTP messages. This
+/// should only be used for testing.
+interface OhttpTestServer {
+    constructor();
+
+    /// Return the unique encryption key config for this instance of test server.
+    sequence<u8> get_config();
+
+    [Throws=OhttpError]
+    TestServerRequest receive([ByRef] sequence<u8> message);
+
+    [Throws=OhttpError]
+    sequence<u8> respond(OhttpResponse response);
+};

--- a/components/as-ohttp-client/src/lib.rs
+++ b/components/as-ohttp-client/src/lib.rs
@@ -1,0 +1,306 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+extern crate rusqlite;
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
+
+#[derive(Debug, thiserror::Error)]
+pub enum OhttpError {
+    #[error("Failed to fetch encryption key")]
+    KeyFetchFailed,
+
+    #[error("OHTTP key config is malformed")]
+    MalformedKeyConfig,
+
+    #[error("Unsupported OHTTP encryption algorithm")]
+    UnsupportedKeyConfig,
+
+    #[error("OhttpSession is in invalid state")]
+    InvalidSession,
+
+    #[error("Network errors communicating with Relay / Gateway")]
+    RelayFailed,
+
+    #[error("Cannot encode message as BHTTP/OHTTP")]
+    CannotEncodeMessage,
+
+    #[error("Cannot decode OHTTP/BHTTP message")]
+    MalformedMessage,
+
+    #[error("Duplicate HTTP response headers")]
+    DuplicateHeaders,
+}
+
+#[derive(Default)]
+enum ExchangeState {
+    #[default]
+    Invalid,
+    Request(ohttp::ClientRequest),
+    Response(ohttp::ClientResponse),
+}
+
+pub struct OhttpSession {
+    state: Mutex<ExchangeState>,
+}
+
+pub struct OhttpResponse {
+    status_code: u16,
+    headers: HashMap<String, String>,
+    payload: Vec<u8>,
+}
+
+/// Transform the headers from a BHTTP message into a HashMap for use from Swift
+/// later. If there are duplicate errors, we currently raise an error.
+fn headers_to_map(message: &bhttp::Message) -> Result<HashMap<String, String>, OhttpError> {
+    let mut headers = HashMap::new();
+
+    for field in message.header().iter() {
+        if headers
+            .insert(
+                std::str::from_utf8(field.name())
+                    .map_err(|_| OhttpError::MalformedMessage)?
+                    .into(),
+                std::str::from_utf8(field.value())
+                    .map_err(|_| OhttpError::MalformedMessage)?
+                    .into(),
+            )
+            .is_some()
+        {
+            return Err(OhttpError::DuplicateHeaders);
+        }
+    }
+
+    Ok(headers)
+}
+
+impl OhttpSession {
+    /// Create a new encryption session for use with specific key configuration
+    pub fn new(config: &[u8]) -> Result<Self, OhttpError> {
+        ohttp::init();
+
+        let request = ohttp::ClientRequest::from_encoded_config(config).map_err(|e| match e {
+            ohttp::Error::Unsupported => OhttpError::UnsupportedKeyConfig,
+            _ => OhttpError::MalformedKeyConfig,
+        })?;
+
+        let state = Mutex::new(ExchangeState::Request(request));
+        Ok(OhttpSession { state })
+    }
+
+    /// Encode an HTTP request in Binary HTTP format and then encrypt it into an
+    /// Oblivious HTTP request message.
+    pub fn encapsulate(
+        &self,
+        method: &str,
+        scheme: &str,
+        server: &str,
+        endpoint: &str,
+        mut headers: HashMap<String, String>,
+        payload: &[u8],
+    ) -> Result<Vec<u8>, OhttpError> {
+        let mut message =
+            bhttp::Message::request(method.into(), scheme.into(), server.into(), endpoint.into());
+
+        for (k, v) in headers.drain() {
+            message.put_header(k, v);
+        }
+
+        message.write_content(payload);
+
+        let mut encoded = vec![];
+        message
+            .write_bhttp(bhttp::Mode::KnownLength, &mut encoded)
+            .map_err(|_| OhttpError::CannotEncodeMessage)?;
+
+        let mut state = self.state.lock();
+        let request = match std::mem::take(&mut *state) {
+            ExchangeState::Request(request) => request,
+            _ => return Err(OhttpError::InvalidSession),
+        };
+        let (capsule, response) = request
+            .encapsulate(&encoded)
+            .map_err(|_| OhttpError::CannotEncodeMessage)?;
+        *state = ExchangeState::Response(response);
+
+        Ok(capsule)
+    }
+
+    /// Decode an OHTTP response returned in response to a request encoded on
+    /// this session.
+    pub fn decapsulate(&self, encoded: &[u8]) -> Result<OhttpResponse, OhttpError> {
+        let mut state = self.state.lock();
+        let decoder = match std::mem::take(&mut *state) {
+            ExchangeState::Response(response) => response,
+            _ => return Err(OhttpError::InvalidSession),
+        };
+        let binary = decoder
+            .decapsulate(encoded)
+            .map_err(|_| OhttpError::MalformedMessage)?;
+
+        let mut cursor = std::io::Cursor::new(binary);
+        let message =
+            bhttp::Message::read_bhttp(&mut cursor).map_err(|_| OhttpError::MalformedMessage)?;
+
+        let headers = headers_to_map(&message)?;
+
+        Ok(OhttpResponse {
+            status_code: match message.control() {
+                bhttp::ControlData::Response(sc) => (*sc).into(),
+                _ => return Err(OhttpError::InvalidSession),
+            },
+            headers,
+            payload: message.content().into(),
+        })
+    }
+}
+
+pub struct OhttpTestServer {
+    server: Mutex<ohttp::Server>,
+    state: Mutex<Option<ohttp::ServerResponse>>,
+    config: Vec<u8>,
+}
+
+pub struct TestServerRequest {
+    method: String,
+    scheme: String,
+    server: String,
+    endpoint: String,
+    headers: HashMap<String, String>,
+    payload: Vec<u8>,
+}
+
+impl OhttpTestServer {
+    /// Create a simple OHTTP server to decrypt and respond to OHTTP messages in
+    /// testing. The key is randomly generated.
+    fn new() -> Self {
+        ohttp::init();
+
+        let key = ohttp::KeyConfig::new(
+            0x01,
+            ohttp::hpke::Kem::X25519Sha256,
+            vec![ohttp::SymmetricSuite::new(
+                ohttp::hpke::Kdf::HkdfSha256,
+                ohttp::hpke::Aead::Aes128Gcm,
+            )],
+        )
+        .unwrap();
+
+        let config = key.encode().unwrap();
+        let server = ohttp::Server::new(key).unwrap();
+
+        OhttpTestServer {
+            server: Mutex::new(server),
+            state: Mutex::new(Option::None),
+            config,
+        }
+    }
+
+    /// Return a copy of the key config for clients to use.
+    fn get_config(&self) -> Vec<u8> {
+        self.config.clone()
+    }
+
+    /// Decode an OHTTP request message and return the cleartext contents. This
+    /// also updates the internal server state so that a response message can be
+    /// generated.
+    fn receive(&self, message: &[u8]) -> Result<TestServerRequest, OhttpError> {
+        let (encoded, response) = self
+            .server
+            .lock()
+            .decapsulate(message)
+            .map_err(|_| OhttpError::MalformedMessage)?;
+        let mut cursor = std::io::Cursor::new(encoded);
+        let message =
+            bhttp::Message::read_bhttp(&mut cursor).map_err(|_| OhttpError::MalformedMessage)?;
+
+        *self.state.lock() = Some(response);
+
+        let headers = headers_to_map(&message)?;
+
+        match message.control() {
+            bhttp::ControlData::Request {
+                method,
+                scheme,
+                authority,
+                path,
+            } => Ok(TestServerRequest {
+                method: String::from_utf8_lossy(method).into(),
+                scheme: String::from_utf8_lossy(scheme).into(),
+                server: String::from_utf8_lossy(authority).into(),
+                endpoint: String::from_utf8_lossy(path).into(),
+                headers,
+                payload: message.content().into(),
+            }),
+            _ => Err(OhttpError::MalformedMessage),
+        }
+    }
+
+    /// Encode an OHTTP response keyed to the last message received.
+    fn respond(&self, response: OhttpResponse) -> Result<Vec<u8>, OhttpError> {
+        let state = self.state.lock().take().unwrap();
+
+        let mut message =
+            bhttp::Message::response(bhttp::StatusCode::try_from(response.status_code).unwrap());
+        message.write_content(&response.payload);
+
+        for (k, v) in response.headers {
+            message.put_header(k, v);
+        }
+
+        let mut encoded = vec![];
+        message
+            .write_bhttp(bhttp::Mode::KnownLength, &mut encoded)
+            .map_err(|_| OhttpError::CannotEncodeMessage)?;
+
+        state
+            .encapsulate(&encoded)
+            .map_err(|_| OhttpError::CannotEncodeMessage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_smoke() {
+        let server = OhttpTestServer::new();
+        let config = server.get_config();
+
+        let body: Vec<u8> = vec![0x00, 0x01, 0x02];
+        let header = HashMap::from([
+            ("Content-Type".into(), "application/octet-stream".into()),
+            ("X-Header".into(), "value".into()),
+        ]);
+
+        let session = OhttpSession::new(&config).unwrap();
+        let mut message = session
+            .encapsulate("GET", "https", "example.com", "/api", header.clone(), &body)
+            .unwrap();
+
+        let request = server.receive(&message).unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.scheme, "https");
+        assert_eq!(request.server, "example.com");
+        assert_eq!(request.endpoint, "/api");
+        assert_eq!(request.headers, header);
+
+        message = server
+            .respond(OhttpResponse {
+                status_code: 200,
+                headers: header.clone(),
+                payload: body.clone(),
+            })
+            .unwrap();
+
+        let response = session.decapsulate(&message).unwrap();
+        assert_eq!(response.status_code, 200);
+        assert_eq!(response.headers, header);
+        assert_eq!(response.payload, body);
+    }
+}
+
+uniffi::include_scaffolding!("as_ohttp_client");

--- a/components/as-ohttp-client/uniffi.toml
+++ b/components/as-ohttp-client/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "as_ohttp_clientFFI"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,6 +40,7 @@
   - [CI Publishing tools and flow](build-and-publish-pipeline.md)
   - [How to upgrade NSS](howtos/upgrading-nss-guide.md)
 - [Rustdocs for components](rust-docs/index.html)
+  - [as_ohttp_client](rust-docs/as_ohttp_client/index.html)
   - [autofill](rust-docs/autofill/index.html)
   - [crashtest](rust-docs/crashtest/index.html)
   - [fxa_client](rust-docs/fxa_client/index.html)

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -26,6 +26,7 @@ sync15 = {path = "../../components/sync15"}
 error-support = { path = "../../components/support/error" }
 tracing-support = { path = "../../components/support/tracing" }
 sync_manager = { path = "../../components/sync_manager" }
+as-ohttp-client = { path = "../../components/as-ohttp-client" }
 search = { path = "../../components/search" }
 init_rust_components = { path = "../../components/init_rust_components" }
 merino = { path = "../../components/merino" }

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -38,8 +38,10 @@ the details of which are reproduced below.
 * [MIT License: want](#mit-license-want)
 * [MIT License: weedle2](#mit-license-weedle2)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
+* [ISC License: libloading](#isc-license-libloading)
 * [ISC License: ring](#isc-license-ring)
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
+* [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [Zlib License: foldhash](#zlib-license-foldhash)
 * [Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-litemap-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerovec-zerovec-derive)
 * [Optional Notice: SQLite](#optional-notice-sqlite)
@@ -452,13 +454,16 @@ The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [base64](https://github.com/marshallpierce/rust-base64),
 [basic-toml](https://github.com/dtolnay/basic-toml),
+[bhttp](https://github.com/martinthomson/ohttp),
 [bitflags](https://github.com/bitflags/bitflags),
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
 [cc](https://github.com/rust-lang/cc-rs),
+[cexpr](https://github.com/jethrogb/rust-cexpr),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
+[clang-sys](https://github.com/KyleMayes/clang-sys),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
@@ -512,6 +517,7 @@ The following text applies to code linked from these dependencies:
 [native-tls](https://github.com/sfackler/rust-native-tls),
 [num-traits](https://github.com/rust-num/num-traits),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
+[ohttp](https://github.com/martinthomson/ohttp),
 [once_cell](https://github.com/matklad/once_cell),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
@@ -545,6 +551,7 @@ The following text applies to code linked from these dependencies:
 [serde_derive](https://github.com/serde-rs/serde),
 [serde_json](https://github.com/serde-rs/json),
 [serde_path_to_error](https://github.com/dtolnay/path-to-error),
+[serde_spanned](https://github.com/toml-rs/toml),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
 [shlex](https://github.com/comex/rust-shlex),
@@ -562,6 +569,10 @@ The following text applies to code linked from these dependencies:
 [tinyvec](https://github.com/Lokathor/tinyvec),
 [tinyvec_macros](https://github.com/Soveu/tinyvec_macros),
 [toml](https://github.com/alexcrichton/toml-rs),
+[toml](https://github.com/toml-rs/toml),
+[toml_datetime](https://github.com/toml-rs/toml),
+[toml_parser](https://github.com/toml-rs/toml),
+[toml_writer](https://github.com/toml-rs/toml),
 [typenum](https://github.com/paholg/typenum),
 [unicase](https://github.com/seanmonstar/unicase),
 [unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
@@ -1937,6 +1948,27 @@ limitations under the License.
 
 ```
 -------------
+## ISC License: libloading
+
+The following text applies to code linked from these dependencies:
+[libloading](https://github.com/nagisa/rust_libloading/)
+
+```
+Copyright © 2015, Simonas Kazlauskas
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+fee is hereby granted, provided that the above copyright notice and this permission notice appear
+in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+```
+-------------
 ## ISC License: ring
 
 The following text applies to code linked from these dependencies:
@@ -1991,6 +2023,44 @@ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+-------------
+## BSD-3-Clause License: bindgen
+
+The following text applies to code linked from these dependencies:
+[bindgen](https://github.com/rust-lang/rust-bindgen)
+
+```
+BSD 3-Clause License
+
+Copyright (c) 2013, Jyun-Yan You
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -18,6 +18,7 @@
 #import "errorFFI.h"
 #import "syncmanagerFFI.h"
 #import "remote_settingsFFI.h"
+#import "as_ohttp_clientFFI.h"
 #import "suggestFFI.h"
 #import "rustlogforwarderFFI.h"
 #import "searchFFI.h"

--- a/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
+++ b/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+public class OhttpManager {
+    // The OhttpManager communicates with the relay and key server using
+    // URLSession.shared.data unless an alternative networking method is
+    // provided with this signature.
+    public typealias NetworkFunction = (_: URLRequest) async throws -> (Data, URLResponse)
+
+    // Global cache to caching Gateway encryption keys. Stale entries are
+    // ignored and on Gateway errors the key used should be purged and retrieved
+    // again next at next network attempt.
+    static var keyCache = [URL: ([UInt8], Date)]()
+
+    private var configUrl: URL
+    private var relayUrl: URL
+    private var network: NetworkFunction
+
+    public init(configUrl: URL,
+                relayUrl: URL,
+                network: @escaping NetworkFunction = URLSession.shared.data)
+    {
+        self.configUrl = configUrl
+        self.relayUrl = relayUrl
+        self.network = network
+    }
+
+    private func fetchKey(url: URL) async throws -> [UInt8] {
+        let request = URLRequest(url: url)
+        if let (data, response) = try? await network(request),
+           let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode == 200
+        {
+            return [UInt8](data)
+        }
+
+        throw OhttpError.KeyFetchFailed(message: "Failed to fetch encryption key")
+    }
+
+    private func keyForGateway(gatewayConfigUrl: URL, ttl: TimeInterval) async throws -> [UInt8] {
+        if let (data, timestamp) = Self.keyCache[gatewayConfigUrl] {
+            if Date() < timestamp + ttl {
+                // Cache Hit!
+                return data
+            }
+
+            Self.keyCache.removeValue(forKey: gatewayConfigUrl)
+        }
+
+        let data = try await fetchKey(url: gatewayConfigUrl)
+        Self.keyCache[gatewayConfigUrl] = (data, Date())
+
+        return data
+    }
+
+    private func invalidateKey() {
+        Self.keyCache.removeValue(forKey: configUrl)
+    }
+
+    public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        // Get the encryption keys for Gateway
+        let config = try await keyForGateway(gatewayConfigUrl: configUrl,
+                                             ttl: TimeInterval(3600))
+
+        // Create an encryption session for a request-response round-trip
+        let session = try OhttpSession(config: config)
+
+        // Encapsulate the URLRequest for the Target
+        let encoded = try session.encapsulate(method: request.httpMethod ?? "GET",
+                                              scheme: request.url!.scheme!,
+                                              server: request.url!.host!,
+                                              endpoint: request.url!.path,
+                                              headers: request.allHTTPHeaderFields ?? [:],
+                                              payload: [UInt8](request.httpBody ?? Data()))
+
+        // Request from Client to Relay
+        var request = URLRequest(url: relayUrl)
+        request.httpMethod = "POST"
+        request.setValue("message/ohttp-req", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(encoded)
+
+        let (data, response) = try await network(request)
+
+        // Decapsulation failures have these codes, so invalidate any cached
+        // keys in case the gateway has changed them.
+        if let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode == 400 ||
+           httpResponse.statusCode == 401
+        {
+            invalidateKey()
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200
+        else {
+            throw OhttpError.RelayFailed(message: "Network errors communicating with Relay / Gateway")
+        }
+
+        // Decapsulate the Target response into a HTTPURLResponse
+        let message = try session.decapsulate(encoded: [UInt8](data))
+        return (Data(message.payload),
+                HTTPURLResponse(url: request.url!,
+                                statusCode: Int(message.statusCode),
+                                httpVersion: "HTTP/1.1",
+                                headerFields: message.headers)!)
+    }
+}

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
+pub use as_ohttp_client;
 pub use autofill;
 pub use context_id;
 pub use crashtest;

--- a/megazords/ios-rust/tests/MozillaRustComponentsTests/OhttpTests.swift
+++ b/megazords/ios-rust/tests/MozillaRustComponentsTests/OhttpTests.swift
@@ -1,0 +1,316 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import MozillaRustComponentsWrapper
+import XCTest
+
+// These tests cover the integration of the underlying Rust libraries into Swift
+// URL{Request,Response} data types, as well as the key management and error
+// handling logic of OhttpManager class.
+
+// A testing model of Client, KeyConfigEndpoint, Relay, Gateway, and Target. This
+// includes an OHTTP decryption server to decode messages, but does not model TLS,
+// etc.
+class FakeOhttpNetwork {
+    let server = OhttpTestServer()
+    let configURL = URL(string: "https://gateway.example.com/ohttp-configs")!
+    let relayURL = URL(string: "https://relay.example.com/")!
+
+    // Create an instance of OhttpManager with networking hooks installed to
+    // send requests to this model instead of the Internet.
+    func newOhttpManager() -> OhttpManager {
+        OhttpManager(configUrl: configURL,
+                     relayUrl: relayURL,
+                     network: client)
+    }
+
+    // Response helpers
+    func statusResponse(request: URLRequest, statusCode: Int) -> (Data, HTTPURLResponse) {
+        (Data(),
+         HTTPURLResponse(url: request.url!,
+                         statusCode: statusCode,
+                         httpVersion: "HTTP/1.1",
+                         headerFields: [:])!)
+    }
+
+    func dataResponse(request: URLRequest, body: Data, contentType: String) -> (Data, HTTPURLResponse) {
+        (body,
+         HTTPURLResponse(url: request.url!,
+                         statusCode: 200,
+                         httpVersion: "HTTP/1.1",
+                         headerFields: ["Content-Length": String(body.count),
+                                        "Content-Type": contentType])!)
+    }
+
+    //
+    // Network node models
+    //
+    func client(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        switch request.url {
+        case configURL: return config(request)
+        case relayURL: return relay(request)
+        default: throw NSError()
+        }
+    }
+
+    func config(_ request: URLRequest) -> (Data, URLResponse) {
+        let key = server.getConfig()
+        return dataResponse(request: request,
+                            body: Data(key),
+                            contentType: "application/octet-stream")
+    }
+
+    func relay(_ request: URLRequest) -> (Data, URLResponse) {
+        return gateway(request)
+    }
+
+    func gateway(_ request: URLRequest) -> (Data, URLResponse) {
+        let inner = try! server.receive(message: [UInt8](request.httpBody!))
+
+        // Unwrap OHTTP/BHTTP
+        var innerUrl = URLComponents()
+        innerUrl.scheme = inner.scheme
+        innerUrl.host = inner.server
+        innerUrl.path = inner.endpoint
+        var innerRequest = URLRequest(url: innerUrl.url!)
+        innerRequest.httpMethod = inner.method
+        innerRequest.httpBody = Data(inner.payload)
+        for (k, v) in inner.headers {
+            innerRequest.setValue(v, forHTTPHeaderField: k)
+        }
+
+        let (innerData, innerResponse) = target(innerRequest)
+
+        // Wrap with BHTTP/OHTTP
+        var headers: [String: String] = [:]
+        for (k, v) in innerResponse.allHeaderFields {
+            headers[k as! String] = v as? String
+        }
+        let reply = try! server.respond(response: OhttpResponse(statusCode: UInt16(innerResponse.statusCode),
+                                                                headers: headers,
+                                                                payload: [UInt8](innerData)))
+        return dataResponse(request: request,
+                            body: Data(reply),
+                            contentType: "message/ohttp-res")
+    }
+
+    func target(_ request: URLRequest) -> (Data, HTTPURLResponse) {
+        // Dummy JSON application response
+        let data = try! JSONSerialization.data(withJSONObject: ["hello": "world"])
+        return dataResponse(request: request,
+                            body: data,
+                            contentType: "application/json")
+    }
+}
+
+class OhttpTests: XCTestCase {
+    override func setUp() {
+        OhttpManager.keyCache.removeAll()
+    }
+
+    // Test that a GET request can retrieve expected data from Target, including
+    // passing headers in each direction.
+    func testGet() async {
+        class DataTargetNetwork: FakeOhttpNetwork {
+            override func target(_ request: URLRequest) -> (Data, HTTPURLResponse) {
+                XCTAssertEqual(request.url, URL(string: "https://example.com/data")!)
+                XCTAssertEqual(request.httpMethod, "GET")
+                XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/octet-stream")
+
+                return dataResponse(request: request,
+                                    body: Data([0x10, 0x20, 0x30]),
+                                    contentType: "application/octet-stream")
+            }
+        }
+
+        let mock = DataTargetNetwork()
+        let ohttp = mock.newOhttpManager()
+
+        let url = URL(string: "https://example.com/data")!
+        var request = URLRequest(url: url)
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Accept")
+        let (data, response) = try! await ohttp.data(for: request)
+
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual([UInt8](data), [0x10, 0x20, 0x30])
+        XCTAssertEqual(response.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
+    }
+
+    // Test that POST requests to an API using JSON work as expected.
+    func testJsonApi() async {
+        class JsonTargetNetwork: FakeOhttpNetwork {
+            override func target(_ request: URLRequest) -> (Data, HTTPURLResponse) {
+                XCTAssertEqual(request.url, URL(string: "https://example.com/api")!)
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+                XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+                XCTAssertEqual(String(decoding: request.httpBody!, as: UTF8.self),
+                               #"{"version":1}"#)
+
+                let data = try! JSONSerialization.data(withJSONObject: ["hello": "world"])
+                return dataResponse(request: request,
+                                    body: data,
+                                    contentType: "application/json")
+            }
+        }
+
+        let mock = JsonTargetNetwork()
+        let ohttp = mock.newOhttpManager()
+
+        let url = URL(string: "https://example.com/api")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try! JSONSerialization.data(withJSONObject: ["version": 1])
+        let (data, response) = try! await ohttp.data(for: request)
+
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(String(bytes: data, encoding: .utf8), #"{"hello":"world"}"#)
+        XCTAssertEqual(response.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    // Test that config keys are cached across requests.
+    func testKeyCache() async {
+        class CountConfigNetwork: FakeOhttpNetwork {
+            var numConfigFetches = 0
+
+            override func config(_ request: URLRequest) -> (Data, URLResponse) {
+                numConfigFetches += 1
+                return super.config(request)
+            }
+        }
+        let mock = CountConfigNetwork()
+        let ohttp = mock.newOhttpManager()
+
+        let request = URLRequest(url: URL(string: "https://example.com/api")!)
+        _ = try! await ohttp.data(for: request)
+        _ = try! await ohttp.data(for: request)
+        _ = try! await ohttp.data(for: request)
+
+        XCTAssertEqual(mock.numConfigFetches, 1)
+    }
+
+    // Test that bad key config data throws MalformedKeyConfig error.
+    func testBadConfig() async {
+        class MalformedKeyNetwork: FakeOhttpNetwork {
+            override func config(_ request: URLRequest) -> (Data, URLResponse) {
+                dataResponse(request: request,
+                             body: Data(),
+                             contentType: "application/octet-stream")
+            }
+        }
+
+        do {
+            let mock = MalformedKeyNetwork()
+            let ohttp = mock.newOhttpManager()
+            let request = URLRequest(url: URL(string: "https://example.com/api")!)
+            _ = try await ohttp.data(for: request)
+            XCTFail()
+        } catch OhttpError.MalformedKeyConfig {
+        } catch {
+            XCTFail()
+        }
+    }
+
+    // Test that using the wrong key throws a RelayFailed error and
+    // that the key is removed from cache.
+    func testWrongKey() async {
+        class WrongKeyNetwork: FakeOhttpNetwork {
+            override func config(_ request: URLRequest) -> (Data, URLResponse) {
+                dataResponse(request: request,
+                             body: Data(OhttpTestServer().getConfig()),
+                             contentType: "application/octet-stream")
+            }
+
+            override func gateway(_ request: URLRequest) -> (Data, URLResponse) {
+                do {
+                    _ = try server.receive(message: [UInt8](request.httpBody!))
+                    XCTFail()
+                } catch OhttpError.MalformedMessage {
+                } catch {
+                    XCTFail()
+                }
+
+                return statusResponse(request: request, statusCode: 400)
+            }
+        }
+
+        do {
+            let mock = WrongKeyNetwork()
+            let ohttp = mock.newOhttpManager()
+            let request = URLRequest(url: URL(string: "https://example.com/")!)
+            _ = try await ohttp.data(for: request)
+            XCTFail()
+        } catch OhttpError.RelayFailed {
+        } catch {
+            XCTFail()
+        }
+
+        XCTAssert(OhttpManager.keyCache.isEmpty)
+    }
+
+    // Test that bad Gateway data generates MalformedMessage errors.
+    func testBadGateway() async {
+        class BadGatewayNetwork: FakeOhttpNetwork {
+            override func gateway(_ request: URLRequest) -> (Data, URLResponse) {
+                dataResponse(request: request,
+                             body: Data(),
+                             contentType: "message/ohttp-res")
+            }
+        }
+
+        do {
+            let mock = BadGatewayNetwork()
+            let ohttp = mock.newOhttpManager()
+            let request = URLRequest(url: URL(string: "https://example.com/api")!)
+            _ = try await ohttp.data(for: request)
+            XCTFail()
+        } catch OhttpError.MalformedMessage {
+        } catch {
+            XCTFail()
+        }
+    }
+
+    // Test behaviour when Gateway disallows a Target URL.
+    func testDisallowedTarget() async {
+        class DisallowedTargetNetwork: FakeOhttpNetwork {
+            override func target(_ request: URLRequest) -> (Data, HTTPURLResponse) {
+                statusResponse(request: request, statusCode: 403)
+            }
+        }
+
+        let mock = DisallowedTargetNetwork()
+        let ohttp = mock.newOhttpManager()
+        let request = URLRequest(url: URL(string: "https://deny.example.com/")!)
+        let (_, response) = try! await ohttp.data(for: request)
+
+        XCTAssertEqual(response.statusCode, 403)
+    }
+
+    // Test that ordinary network failures are surfaced as URLError.
+    func testNetworkFailure() async {
+        class NoConnectionNetwork: FakeOhttpNetwork {
+            override func client(_ request: URLRequest) async throws -> (Data, URLResponse) {
+                if request.url == configURL {
+                    return config(request)
+                }
+
+                throw NSError(domain: NSURLErrorDomain,
+                              code: URLError.cannotConnectToHost.rawValue)
+            }
+        }
+
+        do {
+            let mock = NoConnectionNetwork()
+            let ohttp = mock.newOhttpManager()
+            let request = URLRequest(url: URL(string: "https://example.com/api")!)
+            _ = try await ohttp.data(for: request)
+            XCTFail()
+        } catch is URLError {
+        } catch {
+            XCTFail()
+        }
+    }
+}

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -15,6 +15,7 @@ ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
 WRAPPER_DIR = pathlib.Path("megazords/ios-rust/Sources/MozillaRustComponentsWrapper/")
 # List of globs to copy the sources from
 SOURCE_TO_COPY = [
+    WRAPPER_DIR / "ASOhttpClient",
     WRAPPER_DIR / "Nimbus",
     WRAPPER_DIR / "FxAClient",
     WRAPPER_DIR / "Logins",

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -259,11 +259,25 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "LICENSE-APACHE",
         },
     },
+    "ohttp": {
+        "license": {"check": "MIT OR Apache-2.0"},
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/martinthomson/ohttp/main/LICENSE-APACHE",
+        },
+    },
     "openssl": {
         "license": {"check": "Apache-2.0"},
         "license_file": {
             "check": None,
             "fixup": "https://raw.githubusercontent.com/sfackler/rust-openssl/refs/heads/master/openssl/LICENSE-APACHE",
+        },
+    },
+    "bhttp": {
+        "license": {"check": "MIT OR Apache-2.0"},
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/martinthomson/ohttp/main/LICENSE-APACHE",
         },
     },
     # These packages do not include their license file in their release distributions,


### PR DESCRIPTION
This component is for iOS to use the OHTTP Rust crate (using NSS as the underlying crypto library). This bumps the ohttp crate version to 0.6.1 which brings in the update bindgen library. The new bindgen version fixes the build system issue that led us to removing this component recently.

Since this was removed, we restructured the handling of Swift code so I moved the OhttpManager and tests to appropriate directories. 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
