### PR TITLE
Remove trailing whitespace in some iOS docs

### DIFF
--- a/docs/design/swift-package-manager.md
+++ b/docs/design/swift-package-manager.md
@@ -56,7 +56,7 @@ Example (URL-based):
 
 ## The `rust-components-swift` repository
 
-> [!WARNING]  
+> [!WARNING]
 > rust-components-swift has been deprecated and is only around until there are no more potential uplifts to already-landed versions of firefox-ios. firefox-ios now consumes application-services via [local swift package](https://github.com/mozilla-mobile/firefox-ios/tree/main/MozillaRustComponents)
 
 The repository is a Swift Package for distributing releases of Mozilla's various Rust-based application components. It provides the Swift source code packaged in a format understood by the Swift package manager, and depends on a pre-compiled binary release of the underlying Rust code published from `application-services`

--- a/docs/howtos/locally-published-components-in-firefox-ios.md
+++ b/docs/howtos/locally-published-components-in-firefox-ios.md
@@ -1,6 +1,6 @@
 # How to locally test Swift Package Manager components on Firefox iOS
 
-> This guide explains how to build and test **Firefox iOS against a local Application Services** checkout.  
+> This guide explains how to build and test **Firefox iOS against a local Application Services** checkout.
 > For background on our Swift Package approach, see the [ADR](../adr/0003-swift-packaging.md).
 
 ---


### PR DESCRIPTION
these are being noticed by linters in m-c