### PR TITLE
Replace nimbus-fml `EmailAddress` type with `String`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,15 +1102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
-name = "email_address"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "embedded-uniffi-bindgen"
 version = "0.1.0"
 dependencies = [
@@ -2858,7 +2849,6 @@ dependencies = [
  "askama",
  "cfg-if",
  "clap 4.5.39",
- "email_address",
  "glob",
  "heck 0.5.0",
  "itertools 0.14.0",

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -47,7 +47,6 @@ glob = "0.3.0"
 uniffi = { version = "0.29.0", optional = true }
 cfg-if = "1.0.0"
 lazy_static = "1.4"
-email_address = { version = "0.2.4", features = ["serde"] }
 sha2 = "^0.10"
 itertools = "0"
 regex = "1.9"

--- a/components/support/nimbus-fml/src/client/descriptor.rs
+++ b/components/support/nimbus-fml/src/client/descriptor.rs
@@ -4,7 +4,6 @@
 
 use std::collections::BTreeSet;
 
-use email_address::EmailAddress;
 use url::Url;
 
 use crate::{frontend::DocumentationLink, intermediate_representation::FeatureDef, FmlClient};
@@ -15,7 +14,7 @@ pub struct FmlFeatureDescriptor {
     pub(crate) description: String,
     pub(crate) is_coenrolling: bool,
     pub(crate) documentation: Vec<DocumentationLink>,
-    pub(crate) contacts: Vec<EmailAddress>,
+    pub(crate) contacts: Vec<String>,
     pub(crate) meta_bug: Option<Url>,
     pub(crate) events: Vec<Url>,
     pub(crate) configurator: Option<Url>,

--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -14,7 +14,6 @@ cfg_if::cfg_if! {
     use crate::{editing::{CorrectionCandidate, CursorPosition, CursorSpan}, frontend::DocumentationLink};
     use url::Url;
     use std::str::FromStr;
-    use email_address::EmailAddress;
     use descriptor::FmlFeatureDescriptor;
     use inspector::{FmlEditorError, FmlFeatureExample, FmlFeatureInspector};
     }
@@ -168,13 +167,6 @@ uniffi::custom_type!(JsonObject, String, {
 uniffi::custom_type!(Url, String, {
     remote,
     try_lift: |val| Ok(Self::from_str(&val)?),
-    lower: |obj| obj.as_str().to_string(),
-});
-
-#[cfg(feature = "uniffi-bindings")]
-uniffi::custom_type!(EmailAddress, String, {
-    remote,
-    try_lift: |val| Ok(Self::from_str(val.as_str())?),
     lower: |obj| obj.as_str().to_string(),
 });
 

--- a/components/support/nimbus-fml/src/error.rs
+++ b/components/support/nimbus-fml/src/error.rs
@@ -15,8 +15,6 @@ pub enum FMLError {
     YAMLError(#[from] serde_yaml::Error),
     #[error("URL Error: {0}")]
     UrlError(#[from] url::ParseError),
-    #[error("Email Error: {0}")]
-    EmailError(#[from] email_address::Error),
     #[error("Regex Error: {0}")]
     RegexError(#[from] regex::Error),
 

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -4,12 +4,10 @@ namespace fml {};
 typedef string JsonObject;
 [Custom]
 typedef string Url;
-[Custom]
-typedef string EmailAddress;
 
 [Error]
 enum FMLError {
-    "IOError", "JSONError", "YAMLError", "UrlError", "EmailError", "RegexError", "FetchError",
+    "IOError", "JSONError", "YAMLError", "UrlError", "RegexError", "FetchError",
     "ResponseStatusError", "Utf8DecodingError", "InvalidPath",
     "TemplateProblem", "Fatal", "InternalError", "ValidationError", "TypeParsingError",
     "InvalidChannelError", "FMLModuleError", "CliError", "ClientError", "InvalidFeatureError",
@@ -77,7 +75,8 @@ dictionary FmlFeatureDescriptor {
     /// Documentation for this feature.
     sequence<DocumentationLink> documentation;
     /// Email addresses of engineers and product owners who can answer questions about this feature
-    sequence<EmailAddress> contacts;
+    /// Just a list of email addresses, no validation, no parsing, nothing.
+    sequence<string> contacts;
     /// Where bugs can be filed on this feature
     Url? meta_bug;
     /// The Glean events produced by this feature.

--- a/components/support/nimbus-fml/src/frontend.rs
+++ b/components/support/nimbus-fml/src/frontend.rs
@@ -4,7 +4,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use email_address::EmailAddress;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use url::Url;
@@ -246,7 +245,7 @@ pub(crate) struct FeatureMetadata {
     #[serde(default)]
     #[serde(alias = "owners", alias = "owner")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub(crate) contacts: Vec<EmailAddress>,
+    pub(crate) contacts: Vec<String>,
     /// Where should QA file issues for this feature?
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -712,7 +711,7 @@ mod feature_metadata {
             FeatureMetadata {
                 description: "A description".to_string(),
                 meta_bug: Some(Url::from_str("https://example.com/EXP-23")?),
-                contacts: vec![EmailAddress::from_str("jdoe@example.com")?],
+                contacts: vec!["jdoe@example.com".to_string()],
                 documentation: vec![DocumentationLink::new(
                     "User documentation",
                     "https://example.info/my-feature"
@@ -764,25 +763,11 @@ mod feature_metadata {
             fm,
             FeatureMetadata {
                 description: "A description".to_string(),
-                contacts: vec![EmailAddress::from_str("jdoe@example.com")?],
+                contacts: vec!["jdoe@example.com".to_string()],
                 ..Default::default()
             }
         );
 
-        Ok(())
-    }
-
-    #[test]
-    fn test_invalid_email_addresses() -> Result<()> {
-        let fm = serde_json::from_str::<FeatureMetadata>(
-            r#"{
-            "description": "A description",
-            "contacts": [
-                "Not an email address"
-            ],
-        }"#,
-        );
-        assert!(fm.is_err());
         Ok(())
     }
 


### PR DESCRIPTION
It adds an email_address dependency, which isn't useful in practice, and a string keeps the semantics for a `contact` out of this crate (eg, maybe there's a future where this is a slack handle/channel?)

Not use by foreign bindings - they always were just a string.