### PR TITLE
Move ios megazord .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,17 +35,6 @@ components/**/ios/Generated
 # We don't car about Cargo.lock for our tests.
 testing/sync-test/Cargo.lock
 
-# iOS Building & XCFramework artifacts
-megazords/ios-rust/MozillaRustComponents.xcframework*
-megazords/ios-rust/focus/FocusRustComponents.xcframework*
-megazords/ios-rust/include*
-megazords/ios-rust/.build*
-megazords/ios-rust/sources/MozillaRustComponentsWrapper/generated*
-megazords/ios-rust/.swiftpm
-
-# Glean generated artifacts
-megazords/ios-rust/.venv
-
 # Carthage generated artifacts
 # We no longer use Carthage, but those
 # artifacts may still live in local envirionments.

--- a/megazords/ios-rust/.gitignore
+++ b/megazords/ios-rust/.gitignore
@@ -1,3 +1,16 @@
-# May be built outside of a workspace, leaving extra junk behind.
+# This is all ugly and should be fixed.
+
+# iOS Building & XCFramework artifacts
+MozillaRustComponents.xcframework*
+focus/FocusRustComponents.xcframework*
+include*
+.build*
+sources/MozillaRustComponentsWrapper/generated*
+.swiftpm
+
+# Glean generated artifacts
+.venv
+
+# When built in the monorepo we may get these.
 Cargo.lock
 target


### PR DESCRIPTION
That dir already has its own .gitignore for the monorepo, which also wants the entries.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
