### PR TITLE
Swift Generated Code: Add `@unchecked Sendable` conformance to classes that conform to `FeatureManifestInterface`

### DIFF
--- a/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
@@ -13,7 +13,7 @@
 /// An object for safely accessing feature configuration from Nimbus.
 ///
 /// This is generated.
-public class {{ nimbus_object }} : FeatureManifestInterface {
+public class {{ nimbus_object }} : FeatureManifestInterface, @unchecked Sendable {
     public typealias Features = {{ features_object }}
 
     ///


### PR DESCRIPTION
Hello! This is my first PR to your repo, I've been working on this with @issammani. The iOS team needs to update `/Generated` code in Firefox for iOS to solve some strict concurrency warnings inside our generated code. These warnings will become errors in Swift 6.0.

Here is the ticket on our end: [FXIOS-13577](https://mozilla-hub.atlassian.net/browse/FXIOS-13577) 

This ticket contains detailed information about the concurrency issues with screenshots of the errors we are getting.

## Implementation Details
This PR adds `@unchecked Sendable` to Swift classes that conform to `FeatureManifestInterface`, which suppresses strict concurrency warnings related to non-`Sendable` types containing mutable state.

Using `@unchecked Sendable` simply maintains existing behaviour and does not change any behaviour.

While we can suppress these errors for now, ideally these `FeatureManifestInterface`-conforming classes should be updated in the future to be compliant with Swift Concurrency's rules for concurrency-safe code.

Followup ticket: [FXIOS-13579](https://mozilla-hub.atlassian.net/browse/FXIOS-13579).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
