### PR TITLE
import-app-services-to-central.sh updates

### DIFF
--- a/tools/import-app-services-to-central.sh
+++ b/tools/import-app-services-to-central.sh
@@ -23,10 +23,18 @@ fi
 export MOZ_AVOID_JJ_VCS=1
 
 # existing patches against m-c
+# Bug 1981747 - Add `./mach setup-app-services`
+moz-phab patch --apply-to=here --skip-dependencies --no-branch D260481
+# Bug 1981871 - Make `./mach rusttests` run some tests via cargo directly,
+moz-phab patch --apply-to=here --skip-dependencies --no-branch D260480
 # gradle
 moz-phab patch --apply-to=here --skip-dependencies --no-branch D245762
 # enable `--with-appservices-in-tree` config option by default
 moz-phab patch --apply-to=here --skip-dependencies --no-branch D263599
+# vet `ece`
+moz-phab patch --apply-to=here --skip-dependencies --no-branch D265023
+# various hacks needed until we fix other things
+moz-phab patch --apply-to=here --skip-dependencies --no-branch D265174
 #lint
 moz-phab patch --apply-to=here --no-branch D246875
 
@@ -85,11 +93,6 @@ sed -e 's|context_id = { git = .*$|context_id = { path = "services/app-services/
     Cargo.toml > Cargo.toml.tmp
 mv Cargo.toml.tmp Cargo.toml
 
-./mach vendor rust
-# This will create a commit with Cargo.lock changing just for these crates, and many `third_party/rust` directories removed.
-git add -f third_party/rust/.
-git commit -a -m "Re-vendor application-services from its new in-tree home"
-
 # apply the final "patch" in the stack, which we do by abusing sed.
 # This is mildly (hah!) fragile.
 
@@ -104,51 +107,127 @@ mv services/app-services/megazords/full/Cargo.toml.tmp services/app-services/meg
 printf 'megazord = []\nembedded-uniffi-bindgen = []\nnimbus-fml = []\n' >> build/workspace-hack/Cargo.toml
 # and more hacks - sue me ;) In the short term these are more fragile in theory than practice.
 
-# Add the crates to the workspace which have binary targets
+# Add app-services crates to the workspace `members`, unless their dependencies can't be vendored.
 sed -e 's|  "security/mls/mls_gk",|  "security/mls/mls_gk",\
-  "services/app-services/megazords/full",\
   "services/app-services/tools/embedded-uniffi-bindgen",\
-  "services/app-services/components/support/nimbus-fml",|' \
+  "services/app-services/components/ads-client", \
+  "services/app-services/components/autofill", \
+  "services/app-services/components/context_id", \
+  "services/app-services/components/crashtest", \
+  "services/app-services/components/example", \
+  "services/app-services/components/filter_adult", \
+  "services/app-services/components/fxa-client", \
+  "services/app-services/components/init_rust_components", \
+  "services/app-services/components/logins", \
+  "services/app-services/components/merino", \
+  "services/app-services/components/places", \
+  "services/app-services/components/push", \
+  "services/app-services/components/relay", \
+  "services/app-services/components/relevancy", \
+  "services/app-services/components/remote_settings", \
+  "services/app-services/components/search", \
+  "services/app-services/components/suggest", \
+  "services/app-services/components/support/error", \
+  "services/app-services/components/support/find-places-db", \
+  "services/app-services/components/support/firefox-versioning", \
+  "services/app-services/components/support/guid", \
+  "services/app-services/components/support/interrupt", \
+  "services/app-services/components/support/jwcrypto", \
+  "services/app-services/components/support/payload", \
+  "services/app-services/components/support/rand_rccrypto", \
+  "services/app-services/components/support/rate-limiter", \
+  "services/app-services/components/support/restmail-client", \
+  "services/app-services/components/support/rc_crypto", \
+  "services/app-services/components/support/rc_crypto/nss", \
+  "services/app-services/components/support/rc_crypto/nss/nss_build_common", \
+  "services/app-services/components/support/rc_crypto/nss/nss_sys", \
+  "services/app-services/components/support/rust-log-forwarder", \
+  "services/app-services/components/support/sql", \
+  "services/app-services/components/support/text-table", \
+  "services/app-services/components/support/tracing", \
+  "services/app-services/components/support/types", \
+  "services/app-services/components/sync_manager", \
+  "services/app-services/components/sync15", \
+  "services/app-services/components/tabs", \
+  "services/app-services/components/viaduct", \
+  "services/app-services/components/webext-storage", \
+  "services/app-services/components/webext-storage/ffi",|' \
   Cargo.toml > Cargo.toml.tmp
 mv Cargo.toml.tmp Cargo.toml
 
