### PR TITLE
Fix remote settings last_modified comparison

### DIFF
--- a/components/remote_settings/src/service.rs
+++ b/components/remote_settings/src/service.rs
@@ -101,7 +101,7 @@ impl RemoteSettingsService {
             if let Some(client_last_modified) = client.get_last_modified_timestamp()? {
                 if let Some(server_last_modified) = change_map.get(&(collection_name, &bucket_name))
                 {
-                    if client_last_modified != *server_last_modified {
+                    if client_last_modified == *server_last_modified {
                         trace!("skipping up-to-date collection: {collection_name}");
                         continue;
                     }


### PR DESCRIPTION
Using the wrong comparision is causing issues with the new search engine selector on iOS.

:facepalm: 


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
