### PR TITLE
Revert "EXP-5700: Change from global rollout opt-out to experiments a…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.10.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.10.1"
+version = "0.10.0"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2021"
 description = "A rapid experiment library"

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -141,21 +141,11 @@ open class Nimbus(
 
     private val nimbusClient: NimbusClientInterface
 
-    override var experimentParticipation: Boolean
-        get() = nimbusClient.getExperimentParticipation()
+    override var globalUserParticipation: Boolean
+        get() = nimbusClient.getGlobalUserParticipation()
         set(active) {
             dbScope.launch {
-                nimbusClient.setExperimentParticipation(active)
-                applyPendingExperimentsOnThisThread()
-            }
-        }
-
-    override var rolloutParticipation: Boolean
-        get() = nimbusClient.getRolloutParticipation()
-        set(active) {
-            dbScope.launch {
-                nimbusClient.setRolloutParticipation(active)
-                applyPendingExperimentsOnThisThread()
+                setGlobalUserParticipationOnThisThread(active)
             }
         }
 
@@ -410,25 +400,13 @@ open class Nimbus(
 
     @WorkerThread
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun setExperimentParticipationOnThisThread(active: Boolean) =
-        withCatchAll("setExperimentParticipation") {
-            val enrolmentChanges = nimbusClient.setExperimentParticipation(active)
-            if (enrolmentChanges.isNotEmpty()) {
-                recordExperimentTelemetryEvents(enrolmentChanges)
-                postEnrolmentCalculation()
-            }
+    internal fun setGlobalUserParticipationOnThisThread(active: Boolean) = withCatchAll("setGlobalUserParticipation") {
+        val enrolmentChanges = nimbusClient.setGlobalUserParticipation(active)
+        if (enrolmentChanges.isNotEmpty()) {
+            recordExperimentTelemetryEvents(enrolmentChanges)
+            postEnrolmentCalculation()
         }
-
-    @WorkerThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun setRolloutParticipationOnThisThread(active: Boolean) =
-        withCatchAll("setRolloutParticipation") {
-            val enrolmentChanges = nimbusClient.setRolloutParticipation(active)
-            if (enrolmentChanges.isNotEmpty()) {
-                recordExperimentTelemetryEvents(enrolmentChanges)
-                postEnrolmentCalculation()
-            }
-        }
+    }
 
     override fun optOut(experimentId: String) {
         dbScope.launch {

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -199,19 +199,10 @@ interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusE
     fun resetTelemetryIdentifiers() = Unit
 
     /**
-    * Control the opt out for experiments. This is likely a user action.
-    * When set to false, the user will be opted out of all experiments but not rollouts.
-    */
-    var experimentParticipation: Boolean
-        get() = true
-        set(_) = Unit
-
-    /**
-    * Control the opt out for rollouts. This is likely a user action.
-    * When set to false, the user will be opted out of all rollouts but not experiments.
-    */
-    var rolloutParticipation: Boolean
-        get() = true
+     * Control the opt out for all experiments at once. This is likely a user action.
+     */
+    var globalUserParticipation: Boolean
+        get() = false
         set(_) = Unit
 
     override val events: NimbusEventStore

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -450,8 +450,8 @@ class NimbusTests {
             NimbusEvents.disqualification.testGetValue(),
         )
 
-        // Opt out of experiments but keep rollouts
-        nimbus.setExperimentParticipationOnThisThread(false)
+        // Opt out of all experiments
+        nimbus.setGlobalUserParticipationOnThisThread(false)
 
         // Use the Glean test API to check that the valid event is present
         assertNotNull("Event must have a value", NimbusEvents.disqualification.testGetValue())

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -75,21 +75,6 @@ impl Display for NotEnrolledReason {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Participation {
-    pub in_experiments: bool,
-    pub in_rollouts: bool,
-}
-
-impl Default for Participation {
-    fn default() -> Self {
-        Self {
-            in_experiments: true,
-            in_rollouts: true,
-        }
-    }
-}
-
 // These are types we use internally for managing disqualifications.
 
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️
@@ -598,7 +583,7 @@ impl<'a> EnrollmentsEvolver<'a> {
 
     pub(crate) fn evolve_enrollments<E>(
         &mut self,
-        participation: Participation,
+        is_user_participating: bool,
         prev_experiments: &[E],
         next_experiments: &[Experiment],
         prev_enrollments: &[ExperimentEnrollment],
@@ -619,7 +604,7 @@ impl<'a> EnrollmentsEvolver<'a> {
         let next_rollouts = filter_experiments(next_experiments, ExperimentMetadata::is_rollout);
 
         let (next_ro_enrollments, ro_events) = self.evolve_enrollment_recipes(
-            participation.in_rollouts,
+            is_user_participating,
             &prev_rollouts,
             &next_rollouts,
             &ro_enrollments,
@@ -643,7 +628,7 @@ impl<'a> EnrollmentsEvolver<'a> {
             .collect();
 
         let (next_exp_enrollments, exp_events) = self.evolve_enrollment_recipes(
-            participation.in_experiments,
+            is_user_participating,
             &prev_experiments,
             &next_experiments,
             &prev_enrollments,

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -239,29 +239,10 @@ interface NimbusClient {
     [Throws=NimbusError]
     sequence<AvailableExperiment> get_available_experiments();
 
-    /// Getter and setter for user's participation in experiments only.
+    /// Getter and setter for user's participation in all experiments.
     /// Possible values are:
-    /// * `true`: the user will enroll in experiments as usual.
-    /// * `false`: the user will not enroll in new experiments, and opt out of all existing ones.
-    [Throws=NimbusError]
-    boolean get_experiment_participation();
-
-    [Throws=NimbusError]
-    sequence<EnrollmentChangeEvent> set_experiment_participation(boolean opt_in);
-
-    /// Getter and setter for user's participation in rollouts.
-    /// Possible values are:
-    /// * `true`: the user will enroll in rollouts as usual.
-    /// * `false`: the user will not enroll in new rollouts, and opt out of all existing ones.
-    [Throws=NimbusError]
-    boolean get_rollout_participation();
-
-    [Throws=NimbusError]
-    sequence<EnrollmentChangeEvent> set_rollout_participation(boolean opt_in);
-
-    /// DEPRECATED: Use set_experiment_participation and set_rollout_participation instead.
-    /// Getter and setter for global user participation (applies to both experiments and rollouts).
-    /// For simplicity, the getter returns the experiment participation value.
+    /// * `true`: the user will not enroll in new experiments, and opt out of all existing ones.
+    /// * `false`: experiments proceed as usual.
     [Throws=NimbusError]
     boolean get_global_user_participation();
 
@@ -277,7 +258,7 @@ interface NimbusClient {
     /// Toggles the enablement of the fetch. If `false`, then calling `fetch_experiments`
     /// returns immediately, having not done any fetching from remote settings.
     /// This is only useful for QA, and should not be used in production: use
-    /// `set_experiment_participation` or `set_rollout_participation` instead.
+    /// `set_global_user_participation` instead.
     [Throws=NimbusError]
     void set_fetch_enabled(boolean flag);
 

--- a/components/nimbus/src/stateful/enrollment.rs
+++ b/components/nimbus/src/stateful/enrollment.rs
@@ -1,11 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use crate::enrollment::Participation;
-use crate::stateful::persistence::{
-    DB_KEY_EXPERIMENT_PARTICIPATION, DB_KEY_ROLLOUT_PARTICIPATION,
-    DEFAULT_EXPERIMENT_PARTICIPATION, DEFAULT_ROLLOUT_PARTICIPATION,
-};
 use crate::{
     enrollment::{
         map_enrollments, EnrollmentChangeEvent, EnrollmentChangeEventType, EnrollmentsEvolver,
@@ -19,6 +14,9 @@ use crate::{
     EnrolledExperiment, EnrollmentStatus, Experiment,
 };
 
+const DB_KEY_GLOBAL_USER_PARTICIPATION: &str = "user-opt-in";
+const DEFAULT_GLOBAL_USER_PARTICIPATION: bool = true;
+
 impl EnrollmentsEvolver<'_> {
     /// Convenient wrapper around `evolve_enrollments` that fetches the current state of experiments,
     /// enrollments and user participation from the database.
@@ -28,22 +26,15 @@ impl EnrollmentsEvolver<'_> {
         writer: &mut Writer,
         next_experiments: &[Experiment],
     ) -> Result<Vec<EnrollmentChangeEvent>> {
-        // Get separate participation states from the db
-        let is_participating_in_experiments = get_experiment_participation(db, writer)?;
-        let is_participating_in_rollouts = get_rollout_participation(db, writer)?;
-
-        let participation = Participation {
-            in_experiments: is_participating_in_experiments,
-            in_rollouts: is_participating_in_rollouts,
-        };
-
+        // Get the state from the db.
+        let is_user_participating = get_global_user_participation(db, writer)?;
         let experiments_store = db.get_store(StoreId::Experiments);
         let enrollments_store = db.get_store(StoreId::Enrollments);
         let prev_experiments: Vec<Experiment> = experiments_store.collect_all(writer)?;
         let prev_enrollments: Vec<ExperimentEnrollment> = enrollments_store.collect_all(writer)?;
         // Calculate the changes.
         let (next_enrollments, enrollments_change_events) = self.evolve_enrollments(
-            participation,
+            is_user_participating,
             &prev_experiments,
             next_experiments,
             &prev_enrollments,
@@ -180,41 +171,26 @@ pub fn unenroll_for_pref(
     Ok(events)
 }
 
-pub fn get_experiment_participation<'r>(
+pub fn get_global_user_participation<'r>(
     db: &Database,
     reader: &'r impl Readable<'r>,
 ) -> Result<bool> {
     let store = db.get_store(StoreId::Meta);
-    let opted_in = store.get::<bool, _>(reader, DB_KEY_EXPERIMENT_PARTICIPATION)?;
+    let opted_in = store.get::<bool, _>(reader, DB_KEY_GLOBAL_USER_PARTICIPATION)?;
     if let Some(opted_in) = opted_in {
         Ok(opted_in)
     } else {
-        Ok(DEFAULT_EXPERIMENT_PARTICIPATION)
+        Ok(DEFAULT_GLOBAL_USER_PARTICIPATION)
     }
 }
 
-pub fn get_rollout_participation<'r>(db: &Database, reader: &'r impl Readable<'r>) -> Result<bool> {
-    let store = db.get_store(StoreId::Meta);
-    let opted_in = store.get::<bool, _>(reader, DB_KEY_ROLLOUT_PARTICIPATION)?;
-    if let Some(opted_in) = opted_in {
-        Ok(opted_in)
-    } else {
-        Ok(DEFAULT_ROLLOUT_PARTICIPATION)
-    }
-}
-
-pub fn set_experiment_participation(
+pub fn set_global_user_participation(
     db: &Database,
     writer: &mut Writer,
     opt_in: bool,
 ) -> Result<()> {
     let store = db.get_store(StoreId::Meta);
-    store.put(writer, DB_KEY_EXPERIMENT_PARTICIPATION, &opt_in)
-}
-
-pub fn set_rollout_participation(db: &Database, writer: &mut Writer, opt_in: bool) -> Result<()> {
-    let store = db.get_store(StoreId::Meta);
-    store.put(writer, DB_KEY_ROLLOUT_PARTICIPATION, &opt_in)
+    store.put(writer, DB_KEY_GLOBAL_USER_PARTICIPATION, &opt_in)
 }
 
 /// Reset unique identifiers in response to application-level telemetry reset.

--- a/components/nimbus/src/stateful/persistence.rs
+++ b/components/nimbus/src/stateful/persistence.rs
@@ -24,17 +24,8 @@ use std::path::Path;
 //
 // ⚠️ Warning : Altering the type of `DB_VERSION` would itself require a DB migration. ⚠️
 pub(crate) const DB_KEY_DB_VERSION: &str = "db_version";
-pub(crate) const DB_VERSION: u16 = 3;
+pub(crate) const DB_VERSION: u16 = 2;
 const RKV_MAX_DBS: u32 = 6;
-
-pub(crate) const DB_KEY_EXPERIMENT_PARTICIPATION: &str = "user-opt-in-experiments";
-pub(crate) const DB_KEY_ROLLOUT_PARTICIPATION: &str = "user-opt-in-rollouts";
-
-// Legacy key for migration purposes
-pub(crate) const DB_KEY_GLOBAL_USER_PARTICIPATION: &str = "user-opt-in";
-
-pub(crate) const DEFAULT_EXPERIMENT_PARTICIPATION: bool = true;
-pub(crate) const DEFAULT_ROLLOUT_PARTICIPATION: bool = true;
 
 // Inspired by Glean - use a feature to choose between the backends.
 // Select the LMDB-powered storage backend when the feature is not activated.
@@ -126,10 +117,8 @@ pub enum StoreId {
     ///     applied to this database.
     ///   * "nimbus-id":    String, the randomly-generated identifier for the
     ///     current client instance.
-    ///   * "user-opt-in-experiments":  bool, whether the user has explicitly opted in or out
+    ///   * "user-opt-in":  bool, whether the user has explicitly opted in or out
     ///     of participating in experiments.
-    ///   * "user-opt-in-rollouts":  bool, whether the user has explicitly opted in or out
-    ///     of participating in rollouts.
     ///   * "installation-date": a UTC DateTime string, defining the date the consuming app was
     ///     installed
     ///   * "update-date": a UTC DateTime string, defining the date the consuming app was
@@ -346,50 +335,50 @@ impl Database {
     fn maybe_upgrade(&self) -> Result<()> {
         debug!("entered maybe upgrade");
         let mut writer = self.rkv.write()?;
-        let current_version = self
-            .meta_store
-            .get::<u16, _>(&writer, DB_KEY_DB_VERSION)?
-            .unwrap_or(0);
-
-        if current_version == DB_VERSION {
-            info!("Already at version {}, no upgrade needed", DB_VERSION);
-            return Ok(());
-        }
-
-        if current_version == 0 || current_version > DB_VERSION {
-            info!("maybe_upgrade: no version number; wiping most stores");
-            self.clear_experiments_and_enrollments(&mut writer)?;
-            self.updates_store.clear(&mut writer)?;
-            self.meta_store
-                .put(&mut writer, DB_KEY_DB_VERSION, &DB_VERSION)?;
-            writer.commit()?;
-            return Ok(());
-        }
-
-        if current_version == 1 {
-            info!("Migrating database from v1 to v2");
-            if let Err(e) = self.migrate_v1_to_v2(&mut writer) {
-                error_support::report_error!(
-                    "nimbus-database-migration",
-                    "Error migrating database v1 to v2: {:?}. Wiping experiments and enrollments",
-                    e
-                );
+        let db_version = self.meta_store.get::<u16, _>(&writer, DB_KEY_DB_VERSION)?;
+        match db_version {
+            Some(DB_VERSION) => {
+                // Already at the current version, no migration required.
+                info!("Already at version {}, no upgrade needed", DB_VERSION);
+                return Ok(());
+            }
+            Some(1) => {
+                info!("Migrating database from v1 to v2");
+                match self.migrate_v1_to_v2(&mut writer) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        // The idea here is that it's better to leave an
+                        // individual install with a clean empty database
+                        // than in an unknown inconsistent state, because it
+                        // allows them to start participating in experiments
+                        // again, rather than potentially repeating the upgrade
+                        // over and over at each embedding client restart.
+                        error_support::report_error!(
+                            "nimbus-database-migration",
+                            "Error migrating database v1 to v2: {:?}.  Wiping experiments and enrollments",
+                            e
+                        );
+                        self.clear_experiments_and_enrollments(&mut writer)?;
+                    }
+                };
+            }
+            None => {
+                info!("maybe_upgrade: no version number; wiping most stores");
+                // The "first" version of the database (= no version number) had un-migratable data
+                // for experiments and enrollments, start anew.
+                // XXX: We can most likely remove this behaviour once enough time has passed,
+                // since nimbus wasn't really shipped to production at the time anyway.
                 self.clear_experiments_and_enrollments(&mut writer)?;
             }
-        }
-
-        if current_version == 2 {
-            info!("Migrating database from v2 to v3");
-            if let Err(e) = self.migrate_v2_to_v3(&mut writer) {
+            _ => {
                 error_support::report_error!(
-                    "nimbus-database-migration",
-                    "Error migrating database v2 to v3: {:?}. Wiping experiments and enrollments",
-                    e
+                    "nimbus-unknown-database-version",
+                    "Unknown database version. Wiping all stores."
                 );
                 self.clear_experiments_and_enrollments(&mut writer)?;
+                self.meta_store.clear(&mut writer)?;
             }
         }
-
         // It is safe to clear the update store (i.e. the pending experiments) on all schema upgrades
         // as it will be re-filled from the server on the next `fetch_experiments()`.
         // The current contents of the update store may cause experiments to not load, or worse,
@@ -491,50 +480,6 @@ impl Database {
                 .put(writer, &enrollment.slug, &enrollment)?;
         }
         debug!("exiting migrate_v1_to_v2");
-
-        Ok(())
-    }
-
-    /// Migrates a v2 database to v3
-    ///
-    /// Separates global user participation into experiments and rollouts participation.
-    /// For privacy: if user opted out globally, they remain opted out of experiments.
-    fn migrate_v2_to_v3(&self, writer: &mut Writer) -> Result<()> {
-        info!("Upgrading from version 2 to version 3");
-
-        let meta_store = &self.meta_store;
-
-        // Get the old global participation flag
-        let old_global_participation = meta_store
-            .get::<bool, _>(writer, DB_KEY_GLOBAL_USER_PARTICIPATION)?
-            .unwrap_or(true); // Default was true
-
-        // Set new separate flags based on privacy requirements:
-        // - If user opted out globally, they stay opted out of experiments
-        // - If user opted out globally, they stay opted out of rollouts (per requirement #3)
-        meta_store.put(
-            writer,
-            DB_KEY_EXPERIMENT_PARTICIPATION,
-            &old_global_participation,
-        )?;
-        meta_store.put(
-            writer,
-            DB_KEY_ROLLOUT_PARTICIPATION,
-            &old_global_participation,
-        )?;
-
-        // Remove the old global participation key if it exists
-        if meta_store
-            .get::<bool, _>(writer, DB_KEY_GLOBAL_USER_PARTICIPATION)?
-            .is_some()
-        {
-            meta_store.delete(writer, DB_KEY_GLOBAL_USER_PARTICIPATION)?;
-        }
-
-        info!(
-            "Migration v2->v3: experiments_participation={}, rollouts_participation={}",
-            old_global_participation, old_global_participation
-        );
 
         Ok(())
     }

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -908,7 +908,7 @@ fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -
 
     client.record_event("app.foregrounded".to_string(), 1)?;
 
-    client.set_experiment_participation(true)?;
+    client.set_global_user_participation(true)?;
 
     // The number of non-zero days in our event store is 2, so the first experiment
     // should be applied, but the second experiment will not be.

--- a/components/nimbus/src/tests/stateless/test_cirrus_client.rs
+++ b/components/nimbus/src/tests/stateless/test_cirrus_client.rs
@@ -4,9 +4,7 @@
 
 use crate::metrics::EnrollmentStatusExtraDef;
 use crate::{
-    enrollment::{
-        EnrollmentChangeEventType, ExperimentEnrollment, NotEnrolledReason, Participation,
-    },
+    enrollment::{EnrollmentChangeEventType, ExperimentEnrollment, NotEnrolledReason},
     tests::{
         helpers::TestMetrics,
         stateless::test_cirrus_client::helpers::get_experiment_with_newtab_feature_branches,
@@ -47,12 +45,8 @@ fn test_can_enroll() -> Result<()> {
         .set_experiments(to_string(&HashMap::from([("data", &[exp.clone()])])).unwrap())
         .unwrap();
 
-    let result = client.enroll(
-        "test".to_string(),
-        Default::default(),
-        Participation::default(),
-        &[],
-    )?;
+    let result = client.enroll("test".to_string(), Default::default(), true, &[])?;
+
     assert_eq!(result.enrolled_feature_config_map.len(), 1);
     assert_eq!(
         result
@@ -87,12 +81,7 @@ fn test_will_not_enroll_if_previously_did_not_enroll() -> Result<()> {
         },
     };
 
-    let result = client.enroll(
-        "test".to_string(),
-        Default::default(),
-        Participation::default(),
-        &[enrollment],
-    )?;
+    let result = client.enroll("test".to_string(), Default::default(), true, &[enrollment])?;
 
     assert_eq!(result.events.len(), 0);
 
@@ -118,10 +107,6 @@ fn test_handle_enrollment_works_with_json() -> Result<()> {
                 Value::String("en-US".to_string()),
             )]))
             .unwrap(),
-        ),
-        (
-            "participation".to_string(),
-            to_value(Participation::default()).unwrap(),
         ),
         (
             "nextExperiments".to_string(),
@@ -211,12 +196,7 @@ fn test_sends_metrics_on_enrollment() -> Result<()> {
     client
         .set_experiments(to_string(&HashMap::from([("data", &[exp.clone()])])).unwrap())
         .unwrap();
-    client.enroll(
-        "test".to_string(),
-        Default::default(),
-        Participation::default(),
-        &[],
-    )?;
+    client.enroll("test".to_string(), Default::default(), true, &[])?;
 
     let metric_records: Vec<EnrollmentStatusExtraDef> = metrics_handler.get_enrollment_statuses();
     assert_eq!(metric_records.len(), 1);

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -836,8 +836,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let ro = get_bucketed_rollout(slug, 0);
     let recipes = [ro];
 
-    let (enrollments, _) =
-        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], &recipes, &[])?;
+    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(true, &[], &recipes, &[])?;
 
     assert_eq!(enrollments.len(), 1);
     let enr = enrollments.first().unwrap();
@@ -850,7 +849,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -866,7 +865,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -898,8 +897,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let ro = get_bucketed_rollout(slug, 0);
     let recipes = [ro];
 
-    let (enrollments, _) =
-        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], &recipes, &[])?;
+    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(true, &[], &recipes, &[])?;
 
     assert_eq!(enrollments.len(), 1);
     let enr = enrollments.first().unwrap();
@@ -912,7 +910,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -928,7 +926,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -950,7 +948,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let recipes = [ro];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &prev_recipes,
         &recipes,
         enrollments.as_slice(),
@@ -981,7 +979,7 @@ fn test_experiment_does_not_reenroll_from_disqualified_not_selected_or_not_targe
     let recipes = [exp_1, exp_2];
 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &recipes,
         &recipes,
         &[
@@ -1182,7 +1180,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = vec![];
     let updated_experiments = get_feature_conflict_test_experiments();
     let (enrollments, _events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1222,7 +1220,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments = get_feature_conflict_test_experiments();
     let (enrollments, _events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1249,7 +1247,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments = get_feature_conflict_test_experiments();
     let (enrollments, _events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1272,7 +1270,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments: Vec<Experiment> = vec![];
     let (enrollments, _events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &existing_experiments,
         &updated_experiments,
         &existing_enrollments,
@@ -1334,12 +1332,8 @@ fn test_evolver_experiment_not_enrolled_feature_conflict() -> Result<()> {
     let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
-    let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
-        &[],
-        &test_experiments,
-        &[],
-    )?;
+    let (enrollments, events) =
+        evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
 
     assert_eq!(
         enrollments.len(),
@@ -1400,12 +1394,8 @@ fn test_multi_feature_per_branch_conflict() -> Result<()> {
     let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
-    let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
-        &[],
-        &test_experiments,
-        &[],
-    )?;
+    let (enrollments, events) =
+        evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
 
     let enrolled_count = enrollments
         .iter()
@@ -1444,12 +1434,8 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
     let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
-    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
-        &[],
-        &test_experiments,
-        &[],
-    )?;
+    let (enrollments, _) =
+        evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
 
     let enrolled_count = enrollments
         .iter()
@@ -1462,7 +1448,7 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
 
     let conflicting_experiment = get_conflicting_experiment();
     let (enrollments, events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &test_experiments,
         &[test_experiments[1].clone(), conflicting_experiment.clone()],
         &enrollments,
@@ -1511,12 +1497,8 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     // 1. we have two experiments that use one feature each. There's no conflicts.
     let next_experiments = vec![aboutwelcome_experiment.clone(), newtab_experiment.clone()];
 
-    let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
-        &[],
-        &next_experiments,
-        &[],
-    )?;
+    let (enrollments, _) =
+        evolver.evolve_enrollments::<Experiment>(true, &[], &next_experiments, &[])?;
 
     let feature_map =
         map_features_by_feature_id(&enrollments, &next_experiments, &no_coenrolling_features());
@@ -1554,7 +1536,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         mixed_experiment.clone(),
     ];
     let (enrollments, events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1598,7 +1580,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![newtab_experiment.clone(), mixed_experiment.clone()];
     let (enrollments, _) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1630,7 +1612,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![mixed_experiment.clone()];
     let (enrollments, _) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1666,7 +1648,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = vec![];
     let next_experiments = vec![mixed_experiment.clone()];
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1681,7 +1663,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         mixed_experiment.clone(),
     ];
     let (enrollments, events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1722,7 +1704,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![mixed_experiment, multi_feature_experiment.clone()];
     let (enrollments, events) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -1762,7 +1744,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_experiments = next_experiments;
     let next_experiments = vec![multi_feature_experiment];
     let (enrollments, _) = evolver.evolve_enrollments(
-        Participation::default(),
+        true,
         &prev_experiments,
         &next_experiments,
         &prev_enrollments,
@@ -2289,12 +2271,8 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
     let test_experiments = get_test_experiments();
 
     // this should not return an error
-    let (enrollments, events) = evolver.evolve_enrollments(
-        Participation::default(),
-        &test_experiments,
-        &test_experiments,
-        &[],
-    )?;
+    let (enrollments, events) =
+        evolver.evolve_enrollments(true, &test_experiments, &test_experiments, &[])?;
 
     assert_eq!(
         enrollments.len(),
@@ -2311,7 +2289,7 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
     // Test that evolve_enrollments correctly handles the case where a
     // record with a previous enrollment gets dropped
     let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
+        true,
         &[],
         &test_experiments,
         &existing_enrollments[..],
@@ -2346,12 +2324,8 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
     let test_experiments = &[test_experiment];
     // The user should get enrolled, since the targeting is OR'ing the app_id == 'org.mozilla.fenix'
     // and the 'is_already_enrolled'
-    let (enrollments, events) = evolver.evolve_enrollments::<Experiment>(
-        Participation::default(),
-        &[],
-        test_experiments,
-        &[],
-    )?;
+    let (enrollments, events) =
+        evolver.evolve_enrollments::<Experiment>(true, &[], test_experiments, &[])?;
     assert_eq!(
         enrollments.len(),
         1,
@@ -2369,12 +2343,8 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
 
     // The user should still be enrolled, since the targeting is OR'ing the app_id == 'org.mozilla.fenix'
     // and the 'is_already_enrolled'
-    let (enrollments, events) = evolver.evolve_enrollments(
-        Participation::default(),
-        test_experiments,
-        test_experiments,
-        &enrollments,
-    )?;
+    let (enrollments, events) =
+        evolver.evolve_enrollments(true, test_experiments, test_experiments, &enrollments)?;
     assert_eq!(
         enrollments.len(),
         1,
@@ -2656,7 +2626,7 @@ fn test_evolver_rollouts_do_not_conflict_with_experiments() -> Result<()> {
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], recipes, &[])?;
+        evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
     assert_eq!(enrollments.len(), 2);
     assert_eq!(events.len(), 2);
 
@@ -2717,7 +2687,7 @@ fn test_evolver_rollouts_do_not_conflict_with_rollouts() -> Result<()> {
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let (enrollments, events) =
-        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], recipes, &[])?;
+        evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
     assert_eq!(enrollments.len(), 3);
     assert_eq!(events.len(), 3);
 
@@ -2943,7 +2913,7 @@ fn test_rollouts_end_to_end() -> Result<()> {
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
     let (enrollments, _events) =
-        evolver.evolve_enrollments::<Experiment>(Participation::default(), &[], recipes, &[])?;
+        evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
 
     let features = map_features_by_feature_id(&enrollments, recipes, &no_coenrolling_features());
 

--- a/components/nimbus/tests/test_get_experiment_branch_by_id.rs
+++ b/components/nimbus/tests/test_get_experiment_branch_by_id.rs
@@ -81,7 +81,7 @@ fn test_enrolled() -> Result<()> {
             experiment_slug
         );
     }
-    client.set_experiment_participation(false)?;
+    client.set_global_user_participation(false)?;
     for experiment_slug in experiment_slugs {
         assert_eq!(
             client.get_experiment_branch(experiment_slug.to_string())?,

--- a/components/nimbus/uniffi.toml
+++ b/components/nimbus/uniffi.toml
@@ -18,4 +18,4 @@ ffi_module_filename = "nimbusFFI"
 # This can be commented out, and the `--library` argument of `bindgen-uniffi` should be used instead.
 # We won't comment this out until cirrus— which a) does not use `--library` b) is not in this repo— uses the pre-built
 # binaries built by `server-megazord-build.py`. Until then, it comments out the line programmatically.
-# cdylib_name = "cirrus"
+cdylib_name = "cirrus"

--- a/components/support/nimbus-fml/uniffi.toml
+++ b/components/support/nimbus-fml/uniffi.toml
@@ -6,9 +6,9 @@
 # This can be commented out, and the `--library` argument of `bindgen-uniffi` should be used instead.
 # We won't comment this out until cirrus— which a) does not use `--library` b) is not in this repo— uses the pre-built
 # binaries built by `server-megazord-build.py`. Until then, it comments out the line programmatically.
-# cdylib_name = "cirrus"
+cdylib_name = "cirrus"
 
 [bindings.python.custom_types.JsonObject]
-imports = ["json"]
+imports = [ "json" ]
 into_custom = "json.loads({})"
 from_custom = "json.dumps({})"

--- a/megazords/cirrus/tests/python-tests/conftest.py
+++ b/megazords/cirrus/tests/python-tests/conftest.py
@@ -94,7 +94,6 @@ def req(request_context):
             {
                 "clientId": client_id,
                 "requestContext": request_context,
-                "participation": {"in_experiments": True, "in_rollouts": True},
             }
         )
 

--- a/megazords/cirrus/tests/python-tests/test_cirrus_fml_integration.py
+++ b/megazords/cirrus/tests/python-tests/test_cirrus_fml_integration.py
@@ -17,7 +17,6 @@ def test_enroll_and_get_enrolled_feature_json_control(fml_client, cirrus_client)
         {
             "clientId": "jeddai",
             "requestContext": {"username": "jeddai"},
-            "participation": {"in_experiments": True, "in_rollouts": True},
         }
     )
     res = json.loads(cirrus_client.handle_enrollment(req))
@@ -51,7 +50,6 @@ def test_enroll_and_get_enrolled_feature_json_treatment(fml_client, cirrus_clien
         {
             "clientId": "test",
             "requestContext": {"username": "test"},
-            "participation": {"in_experiments": True, "in_rollouts": True},
         }
     )
     res = json.loads(cirrus_client.handle_enrollment(req))

--- a/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
+++ b/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/Nimbus.swift
@@ -222,13 +222,8 @@ private extension Nimbus {
  * Methods split out onto a separate internal extension for testing purposes.
  */
 extension Nimbus {
-    func setExperimentParticipationOnThisThread(_ value: Bool) throws {
-        let changes = try nimbusClient.setExperimentParticipation(optIn: value)
-        postEnrollmentCalculation(changes)
-    }
-
-    func setRolloutParticipationOnThisThread(_ value: Bool) throws {
-        let changes = try nimbusClient.setRolloutParticipation(optIn: value)
+    func setGlobalUserParticipationOnThisThread(_ value: Bool) throws {
+        let changes = try nimbusClient.setGlobalUserParticipation(optIn: value)
         postEnrollmentCalculation(changes)
     }
 
@@ -271,24 +266,13 @@ extension Nimbus {
 }
 
 extension Nimbus: NimbusUserConfiguration {
-    public var experimentParticipation: Bool {
+    public var globalUserParticipation: Bool {
         get {
-            catchAll { try nimbusClient.getExperimentParticipation() } ?? true
+            catchAll { try nimbusClient.getGlobalUserParticipation() } ?? false
         }
         set {
             _ = catchAll(dbQueue) { _ in
-                try self.setExperimentParticipationOnThisThread(newValue)
-            }
-        }
-    }
-
-    public var rolloutParticipation: Bool {
-        get {
-            catchAll { try nimbusClient.getRolloutParticipation() } ?? true
-        }
-        set {
-            _ = catchAll(dbQueue) { _ in
-                try self.setRolloutParticipationOnThisThread(newValue)
+                try self.setGlobalUserParticipationOnThisThread(newValue)
             }
         }
     }
@@ -445,8 +429,7 @@ extension Nimbus: NimbusMessagingProtocol {
 public class NimbusDisabled: NimbusApi {
     public static let shared = NimbusDisabled()
 
-    public var experimentParticipation: Bool = true
-    public var rolloutParticipation: Bool = true
+    public var globalUserParticipation: Bool = false
 }
 
 public extension NimbusDisabled {

--- a/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
+++ b/megazords/ios-rust/Sources/MozillaRustComponentsWrapper/Nimbus/NimbusApi.swift
@@ -146,12 +146,9 @@ public protocol NimbusUserConfiguration {
     /// Call this when toggling user preferences about sending analytics.
     func resetTelemetryIdentifiers()
 
-    /// Control the opt out for all experiments. This is likely a user action.
+    /// Control the opt out for all experiments at once. This is likely a user action.
     ///
-    var experimentParticipation: Bool { get set }
-    /// Control the opt out for all rollouts at once. This is likely a user action.
-    ///
-    var rolloutParticipation: Bool { get set }
+    var globalUserParticipation: Bool { get set }
 
     /// Get the list of currently enrolled experiments
     ///

--- a/megazords/ios-rust/tests/MozillaRustComponentsTests/NimbusTests.swift
+++ b/megazords/ios-rust/tests/MozillaRustComponentsTests/NimbusTests.swift
@@ -188,7 +188,7 @@ class NimbusTests: XCTestCase {
             return self.minimalExperimentJSON()
         }
 
-        let finishedNormally = job.joinOrTimeout(timeout: 10.0)
+        let finishedNormally = job.joinOrTimeout(timeout: 4.0)
         XCTAssertTrue(finishedNormally)
 
         let noExperiments = nimbus.getActiveExperiments()
@@ -474,7 +474,7 @@ class NimbusTests: XCTestCase {
 
         // Opt out of all experiments, which should generate a "disqualification" event for the enrolled
         // experiment
-        try nimbus.setExperimentParticipationOnThisThread(false)
+        try nimbus.setGlobalUserParticipationOnThisThread(false)
 
         // Use the Glean test API to check that the valid event is present
         XCTAssertNotNil(GleanMetrics.NimbusEvents.disqualification.testGetValue(), "Event must have a value")


### PR DESCRIPTION
…nd rollouts separately (#6888)"

This was causing CI failures in mozilla-firefox.

This reverts commit 761dd8b7eba6be2a46107068147fa8449849ab14.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