-# exclude all the app-services crates.
+
+# Add app-services crates whose dependencies have vendoring issues to the `exclude` section.
+#
+# Disable complaints about the backtick usage below.
+# shellcheck disable=SC2016
 sed -e 's|  "intl/l10n/rust/l10nregistry-tests",|  "intl/l10n/rust/l10nregistry-tests",\
 \
-  # app-services excluded members, also to avoid dev dependencies.\
-  "services/app-services/components/autofill",\
-  "services/app-services/components/fxa-client",\
-  "services/app-services/components/logins",\
-  "services/app-services/components/nimbus",\
-  "services/app-services/components/places",\
-  "services/app-services/components/push",\
-  "services/app-services/components/relay",\
-  "services/app-services/components/relevancy",\
-  "services/app-services/components/remote_settings",\
-  "services/app-services/components/search",\
-  "services/app-services/components/suggest",\
-  "services/app-services/components/support/error",\
-  "services/app-services/components/support/guid",\
-  "services/app-services/components/support/nimbus-fml",\
-  "services/app-services/components/support/sql",\
-  "services/app-services/components/support/tracing",\
-  "services/app-services/components/sync15",\
-  "services/app-services/components/tabs",\
-  "services/app-services/components/webext-storage",\
-  # app-services excluded members, for other reasons.\
+  # Exclude various app-services crates to avoid vendoring in their dependencies \
+  # This disadvantage of this is that building these crates will require a separate `Cargo.lock` file and `target` directory. \
+  # This is not ideal, but we are willing accept the trade-off for now. \
+  #\
+  # These depend on `hyper-tls` and we do not want to bring in the subdependencies, like `openssl` \
+  "services/app-services/components/support/viaduct-hyper", \
+  "services/app-services/components/support/viaduct-reqwest", \
+  # Excluded because it depends on `hyper` and having it as top-level member would make \
+  # `cargo vet` require it to be `safe-to-deploy`.  However, since we only use it as a dev-dependency, we want \
+  # it to be `safe-to-run`. \
+  "services/app-services/components/support/viaduct-dev", \
+  # CLIs that depend on `viaduct-hyper` \
+  "services/app-services/examples/autofill-utils/", \
+  "services/app-services/examples/cli-support/", \
+  "services/app-services/examples/example-cli/", \
+  "services/app-services/examples/fxa-client/", \
+  "services/app-services/examples/merino-cli/", \
+  "services/app-services/examples/places-autocomplete/", \
+  "services/app-services/examples/places-utils/", \
+  "services/app-services/examples/push-livetest/", \
+  "services/app-services/examples/relay-cli/", \
+  "services/app-services/examples/relevancy-cli/", \
+  "services/app-services/examples/remote-settings-cli/", \
+  "services/app-services/examples/suggest-cli/", \
+  "services/app-services/examples/sync-pass/", \
+  "services/app-services/examples/tabs-sync/", \
+  "services/app-services/examples/viaduct-cli/", \
+  "services/app-services/components/example/cli", \
+  "services/app-services/components/support/nimbus-cli", \
+  "services/app-services/components/support/nimbus-fml", \
+  # Excluded to avoid vendoring in `trybuild` and its subdependencies \
+  "services/app-services/components/support/error/tests", \
+  # Temporarily in excludes until we can land some nimbus fixes: \
+  # * Remove unicode_segmentation dependency \
+  # * Split off the `examples` code into a separate crate \
+  "services/app-services/components/nimbus", \
+  "services/app-services/megazords/full", \
+  # Temporarily in excludes until everyone is on the same `ohttp`/`bhttp` version \
+  "services/app-services/components/as-ohttp-client", \
+  # Excluded because of the `viaduct-reqwest` dependency \
   "services/app-services/megazords/ios-rust",|' \
   Cargo.toml > Cargo.toml.tmp
 mv Cargo.toml.tmp Cargo.toml
 
-# Cargo.lock
+# Update Cargo.lock
 cargo update -p gkrust-shared
+# Downgrade some versions to avoid having to vet the newer ones
+cargo update -p expect-test --precise 1.4.1
+cargo update -p fragile --precise 2.0.0
+cargo update -p mockito --precise 0.31.0
+cargo update -p predicates --precise 3.0.4
+cargo update -p predicates-core --precise 1.0.6
+cargo update -p predicates-tree --precise 1.0.9
+
+# update .gitignore to exclude directories created by excluded app-services crates
+sed -e 's|/dom/webgpu/tests/cts/vendor/target/|/dom/webgpu/tests/cts/vendor/target/\
+/services/app-services/**/target/\
+/services/app-services/**/Cargo.lock|' \
+  .gitignore > .gitignore.tmp
+mv .gitignore.tmp .gitignore
+
 git commit -a -m "Integrate app-services into the build system"
 
-# XXX - Final vendor for rc_crypto, which doesn't yet `vet` - todo
-# once it vets, we can just do a single vendor with the above one at the end.
-# BUT - now there are more vendoring issues with nimbus-fml - bug 1983669.
-./mach vendor rust --force --ignore-modified
+# Vendor everything in
+./mach vendor rust
 git add -f third_party/rust/.
-git commit -a -m "final vendor ignoring vet issues."
+git commit -a -m "final vendor."
 
 echo "Done!"


### PR DESCRIPTION
- Apply a few of my patches as part of the process
- Add app-services crates to `members` rather than exclude (with some exceptions because of dependency vendoring issues)
- Use a single commit for vendoring.  This feels slightly cleaner to me, but mainly it hacks around a weird git issues I saw.
- Don't use the latest versions for all dependencies.  By using slightly older versions, we can leverage the audits from google and avoid having to vet so many things.
- Use `./mach vendor` without `--force`.

After running this, you should be able to use `cargo` directly with the app-services crates.

Start by running `./mach setup-app-services` to setup your NSS env vars (this does the work that `libs/verify-desktop-environment.sh` is currently doing.

After that you should be able to run cargo commands for app-services crates, for example `cargo test -p logins`.

Running CLIs is a bit trickier, you need to use awkward command lines and delete the `.cli-data` directory after.  See
https://bugzilla.mozilla.org/show_bug.cgi?id=1989329 for details and a plan for improvement.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
