### PR TITLE
Add Ads-Client to megazord

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,5 +1,12 @@
 groupId: org.mozilla.appservices
 projects:
+  ads-client:
+    path: components/ads-client/android
+    artifactId: ads-client
+    publications:
+    - name: ads-client
+      type: aar
+    description: for fetching ads via UAPI
   autofill:
     path: components/autofill/android
     artifactId: autofill
@@ -165,3 +172,4 @@ projects:
     - name: relay
       type: aar
     description: Client for Firefox Relay.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Swift
 - Added `@unchecked Sendable` to classes that conform to `FeatureManifestInterface`. ([#6963](https://github.com/mozilla/application-services/pull/6963)
+### Ads Client
+- Added the Ads Client component to the Megazord.
+- Updated the ApiError enum to AdsClientApiError to avoid naming collision.
 
 # v144.0 (_2025-09-15_)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
 name = "megazord"
 version = "0.1.0"
 dependencies = [
+ "ads-client",
  "autofill",
  "crashtest",
  "error-support",
@@ -2584,6 +2585,7 @@ dependencies = [
 name = "megazord_focus"
 version = "0.1.0"
 dependencies = [
+ "ads-client",
  "error-support",
  "nimbus-sdk",
  "remote_settings",
@@ -2596,6 +2598,7 @@ dependencies = [
 name = "megazord_ios"
 version = "0.1.0"
 dependencies = [
+ "ads-client",
  "as-ohttp-client",
  "autofill",
  "context_id",

--- a/components/ads-client/android/build.gradle
+++ b/components/ads-client/android/build.gradle
@@ -1,0 +1,10 @@
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
+
+android {
+    namespace 'org.mozilla.appservices.ads_client'
+}
+
+ext.configureUniFFIBindgen("ads_client")
+ext.dependsOnTheMegazord()
+ext.configurePublish()

--- a/components/ads-client/android/proguard-rules.pro
+++ b/components/ads-client/android/proguard-rules.pro
@@ -1,0 +1,22 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+

--- a/components/ads-client/android/src/main/AndroidManifest.xml
+++ b/components/ads-client/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>
+

--- a/components/ads-client/src/error.rs
+++ b/components/ads-client/src/error.rs
@@ -6,10 +6,10 @@
 use error_support::{error, ErrorHandling, GetErrorHandling};
 use viaduct::Response;
 
-pub type ApiResult<T> = std::result::Result<T, ApiError>;
+pub type AdsClientApiResult<T> = std::result::Result<T, AdsClientApiError>;
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
-pub enum ApiError {
+pub enum AdsClientApiError {
     #[error("Something unexpected occurred.")]
     Other { reason: String },
 }
@@ -30,10 +30,10 @@ pub enum ComponentError {
 }
 
 impl GetErrorHandling for ComponentError {
-    type ExternalError = ApiError;
+    type ExternalError = AdsClientApiError;
 
     fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError> {
-        ErrorHandling::convert(ApiError::Other {
+        ErrorHandling::convert(AdsClientApiError::Other {
             reason: self.to_string(),
         })
     }

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use error::ApiResult;
+use error::AdsClientApiResult;
 use error::{
     BuildPlacementsError, BuildRequestError, ComponentError, RecordClickError,
     RecordImpressionError, ReportAdError, RequestAdsError,
@@ -24,7 +24,7 @@ mod models;
 #[cfg(test)]
 mod test_utils;
 
-uniffi::setup_scaffolding!("adsclient");
+uniffi::setup_scaffolding!("ads_client");
 
 /// Top-level API for the mac component
 #[derive(uniffi::Object)]
@@ -51,7 +51,7 @@ impl MozAdsClient {
     pub fn request_ads(
         &self,
         moz_ad_configs: Vec<MozAdsPlacementConfig>,
-    ) -> ApiResult<HashMap<String, MozAdsPlacement>> {
+    ) -> AdsClientApiResult<HashMap<String, MozAdsPlacement>> {
         let inner = self.inner.lock();
         let placements = inner
             .request_ads(&moz_ad_configs)
@@ -60,7 +60,7 @@ impl MozAdsClient {
     }
 
     #[handle_error(ComponentError)]
-    pub fn record_impression(&self, placement: MozAdsPlacement) -> ApiResult<()> {
+    pub fn record_impression(&self, placement: MozAdsPlacement) -> AdsClientApiResult<()> {
         let inner = self.inner.lock();
         inner
             .record_impression(&placement)
@@ -69,7 +69,7 @@ impl MozAdsClient {
     }
 
     #[handle_error(ComponentError)]
-    pub fn record_click(&self, placement: MozAdsPlacement) -> ApiResult<()> {
+    pub fn record_click(&self, placement: MozAdsPlacement) -> AdsClientApiResult<()> {
         let inner = self.inner.lock();
         inner
             .record_click(&placement)
@@ -78,7 +78,7 @@ impl MozAdsClient {
     }
 
     #[handle_error(ComponentError)]
-    pub fn report_ad(&self, placement: MozAdsPlacement) -> ApiResult<()> {
+    pub fn report_ad(&self, placement: MozAdsPlacement) -> AdsClientApiResult<()> {
         let inner = self.inner.lock();
         inner
             .report_ad(&placement)
@@ -86,13 +86,13 @@ impl MozAdsClient {
             .emit_telemetry_if_error()
     }
 
-    pub fn cycle_context_id(&self) -> ApiResult<String> {
+    pub fn cycle_context_id(&self) -> AdsClientApiResult<String> {
         let mut inner = self.inner.lock();
         let previous_context_id = inner.cycle_context_id();
         Ok(previous_context_id)
     }
 
-    pub fn clear_cache(&self) -> ApiResult<()> {
+    pub fn clear_cache(&self) -> AdsClientApiResult<()> {
         let mut inner = self.inner.lock();
         inner.clear_cache();
         Ok(())

--- a/components/ads-client/uniffi.toml
+++ b/components/ads-client/uniffi.toml
@@ -1,6 +1,6 @@
 [bindings.kotlin]
-package_name = "mozilla.appservices.adsclient"
+package_name = "mozilla.appservices.ads_client"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"
-ffi_module_filename = "adsclientFFI"
+ffi_module_filename = "ads_clientFFI"

--- a/megazords/fenix-dylib/megazord_stub.c
+++ b/megazords/fenix-dylib/megazord_stub.c
@@ -10,6 +10,7 @@
 // but here we are.
 // To get the symbols from our static lib we need to refer to a symbol from each crate within it.
 // This is an arbitrary choice - any symbol will do, but we chose these because every uniffi crate has it.
+extern int MOZ_EXPORT ffi_ads_client_uniffi_contract_version();
 extern int MOZ_EXPORT ffi_autofill_uniffi_contract_version();
 extern int MOZ_EXPORT ffi_crashtest_uniffi_contract_version();
 extern int MOZ_EXPORT ffi_fxa_client_uniffi_contract_version();
@@ -37,6 +38,7 @@ extern int MOZ_EXPORT ffi_tabs_uniffi_contract_version();
 extern int MOZ_EXPORT uniffi_search_checksum_constructor_searchengineselector_new();
 
 void _local_megazord_dummy_symbol() {
+    ffi_ads_client_uniffi_contract_version();
     ffi_autofill_uniffi_contract_version();
     ffi_crashtest_uniffi_contract_version();
     ffi_fxa_client_uniffi_contract_version();

--- a/megazords/full/Cargo.toml
+++ b/megazords/full/Cargo.toml
@@ -32,3 +32,4 @@ lazy_static = "1.4"
 init_rust_components = { path = "../../components/init_rust_components" }
 merino = { path = "../../components/merino" }
 relay = { path = "../../components/relay" }
+ads-client = { path = "../../components/ads-client" }

--- a/megazords/full/src/lib.rs
+++ b/megazords/full/src/lib.rs
@@ -9,6 +9,7 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 
 // NOTE if you add or remove crates below here, please make a corresponding change in ../fenix-dylib/megazord_stub.c
+pub use ads_client;
 pub use autofill;
 pub use crashtest;
 pub use error_support;

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -19,10 +19,10 @@ logins = { path = "../../components/logins" }
 autofill = { path = "../../components/autofill" }
 push = { path = "../../components/push" }
 tabs = { path = "../../components/tabs" }
-places = {path = "../../components/places" }
+places = { path = "../../components/places" }
 remote_settings = { path = "../../components/remote_settings" }
 suggest = { path = "../../components/suggest" }
-sync15 = {path = "../../components/sync15"}
+sync15 = { path = "../../components/sync15" }
 error-support = { path = "../../components/support/error" }
 tracing-support = { path = "../../components/support/tracing" }
 sync_manager = { path = "../../components/sync_manager" }
@@ -32,3 +32,4 @@ init_rust_components = { path = "../../components/init_rust_components" }
 merino = { path = "../../components/merino" }
 context_id = { path = "../../components/context_id" }
 relay = { path = "../../components/relay" }
+ads-client = { path = "../../components/ads-client" }

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -6,6 +6,7 @@
 // It needs to import all of the individual headers.
 
 #import "RustViaductFFI.h"
+#import "ads_clientFFI.h"
 #import "autofillFFI.h"
 #import "crashtestFFI.h"
 #import "fxa_clientFFI.h"

--- a/megazords/ios-rust/focus/Cargo.toml
+++ b/megazords/ios-rust/focus/Cargo.toml
@@ -15,3 +15,4 @@ viaduct-reqwest = { path = "../../../components/support/viaduct-reqwest" }
 nimbus-sdk = { path = "../../../components/nimbus" }
 error-support = { path = "../../../components/support/error" }
 remote_settings = { path = "../../../components/remote_settings" }
+ads-client = { path = "../../../components/ads-client" }

--- a/megazords/ios-rust/focus/MozillaRustComponents.h
+++ b/megazords/ios-rust/focus/MozillaRustComponents.h
@@ -6,6 +6,7 @@
 // It needs to import all of the individual headers.
 
 #import "RustViaductFFI.h"
+#import "ads_clientFFI.h"
 #import "nimbusFFI.h"
 #import "errorFFI.h"
 #import "remote_settingsFFI.h"

--- a/megazords/ios-rust/focus/src/lib.rs
+++ b/megazords/ios-rust/focus/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
+pub use ads_client;
 pub use error_support;
 pub use nimbus;
 pub use remote_settings;

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
+pub use ads_client;
 pub use as_ohttp_client;
 pub use autofill;
 pub use context_id;


### PR DESCRIPTION
This PR ads the Ads Client to the megazord so it can be accessed by iOS and Android applications.

It also renames the `ApiError` enum to `AdsClientApiError` to avoid naming collisions with the Context Id component.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
