### PR TITLE
Bug 1989583: Remove `uniffi_segmentation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,10 +2015,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
 ]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke 0.8.0",
+ "zerofrom",
+ "zerovec 0.11.4",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae5921528335e91da1b6c695dbf1ec37df5ac13faa3f91e5640be93aa2fbefd"
+dependencies = [
+ "displaydoc",
+ "icu_collections 2.0.0",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider 2.0.0",
+ "potential_utf",
+ "tinystr 0.8.1",
+ "zerovec 0.11.4",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap 0.8.0",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
+ "zerovec 0.11.4",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fdef0c124749d06a743c69e938350816554eb63ac979166590e2b4ee4252765"
 
 [[package]]
 name = "icu_locid"
@@ -2018,10 +2075,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.7.4",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2033,9 +2090,9 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2051,15 +2108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_normalizer_data",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2075,12 +2132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_locid_transform",
  "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2099,11 +2156,28 @@ dependencies = [
  "icu_locid",
  "icu_provider_macros",
  "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
+ "yoke 0.8.0",
+ "zerofrom",
+ "zerotrie",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -2116,6 +2190,30 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e185fc13b6401c138cf40db12b863b35f5edf31b88192a545857b41aeaf7d3d3"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+ "icu_collections 2.0.0",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_provider 2.0.0",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec 0.11.4",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5360a2fbe97f617c4f8b944356dedb36d423f7da7f13c070995cf89e59f01220"
 
 [[package]]
 name = "id-arena"
@@ -2447,6 +2545,12 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "local-ip-address"
@@ -2879,6 +2983,7 @@ dependencies = [
  "error-support",
  "firefox-versioning",
  "hex",
+ "icu_segmenter",
  "jexl-eval",
  "once_cell",
  "regex",
@@ -2890,7 +2995,6 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.3",
- "unicode-segmentation",
  "uniffi",
  "url",
  "uuid",
@@ -3331,6 +3435,16 @@ name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "serde",
+ "zerovec 0.11.4",
+]
 
 [[package]]
 name = "powerfmt"
@@ -4598,7 +4712,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -5798,6 +5922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "x11-clipboard"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5869,7 +5999,19 @@ checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.8.0",
  "zerofrom",
 ]
 
@@ -5878,6 +6020,18 @@ name = "yoke-derive"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+ "synstructure",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5927,14 +6081,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
 name = "zerovec"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.10.3",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke 0.8.0",
+ "zerofrom",
+ "zerovec-derive 0.11.1",
 ]
 
 [[package]]
@@ -5942,6 +6116,17 @@ name = "zerovec-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -12,6 +12,7 @@ the details of which are reproduced below.
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: caseless](#mit-license-caseless)
+* [MIT License: core_maths](#mit-license-core_maths)
 * [MIT License: extend](#mit-license-extend)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
@@ -47,7 +48,7 @@ the details of which are reproduced below.
 * [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
 * [Zlib License: foldhash](#zlib-license-foldhash)
-* [Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-litemap-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerovec-zerovec-derive)
+* [Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locale-icu_locale_core-icu_locale_data-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-icu_segmenter-icu_segmenter_data-litemap-potential_utf-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerotrie-zerovec-zerovec-derive)
 * [OpenSSL License](#openssl-license)
 * [Optional Notice: SQLite](#optional-notice-sqlite)
 * [(Apache-2.0 OR MIT) AND BSD-3-Clause License: encoding_rs](#(apache-20-or-mit)-and-bsd-3-clause-license-encoding_rs)
@@ -521,6 +522,7 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
+[libm](https://github.com/rust-lang/libm),
 [linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
@@ -593,7 +595,6 @@ The following text applies to code linked from these dependencies:
 [typenum](https://github.com/paholg/typenum),
 [unicase](https://github.com/seanmonstar/unicase),
 [unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
-[unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation),
 [url](https://github.com/servo/rust-url),
 [utf16_iter](https://github.com/hsivonen/utf16_iter),
 [utf8_iter](https://github.com/hsivonen/utf8_iter),
@@ -1003,6 +1004,35 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+```
+-------------
+## MIT License: core_maths
+
+The following text applies to code linked from these dependencies:
+[core_maths](https://github.com/robertbastian/core_maths)
+
+```
+MIT License
+
+Copyright (c) 2024 Robert Bastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 -------------
 ## MIT License: extend
@@ -2235,10 +2265,13 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 ```
 -------------
-## Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive
+## Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive
 
 The following text applies to code linked from these dependencies:
 [icu_collections](https://github.com/unicode-org/icu4x),
+[icu_locale](https://github.com/unicode-org/icu4x),
+[icu_locale_core](https://github.com/unicode-org/icu4x),
+[icu_locale_data](https://github.com/unicode-org/icu4x),
 [icu_locid](https://github.com/unicode-org/icu4x),
 [icu_locid_transform](https://github.com/unicode-org/icu4x),
 [icu_locid_transform_data](https://github.com/unicode-org/icu4x),
@@ -2248,13 +2281,17 @@ The following text applies to code linked from these dependencies:
 [icu_properties_data](https://github.com/unicode-org/icu4x),
 [icu_provider](https://github.com/unicode-org/icu4x),
 [icu_provider_macros](https://github.com/unicode-org/icu4x),
+[icu_segmenter](https://github.com/unicode-org/icu4x),
+[icu_segmenter_data](https://github.com/unicode-org/icu4x),
 [litemap](https://github.com/unicode-org/icu4x),
+[potential_utf](https://github.com/unicode-org/icu4x),
 [tinystr](https://github.com/unicode-org/icu4x),
 [writeable](https://github.com/unicode-org/icu4x),
 [yoke-derive](https://github.com/unicode-org/icu4x),
 [yoke](https://github.com/unicode-org/icu4x),
 [zerofrom-derive](https://github.com/unicode-org/icu4x),
 [zerofrom](https://github.com/unicode-org/icu4x),
+[zerotrie](https://github.com/unicode-org/icu4x),
 [zerovec-derive](https://github.com/unicode-org/icu4x),
 [zerovec](https://github.com/unicode-org/icu4x)
 

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4"
 once_cell = "1"
 uniffi = { version = "0.29.0" }
 chrono = { version = "0.4", features = ["serde"]}
-unicode-segmentation = "1.8.0"
+icu_segmenter = "2"
 error-support = { path = "../support/error" }
 remote_settings = { path = "../remote_settings", optional = true }
 cfg-if = "1.0.0"

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -11,6 +11,7 @@ the details of which are reproduced below.
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: caseless](#mit-license-caseless)
+* [MIT License: core_maths](#mit-license-core_maths)
 * [MIT License: extend](#mit-license-extend)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
@@ -31,7 +32,7 @@ the details of which are reproduced below.
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
 * [Zlib License: foldhash](#zlib-license-foldhash)
-* [Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-litemap-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerovec-zerovec-derive)
+* [Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locale-icu_locale_core-icu_locale_data-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-icu_segmenter-icu_segmenter_data-litemap-potential_utf-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerotrie-zerovec-zerovec-derive)
 * [Optional Notice: SQLite](#optional-notice-sqlite)
 * [(MIT OR Apache-2.0) AND Unicode-3.0 License: unicode-ident](#(mit-or-apache-20)-and-unicode-30-license-unicode-ident)
 -------------
@@ -485,6 +486,7 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
+[libm](https://github.com/rust-lang/libm),
 [linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
@@ -538,7 +540,6 @@ The following text applies to code linked from these dependencies:
 [typenum](https://github.com/paholg/typenum),
 [unicase](https://github.com/seanmonstar/unicase),
 [unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
-[unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation),
 [url](https://github.com/servo/rust-url),
 [utf16_iter](https://github.com/hsivonen/utf16_iter),
 [utf8_iter](https://github.com/hsivonen/utf8_iter),
@@ -915,6 +916,35 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+```
+-------------
+## MIT License: core_maths
+
+The following text applies to code linked from these dependencies:
+[core_maths](https://github.com/robertbastian/core_maths)
+
+```
+MIT License
+
+Copyright (c) 2024 Robert Bastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 -------------
 ## MIT License: extend
@@ -1690,10 +1720,13 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 ```
 -------------
-## Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive
+## Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive
 
 The following text applies to code linked from these dependencies:
 [icu_collections](https://github.com/unicode-org/icu4x),
+[icu_locale](https://github.com/unicode-org/icu4x),
+[icu_locale_core](https://github.com/unicode-org/icu4x),
+[icu_locale_data](https://github.com/unicode-org/icu4x),
 [icu_locid](https://github.com/unicode-org/icu4x),
 [icu_locid_transform](https://github.com/unicode-org/icu4x),
 [icu_locid_transform_data](https://github.com/unicode-org/icu4x),
@@ -1703,13 +1736,17 @@ The following text applies to code linked from these dependencies:
 [icu_properties_data](https://github.com/unicode-org/icu4x),
 [icu_provider](https://github.com/unicode-org/icu4x),
 [icu_provider_macros](https://github.com/unicode-org/icu4x),
+[icu_segmenter](https://github.com/unicode-org/icu4x),
+[icu_segmenter_data](https://github.com/unicode-org/icu4x),
 [litemap](https://github.com/unicode-org/icu4x),
+[potential_utf](https://github.com/unicode-org/icu4x),
 [tinystr](https://github.com/unicode-org/icu4x),
 [writeable](https://github.com/unicode-org/icu4x),
 [yoke-derive](https://github.com/unicode-org/icu4x),
 [yoke](https://github.com/unicode-org/icu4x),
 [zerofrom-derive](https://github.com/unicode-org/icu4x),
 [zerofrom](https://github.com/unicode-org/icu4x),
+[zerotrie](https://github.com/unicode-org/icu4x),
 [zerovec-derive](https://github.com/unicode-org/icu4x),
 [zerovec](https://github.com/unicode-org/icu4x)
 

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -269,6 +269,10 @@ the details of which are reproduced below.
     <url>https://github.com/rust-lang/libc/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: libm</name>
+    <url>https://github.com/rust-lang/libm/blob/master/libm/LICENSE.txt</url>
+  </license>
+  <license>
     <name>Apache License 2.0: linux-raw-sys</name>
     <url>https://github.com/sunfishcode/linux-raw-sys/blob/main/LICENSE-APACHE</url>
   </license>
@@ -481,10 +485,6 @@ the details of which are reproduced below.
     <url>https://github.com/unicode-rs/unicode-normalization/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: unicode-segmentation</name>
-    <url>https://github.com/unicode-rs/unicode-segmentation/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: url</name>
     <url>https://github.com/servo/rust-url/blob/main/LICENSE-APACHE</url>
   </license>
@@ -563,6 +563,10 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: caseless</name>
     <url>https://github.com/SimonSapin/rust-caseless/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: core_maths</name>
+    <url>https://github.com/robertbastian/core_maths/blob/main/LICENSE</url>
   </license>
   <license>
     <name>MIT License: extend</name>
@@ -669,6 +673,18 @@ the details of which are reproduced below.
     <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
   </license>
   <license>
+    <name>Unicode-3.0 License: icu_locale</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
+    <name>Unicode-3.0 License: icu_locale_core</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
+    <name>Unicode-3.0 License: icu_locale_data</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
     <name>Unicode-3.0 License: icu_locid</name>
     <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
   </license>
@@ -705,7 +721,19 @@ the details of which are reproduced below.
     <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
   </license>
   <license>
+    <name>Unicode-3.0 License: icu_segmenter</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
+    <name>Unicode-3.0 License: icu_segmenter_data</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
     <name>Unicode-3.0 License: litemap</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
+    <name>Unicode-3.0 License: potential_utf</name>
     <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
   </license>
   <license>
@@ -730,6 +758,10 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Unicode-3.0 License: zerofrom-derive</name>
+    <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
+  </license>
+  <license>
+    <name>Unicode-3.0 License: zerotrie</name>
     <url>https://github.com/unicode-org/icu4x/blob/main/LICENSE</url>
   </license>
   <license>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -12,6 +12,7 @@ the details of which are reproduced below.
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
 * [MIT License: caseless](#mit-license-caseless)
+* [MIT License: core_maths](#mit-license-core_maths)
 * [MIT License: extend](#mit-license-extend)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
@@ -43,7 +44,7 @@ the details of which are reproduced below.
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
 * [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [Zlib License: foldhash](#zlib-license-foldhash)
-* [Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-litemap-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerovec-zerovec-derive)
+* [Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locale-icu_locale_core-icu_locale_data-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-icu_segmenter-icu_segmenter_data-litemap-potential_utf-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerotrie-zerovec-zerovec-derive)
 * [Optional Notice: SQLite](#optional-notice-sqlite)
 * [(Apache-2.0 OR MIT) AND BSD-3-Clause License: encoding_rs](#(apache-20-or-mit)-and-bsd-3-clause-license-encoding_rs)
 * [(MIT OR Apache-2.0) AND Unicode-3.0 License: unicode-ident](#(mit-or-apache-20)-and-unicode-30-license-unicode-ident)
@@ -511,6 +512,7 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
+[libm](https://github.com/rust-lang/libm),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -578,7 +580,6 @@ The following text applies to code linked from these dependencies:
 [typenum](https://github.com/paholg/typenum),
 [unicase](https://github.com/seanmonstar/unicase),
 [unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
-[unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation),
 [url](https://github.com/servo/rust-url),
 [utf16_iter](https://github.com/hsivonen/utf16_iter),
 [utf8_iter](https://github.com/hsivonen/utf8_iter),
@@ -981,6 +982,35 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+```
+-------------
+## MIT License: core_maths
+
+The following text applies to code linked from these dependencies:
+[core_maths](https://github.com/robertbastian/core_maths)
+
+```
+MIT License
+
+Copyright (c) 2024 Robert Bastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 -------------
 ## MIT License: extend
@@ -2094,10 +2124,13 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 ```
 -------------
-## Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive
+## Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive
 
 The following text applies to code linked from these dependencies:
 [icu_collections](https://github.com/unicode-org/icu4x),
+[icu_locale](https://github.com/unicode-org/icu4x),
+[icu_locale_core](https://github.com/unicode-org/icu4x),
+[icu_locale_data](https://github.com/unicode-org/icu4x),
 [icu_locid](https://github.com/unicode-org/icu4x),
 [icu_locid_transform](https://github.com/unicode-org/icu4x),
 [icu_locid_transform_data](https://github.com/unicode-org/icu4x),
@@ -2107,13 +2140,17 @@ The following text applies to code linked from these dependencies:
 [icu_properties_data](https://github.com/unicode-org/icu4x),
 [icu_provider](https://github.com/unicode-org/icu4x),
 [icu_provider_macros](https://github.com/unicode-org/icu4x),
+[icu_segmenter](https://github.com/unicode-org/icu4x),
+[icu_segmenter_data](https://github.com/unicode-org/icu4x),
 [litemap](https://github.com/unicode-org/icu4x),
+[potential_utf](https://github.com/unicode-org/icu4x),
 [tinystr](https://github.com/unicode-org/icu4x),
 [writeable](https://github.com/unicode-org/icu4x),
 [yoke-derive](https://github.com/unicode-org/icu4x),
 [yoke](https://github.com/unicode-org/icu4x),
 [zerofrom-derive](https://github.com/unicode-org/icu4x),
 [zerofrom](https://github.com/unicode-org/icu4x),
+[zerotrie](https://github.com/unicode-org/icu4x),
 [zerovec-derive](https://github.com/unicode-org/icu4x),
 [zerovec](https://github.com/unicode-org/icu4x)
 

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -11,6 +11,7 @@ the details of which are reproduced below.
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata, winnow](#mit-license-cargo_metadata-winnow)
+* [MIT License: core_maths](#mit-license-core_maths)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
 * [MIT License: h2](#mit-license-h2)
@@ -36,7 +37,7 @@ the details of which are reproduced below.
 * [MIT License: weedle2](#mit-license-weedle2)
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
 * [Zlib License: foldhash](#zlib-license-foldhash)
-* [Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-litemap-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerovec-zerovec-derive)
+* [Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive](#unicode-30-license-icu_collections-icu_locale-icu_locale_core-icu_locale_data-icu_locid-icu_locid_transform-icu_locid_transform_data-icu_normalizer-icu_normalizer_data-icu_properties-icu_properties_data-icu_provider-icu_provider_macros-icu_segmenter-icu_segmenter_data-litemap-potential_utf-tinystr-writeable-yoke-yoke-derive-zerofrom-zerofrom-derive-zerotrie-zerovec-zerovec-derive)
 * [Optional Notice: SQLite](#optional-notice-sqlite)
 * [(Apache-2.0 OR MIT) AND BSD-3-Clause License: encoding_rs](#(apache-20-or-mit)-and-bsd-3-clause-license-encoding_rs)
 * [(MIT OR Apache-2.0) AND Unicode-3.0 License: unicode-ident](#(mit-or-apache-20)-and-unicode-30-license-unicode-ident)
@@ -496,6 +497,7 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
+[libm](https://github.com/rust-lang/libm),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -546,7 +548,6 @@ The following text applies to code linked from these dependencies:
 [thread_local](https://github.com/Amanieu/thread_local-rs),
 [toml](https://github.com/alexcrichton/toml-rs),
 [typenum](https://github.com/paholg/typenum),
-[unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation),
 [url](https://github.com/servo/rust-url),
 [utf16_iter](https://github.com/hsivonen/utf16_iter),
 [utf8_iter](https://github.com/hsivonen/utf8_iter),
@@ -917,6 +918,35 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
+```
+-------------
+## MIT License: core_maths
+
+The following text applies to code linked from these dependencies:
+[core_maths](https://github.com/robertbastian/core_maths)
+
+```
+MIT License
+
+Copyright (c) 2024 Robert Bastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 -------------
 ## MIT License: generic-array
@@ -1678,10 +1708,13 @@ the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 ```
 -------------
-## Unicode-3.0 License: icu_collections, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, litemap, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerovec, zerovec-derive
+## Unicode-3.0 License: icu_collections, icu_locale, icu_locale_core, icu_locale_data, icu_locid, icu_locid_transform, icu_locid_transform_data, icu_normalizer, icu_normalizer_data, icu_properties, icu_properties_data, icu_provider, icu_provider_macros, icu_segmenter, icu_segmenter_data, litemap, potential_utf, tinystr, writeable, yoke, yoke-derive, zerofrom, zerofrom-derive, zerotrie, zerovec, zerovec-derive
 
 The following text applies to code linked from these dependencies:
 [icu_collections](https://github.com/unicode-org/icu4x),
+[icu_locale](https://github.com/unicode-org/icu4x),
+[icu_locale_core](https://github.com/unicode-org/icu4x),
+[icu_locale_data](https://github.com/unicode-org/icu4x),
 [icu_locid](https://github.com/unicode-org/icu4x),
 [icu_locid_transform](https://github.com/unicode-org/icu4x),
 [icu_locid_transform_data](https://github.com/unicode-org/icu4x),
@@ -1691,13 +1724,17 @@ The following text applies to code linked from these dependencies:
 [icu_properties_data](https://github.com/unicode-org/icu4x),
 [icu_provider](https://github.com/unicode-org/icu4x),
 [icu_provider_macros](https://github.com/unicode-org/icu4x),
+[icu_segmenter](https://github.com/unicode-org/icu4x),
+[icu_segmenter_data](https://github.com/unicode-org/icu4x),
 [litemap](https://github.com/unicode-org/icu4x),
+[potential_utf](https://github.com/unicode-org/icu4x),
 [tinystr](https://github.com/unicode-org/icu4x),
 [writeable](https://github.com/unicode-org/icu4x),
 [yoke-derive](https://github.com/unicode-org/icu4x),
 [yoke](https://github.com/unicode-org/icu4x),
 [zerofrom-derive](https://github.com/unicode-org/icu4x),
 [zerofrom](https://github.com/unicode-org/icu4x),
+[zerotrie](https://github.com/unicode-org/icu4x),
 [zerovec-derive](https://github.com/unicode-org/icu4x),
 [zerovec](https://github.com/unicode-org/icu4x)
 

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -356,6 +356,15 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/taskcluster/rust-hawk/main/LICENSE",
         },
     },
+    "libm": {
+        "repository": {
+            "check": "https://github.com/rust-lang/libm",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://github.com/rust-lang/libm/blob/master/libm/LICENSE.txt",
+        },
+    },
     "oneshot-uniffi": {
         "repository": {
             "check": "https://github.com/faern/oneshot",


### PR DESCRIPTION
Use `icu_segmenter` instead, which will vendor more easily into moz-central.

Added test for the weird grapheme case.  I think something like this is what these crates are intended to handle.  Before, I could have just used `str::char_indicies` and the tests would pass.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
