### PR TITLE
Ensure the CLI data dir exists

### DIFF
--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -28,6 +28,7 @@ pub fn init_logging_with(default_env: &str) {
 }
 
 pub fn cli_data_dir() -> String {
+    ensure_cli_data_dir_exists();
     data_path(None).to_string_lossy().to_string()
 }
 
@@ -39,10 +40,12 @@ pub fn ensure_cli_data_dir_exists() {
 }
 
 pub fn cli_data_subdir(relative_path: &str) -> String {
+    ensure_cli_data_dir_exists();
     data_path(Some(relative_path)).to_string_lossy().to_string()
 }
 
 pub fn cli_data_path(filename: &str) -> String {
+    ensure_cli_data_dir_exists();
     data_path(None).join(filename).to_string_lossy().to_string()
 }
 


### PR DESCRIPTION
This fixes the first-time run for many CLI tools.  I noticed this issue when I tried to run these tools in moz-central, where I didn't have a `.cli-data` directory yet.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
