### PR TITLE
Monorepo build and version tweaks for nimbus-fml.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,20 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
-dependencies = [
- "cfg-if 1.0.0",
- "getrandom 0.2.7",
- "once_cell",
- "serde",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,7 +345,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.3",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -367,21 +353,6 @@ dependencies = [
  "shlex",
  "syn 2.0.89",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -418,12 +389,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "byteorder"
@@ -1544,16 +1509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,16 +1601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fraction"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
-dependencies = [
- "lazy_static",
- "num",
 ]
 
 [[package]]
@@ -1853,10 +1798,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2386,15 +2329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iso8601"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,34 +2401,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonschema"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
-dependencies = [
- "ahash",
- "anyhow",
- "base64 0.21.2",
- "bytecount",
- "fancy-regex",
- "fraction",
- "getrandom 0.2.7",
- "iso8601",
- "itoa",
- "memchr",
- "num-cmp",
- "once_cell",
- "parking_lot",
- "percent-encoding",
- "regex",
- "serde",
- "serde_json",
- "time",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -3018,18 +2924,17 @@ dependencies = [
  "clap 4.5.39",
  "email_address",
  "glob",
- "heck 0.3.3",
+ "heck 0.5.0",
  "itertools 0.14.0",
- "jsonschema",
  "lazy_static",
  "regex",
  "serde",
  "serde_json",
- "serde_yaml 0.8.24",
+ "serde_yaml 0.9.21",
  "sha2",
  "tempfile",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.16.1",
  "thiserror 1.0.69",
  "unicode-segmentation",
  "uniffi",
@@ -3115,83 +3020,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-cmp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
-
-[[package]]
-name = "num-complex"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -3981,22 +3813,20 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6d906922d99c677624d2042a93f89b2b7df0f6411032237d5d99a602c2487c"
+checksum = "0f67a9dbc634fcd36a2d1d800ca818065dcf71a1d907dc35130c2d1552c6e1dc"
 dependencies = [
  "arrayref",
  "bincode",
  "bitflags 2.8.0",
- "byteorder",
  "id-arena",
  "lazy_static",
  "log",
  "ordered-float",
- "paste",
  "serde",
  "serde_derive",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "url",
  "uuid",
 ]
@@ -4784,22 +4614,13 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width 0.1.11",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -4863,7 +4684,6 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -4871,16 +4691,6 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tinystr"
@@ -6171,26 +5981,6 @@ dependencies = [
  "quote",
  "syn 2.0.89",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
 ]
 
 [[package]]

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -26,7 +26,7 @@ serde_derive = "1"
 serde_json = "1"
 thiserror = "1"
 url = "2.5"
-rkv = { version = "0.19", optional = true }
+rkv = { version = "0.20", optional = true }
 jexl-eval = "0.4.0"
 uuid = { version = "1.3", features = ["serde", "v4"]}
 sha2 = "^0.10"

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -9,20 +9,38 @@ license = "MPL-2.0"
 [features]
 client-lib = []
 uniffi-bindings = ["client-lib", "dep:uniffi"]
+# XXX - this test code has failed undetected for a very long time and should either be removed or fixed.
+kotlin-tests = []
+swift-tests = []
+# and a work-around so that `--all-features` still arranges to keep our test features disabled.
+all-features-workaround = []
 
 [lib]
 name = "nimbus_fml"
+
+# A bin target needed when used in m-c.
+[[bin]]
+name = "nimbus-fml"
+
+[build-dependencies]
+uniffi = { version = "0.29.0", features = ["build"], optional = true }
+
+[dev-dependencies]
+tempfile = "3"
+# If you enable any of the `*-tests` features you will also need to uncomment this.
+# It is commented to avoid dragging it into m-c, which is a larger than expected yak to shave for something that's not actually used.
+# jsonschema = { version = "0.17", default-features = false, optional = true }
 
 [dependencies]
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 anyhow = "1.0.44"
 serde_json = { version = "1", features = ["preserve_order"] }
-serde_yaml = "0.8.21"
+serde_yaml = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.29"
 askama = "0.13"
-textwrap = "0.14.2"
-heck = "0.3.3"
+textwrap = "0.16"
+heck = "0.5"
 unicode-segmentation = "1.8.0"
 url = { version = "2", features = ["serde"] }
 glob = "0.3.0"
@@ -35,10 +53,3 @@ itertools = "0"
 regex = "1.9"
 viaduct = { path = "../../viaduct/" }
 termcolor = "1.4.1"
-
-[build-dependencies]
-uniffi = { version = "0.29.0", features = ["build"], optional = true }
-
-[dev-dependencies]
-tempfile = "3"
-jsonschema = { version = "0.17", default-features = false }

--- a/components/support/nimbus-fml/moz.build
+++ b/components/support/nimbus-fml/moz.build
@@ -1,0 +1,19 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+HOST_RUST_PROGRAMS = ["nimbus-fml"]
+
+# copy-pasta from other moz.build file.
+if CONFIG["MOZ_WIDGET_TOOLKIT"] == "cocoa":
+    OS_LIBS += ["-framework CoreFoundation"]
+elif CONFIG["OS_TARGET"] == "WINNT":
+    OS_LIBS += [
+        "advapi32",
+        "wsock32",
+        "ws2_32",
+        "mswsock",
+        "winmm",
+    ]

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/bundled.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/bundled.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 use super::common::{code_type, quoted};
 use crate::backends::{CodeOracle, CodeType, LiteralRenderer, TypeIdentifier, VariablesType};
 use crate::intermediate_representation::{Literal, TypeRef};
-use heck::SnakeCase;
+use heck::ToSnakeCase;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub(crate) struct TextCodeType;

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/common.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/common.rs
@@ -1,17 +1,17 @@
 // /* This Source Code Form is subject to the terms of the Mozilla Public
 //  * License, v. 2.0. If a copy of the MPL was not distributed with this
 //  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use heck::{CamelCase, MixedCase, ShoutySnakeCase};
+use heck::{ToLowerCamelCase, ToShoutySnakeCase, ToUpperCamelCase};
 use std::fmt::Display;
 
 /// Get the idiomatic Kotlin rendering of a class name (for enums, records, errors, etc).
 pub fn class_name(nm: &dyn Display) -> String {
-    nm.to_string().to_camel_case()
+    nm.to_string().to_upper_camel_case()
 }
 
 /// Get the idiomatic Kotlin rendering of a variable name.
 pub fn var_name(nm: &dyn Display) -> String {
-    nm.to_string().to_mixed_case()
+    nm.to_string().to_lower_camel_case()
 }
 
 /// Get the idiomatic Kotlin rendering of an individual enum variant.

--- a/components/support/nimbus-fml/src/backends/kotlin/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/mod.rs
@@ -71,7 +71,11 @@ pub(crate) fn generate_struct(manifest: &FeatureManifest, cmd: &GenerateStructCm
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "kotlin-tests",
+    not(feature = "all-features-workaround")
+))]
 pub mod test {
     use crate::util::{join, pkg_dir, sdk_dir};
     use anyhow::{bail, Result};

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/common.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/common.rs
@@ -1,22 +1,22 @@
 // /* This Source Code Form is subject to the terms of the Mozilla Public
 //  * License, v. 2.0. If a copy of the MPL was not distributed with this
 //  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use heck::{CamelCase, MixedCase};
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use std::fmt::Display;
 
 /// Get the idiomatic Swift rendering of a class name (for enums, records, errors, etc).
 pub fn class_name(nm: &dyn Display) -> String {
-    nm.to_string().to_camel_case()
+    nm.to_string().to_upper_camel_case()
 }
 
 /// Get the idiomatic Swift rendering of a variable name.
 pub fn var_name(nm: &dyn Display) -> String {
-    nm.to_string().to_mixed_case()
+    nm.to_string().to_lower_camel_case()
 }
 
 /// Get the idiomatic Swift rendering of an individual enum variant.
 pub fn enum_variant_name(nm: &dyn Display) -> String {
-    nm.to_string().to_mixed_case()
+    nm.to_string().to_lower_camel_case()
 }
 
 /// Surrounds a property name with quotes. It is assumed that property names do not need escaping.

--- a/components/support/nimbus-fml/src/backends/swift/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/mod.rs
@@ -53,7 +53,11 @@ pub(crate) fn generate_struct(manifest: &FeatureManifest, cmd: &GenerateStructCm
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "swift-tests",
+    not(feature = "all-features-workaround")
+))]
 pub mod test {
     use crate::util::{join, pkg_dir, sdk_dir};
     use anyhow::{bail, Context, Result};

--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -362,7 +362,11 @@ pub(crate) fn print_info(cmd: &PrintInfoCmd) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(feature = "swift-tests", feature = "kotlin-tests"),
+    not(feature = "all-features-workaround")
+))]
 mod test {
     use std::fs;
     use std::path::PathBuf;
@@ -705,7 +709,11 @@ mod test {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "kotlin-tests",
+    not(feature = "all-features-workaround")
+))]
 mod kts_tests {
     use crate::frontend::{AboutBlock, KotlinAboutBlock};
 
@@ -979,7 +987,11 @@ mod kts_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "swift-tests",
+    not(feature = "all-features-workaround")
+))]
 mod swift_tests {
     use super::{
         test::{generate_and_assert, generate_multiple_and_assert},

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -7,7 +7,7 @@ the details of which are reproduced below.
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
 * [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
-* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
+* [MIT License: aho-corasick, memchr](#mit-license-aho-corasick-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
@@ -505,7 +505,6 @@ The following text applies to code linked from these dependencies:
 [once_cell](https://github.com/matklad/once_cell),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
-[paste](https://github.com/dtolnay/paste),
 [percent-encoding](https://github.com/servo/rust-url/),
 [pin-project-lite](https://github.com/taiki-e/pin-project-lite),
 [pin-utils](https://github.com/rust-lang-nursery/pin-utils),
@@ -790,11 +789,10 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr
+## MIT License: aho-corasick, memchr
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
-[byteorder](https://github.com/BurntSushi/byteorder),
 [memchr](https://github.com/BurntSushi/memchr)
 
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,9 +7,12 @@ import org.yaml.snakeyaml.Yaml
 // (They are the same in app-services but different in moz-central)
 def appServicesRootDir = gradle.root.hasProperty("mozconfig") ? new File(ext.topsrcdir, "services/app-services/") : rootDir
 
-includeBuild("$appServicesRootDir/tools/nimbus-gradle-plugin") {
-    dependencySubstitution {
-        substitute module("org.mozilla.appservices:tooling-nimbus-gradle") using(project(':'))
+// It's not clear this is needed at all. It is certain it's not wanted when in mozilla-central.
+if (!gradle.root.hasProperty("mozconfig")) {
+    includeBuild("$appServicesRootDir/tools/nimbus-gradle-plugin") {
+        dependencySubstitution {
+            substitute module("org.mozilla.appservices:tooling-nimbus-gradle") using(project(':'))
+        }
     }
 }
 
@@ -56,7 +59,12 @@ def setupProject(name, projectProps, appServicesRootDir) {
 
     settings.include(":$name")
 
-    project(":$name").projectDir = new File(appServicesRootDir, path)
+    def projectDir = new File(appServicesRootDir, path)
+    // tooling-nimbus-gradle gets special treatment, it doesn't exist in the monorepo
+    if (!projectDir.exists() && name != "tooling-nimbus-gradle") {
+        throw new GradleException("Project directory does not exist: $projectDir (for project $name)")
+    }
+    project(":$name").projectDir = projectDir
 
     // project(...) gives us a skeleton project that we can't set ext.* on
     gradle.beforeProject { project ->


### PR DESCRIPTION
* Update Cargo.toml for m-c.
* The gradle files are modified so they work correctly in m-c.
* Upgraded "heck" to 0.5, which required some code changes.
* A couple other version bumps to match m-c which didn't require code changes.
* Includes a bonus bump of rkv in nimbus itself.
* Hacky work-arounds for the fact that the swift and kotlin tests have been broken for years
  via features. This avoids needing to vendor `jsonschema` into m-c, but keeps the door open
  to fixing these tests (and requiring a vendor of jsonschema) at that time.