### PR TITLE
Bug 1991777 - Make sure rust-log-forwarder forwards all logs

### DIFF
--- a/components/support/rust-log-forwarder/src/lib.rs
+++ b/components/support/rust-log-forwarder/src/lib.rs
@@ -8,38 +8,6 @@ static MAX_LEVEL: OnceLock<Level> = OnceLock::new();
 static FOREIGN_LOGGER: OnceLock<Box<dyn AppServicesLogger>> = OnceLock::new();
 static GLOBAL_SUBSCRIBER: Once = Once::new();
 
-// The "targets" (in practice, crate names) which are hooked up to the `tracing` crate for logging.
-// We should improve this, or better still, just kill this crate entirely and move to using
-// tracing-support directly, like we (plan to) do on Desktop.
-//
-// Note also that it is a natural consequence of using `tracing` that each target must be explicitly listened for
-// *somewhere*, otherwise logs from that target will not be seen. For now, that list of targets is here, but
-// when we move to tracing-support it's likely this list will be pushed down into the clients (so that each
-// target can optionally be handled differently from the others).
-static TRACING_TARGETS: &[&str] = &[
-    "autofill",
-    "error_support",
-    "fxa-client",
-    "init_rust_components",
-    "interrupt_support",
-    "logins",
-    "merino",
-    "nimbus",
-    "places",
-    "push",
-    "rate-limiter",
-    "rc_crypto",
-    "relevancy",
-    "remote_settings",
-    "search",
-    "sql_support",
-    "suggest",
-    "sync_manager",
-    "sync15",
-    "tabs",
-    "viaduct",
-];
-
 #[derive(uniffi::Record, Debug, PartialEq, Eq)]
 pub struct Record {
     pub level: Level,
@@ -90,7 +58,8 @@ pub trait AppServicesLogger: Sync + Send {
 
 /// Set the logger to forward to.
 ///
-/// Pass in None to disable logging.
+/// Once a logger is passed in, it cannot be changed.
+/// However, you can pass in `None` to disable logging.
 #[uniffi::export]
 pub fn set_logger(logger: Option<Box<dyn AppServicesLogger>>) {
     GLOBAL_SUBSCRIBER.call_once(|| {
@@ -102,13 +71,13 @@ pub fn set_logger(logger: Option<Box<dyn AppServicesLogger>>) {
 
     let level = MAX_LEVEL.get_or_init(|| Level::Debug);
     let sink = Arc::new(ForwarderEventSink {});
-    // Set up a tracing subscriber for crates which use tracing and forward to the foreign log forwarder.
-    for target in TRACING_TARGETS {
-        tracing_support::register_event_sink(target, (*level).into(), sink.clone())
-    }
-    // if called before we just ignore the error for now, and also ignored if they supply None.
     if let Some(logger) = logger {
+        // Set up a tracing subscriber for crates which use tracing and forward to the foreign log forwarder.
+        tracing_support::register_min_level_event_sink((*level).into(), sink.clone());
+        // Set the `FOREIGN_LOGGER` global.  If this was called before we just ignore the error.
         FOREIGN_LOGGER.set(logger).ok();
+    } else {
+        tracing_support::unregister_min_level_event_sink();
     }
 }
 

--- a/components/support/tracing/src/filters.rs
+++ b/components/support/tracing/src/filters.rs
@@ -14,8 +14,6 @@ use tracing_subscriber::{
 /// See `build_targets_from_env` for the exact behavior.  If not so configured, the filter will
 /// default to the `Level::Error` level.
 pub fn init_from_env() {
-    // This is intended to be equivalent to `env_logger::try_init().ok();`
-    // `debug!()` output is seen. We could maybe add logging for `#[tracing::instrument]`?
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(build_targets_from_env(LevelFilter::ERROR, None))
@@ -25,8 +23,6 @@ pub fn init_from_env() {
 /// Like `init_for_tests` but uses the specified `level` if logging is not configured in the environment.
 pub fn init_from_env_with_level(level: crate::Level) {
     let level_filter = LevelFilter::from_level(level.into());
-    // This is intended to be equivalent to `env_logger::try_init().ok();`
-    // `debug!()` output is seen. We could maybe add logging for `#[tracing::instrument]`?
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(build_targets_from_env(level_filter, None))
@@ -35,8 +31,6 @@ pub fn init_from_env_with_level(level: crate::Level) {
 
 /// Like `init_for_tests` but uses a default string if logging is not configured in the environment
 pub fn init_from_env_with_default(default_env: &str) {
-    // This is intended to be equivalent to `env_logger::try_init().ok();`
-    // `debug!()` output is seen. We could maybe add logging for `#[tracing::instrument]`?
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(build_targets_from_env(LevelFilter::OFF, Some(default_env)))


### PR DESCRIPTION
I was seeing an issue with the target list because we spelled things out as `fxa-client` when it should have been `fxa_client`.  Let's just install a min_level_event_sink to capture all logs. `simple_event_layer` will filter out tracing logs from non-app-services Rust crates that don't use tracing-support.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
