### PR TITLE
Relax uniffi version dep for uniffi-bindgen-library-mode

### DIFF
--- a/tools/uniffi-bindgen-library-mode/Cargo.toml
+++ b/tools/uniffi-bindgen-library-mode/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uniffi = { version = "0.29.4", features = ["cli"] }
-uniffi_bindgen = { version = "0.29.4" }
+uniffi = { version = "0.29.3", features = ["cli"] }
+uniffi_bindgen = { version = "0.29.3" }
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 cargo_metadata = "0.19"
 camino = "1"


### PR DESCRIPTION
moz-central is still on 0.29.3 - this patch makes our uniffi version constraints consistent.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
