### PR TITLE
Include classes that extend from JNA Structure in proguard consumer rules

### DIFF
--- a/proguard-rules-consumer-jna.pro
+++ b/proguard-rules-consumer-jna.pro
@@ -4,4 +4,12 @@
 # See https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
 -dontwarn java.awt.*
 -keep class com.sun.jna.* { *; }
+-keep class * extends com.sun.jna.* { *; }
 -keepclassmembers class * extends com.sun.jna.* { public *; }
+
+####################################################################################################
+# Add explicit keep rules for Nimbus RustBuffer and related structs to avoid
+# overly-aggressive optimization when R8 fullMode is enabled, leading to crashes.
+####################################################################################################
+-keepattributes RuntimeVisibleAnnotations,RuntimeInvisibleAnnotations,RuntimeVisibleTypeAnnotations,RuntimeInvisibleTypeAnnotations,AnnotationDefault,InnerClasses,EnclosingMethod,Signature
+-keep class org.mozilla.experiments.nimbus.internal.** { *; }


### PR DESCRIPTION
Specifically, I found that `com.sun.jna.Structure` ones via `RustBuffer` that seem to be removed from Android when using [R8 fullMode][0]

Fixes https://github.com/mozilla-mobile/reference-browser/issues/3885 and includes upstreaming the Nimbus RustBuffer rules as well.

[0]: https://developer.android.com/topic/performance/app-optimization/enable-app-optimization#full-mode
---

Does not contain breaking changes, but I can add a changelog entry if that's the right approach for this type of patch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
