### PR TITLE
Backport bug 1989840 - Don't call unwrap() in webext-storage custom types

### DIFF
--- a/components/webext-storage/src/lib.rs
+++ b/components/webext-storage/src/lib.rs
@@ -35,7 +35,7 @@ use serde_json::Value as JsonValue;
 
 uniffi::custom_type!(JsonValue, String, {
     remote,
-    try_lift: |val| Ok(serde_json::from_str(val.as_str()).unwrap()),
+    try_lift: |val| Ok(serde_json::from_str(val.as_str())?),
     lower: |obj| obj.to_string(),
 });
 


### PR DESCRIPTION
Backporting the fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1989840 to the desktop-140 branch.

I think we should uplift to the ESR branch since this is a hard crash and the extension devs are saying that users are reporting issues to them.

Also, please double-check my git rev logic:  The [desktop ESR branch](https://github.com/mozilla-firefox/firefox/blob/esr140/Cargo.toml#L268) has `9b46be5beedb6a1d859014a71bac58e2d722f954` as the app-services rev so I used that to create the desktop-140 branch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
