### PR TITLE
Upgrade ohttp to released version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,8 +321,9 @@ dependencies = [
 
 [[package]]
 name = "bhttp"
-version = "0.6.1"
-source = "git+https://github.com/martinthomson/ohttp.git?rev=c6131ace4e4e82a4269afac3cb0524541d2cd315#c6131ace4e4e82a4269afac3cb0524541d2cd315"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23039ff1530c05a237757cb6b830f7941b8a12aacc58ae48e888d2c8d69a133"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -3022,8 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "ohttp"
-version = "0.6.1"
-source = "git+https://github.com/martinthomson/ohttp.git?rev=c6131ace4e4e82a4269afac3cb0524541d2cd315#c6131ace4e4e82a4269afac3cb0524541d2cd315"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7596cbb2bb1326a1a9459d3b82e479dbb4606bb1d2854c6978284c446000b726"
 dependencies = [
  "bindgen",
  "byteorder",

--- a/components/as-ohttp-client/Cargo.toml
+++ b/components/as-ohttp-client/Cargo.toml
@@ -14,16 +14,8 @@ uniffi = { version = "0.29.0" }
 thiserror = "2"
 parking_lot = "0.12"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
-
-[dependencies.bhttp]
-git = "https://github.com/martinthomson/ohttp.git"
-rev = "c6131ace4e4e82a4269afac3cb0524541d2cd315"
-
-[dependencies.ohttp]
-default-features = false
-git = "https://github.com/martinthomson/ohttp.git"
-rev = "c6131ace4e4e82a4269afac3cb0524541d2cd315"
-features = ["client", "server", "app-svc", "external-sqlite"]
+bhttp = "0.7"
+ohttp = { version = "0.7", default-features = false, features = ["client", "server", "app-svc", "external-sqlite"]}
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features=["build"]}


### PR DESCRIPTION
There's been some changes since the git rev we were using, but most of them seem to behind feature flags.

https://github.com/martinthomson/ohttp/compare/c6131ace4e4e82a4269afac3cb0524541d2cd315...v0.7.0

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
