### PR TITLE
Refactor: remove fixed_size option from ads-client config

### DIFF
--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -250,15 +250,8 @@ pub struct IABContent {
 }
 
 #[derive(Debug, Clone, PartialEq, uniffi::Record)]
-pub struct MozAdsSize {
-    pub width: u16,
-    pub height: u16,
-}
-
-#[derive(Debug, Clone, PartialEq, uniffi::Record)]
 pub struct MozAdsPlacementConfig {
     pub placement_id: String,
-    pub fixed_size: Option<MozAdsSize>,
     pub iab_content: Option<IABContent>,
 }
 
@@ -302,7 +295,6 @@ mod tests {
                     taxonomy: IABContentTaxonomy::IAB2_1,
                     category_ids: vec!["entertainment".to_string()],
                 }),
-                fixed_size: None,
             },
             MozAdsPlacementConfig {
                 placement_id: "example_placement_2".to_string(),
@@ -310,17 +302,12 @@ mod tests {
                     taxonomy: IABContentTaxonomy::IAB3_0,
                     category_ids: vec![],
                 }),
-                fixed_size: None,
             },
             MozAdsPlacementConfig {
                 placement_id: "example_placement_3".to_string(),
                 iab_content: Some(IABContent {
                     taxonomy: IABContentTaxonomy::IAB2_1,
                     category_ids: vec![],
-                }),
-                fixed_size: Some(MozAdsSize {
-                    width: 200,
-                    height: 200,
                 }),
             },
         ];
@@ -380,7 +367,6 @@ mod tests {
                     taxonomy: IABContentTaxonomy::IAB2_1,
                     category_ids: vec!["entertainment".to_string()],
                 }),
-                fixed_size: None,
             },
             MozAdsPlacementConfig {
                 placement_id: "example_placement_2".to_string(),
@@ -388,17 +374,12 @@ mod tests {
                     taxonomy: IABContentTaxonomy::IAB3_0,
                     category_ids: vec![],
                 }),
-                fixed_size: None,
             },
             MozAdsPlacementConfig {
                 placement_id: "example_placement_2".to_string(),
                 iab_content: Some(IABContent {
                     taxonomy: IABContentTaxonomy::IAB2_1,
                     category_ids: vec![],
-                }),
-                fixed_size: Some(MozAdsSize {
-                    width: 200,
-                    height: 200,
                 }),
             },
         ];
@@ -464,10 +445,6 @@ mod tests {
                 taxonomy: IABContentTaxonomy::IAB2_1,
                 category_ids: vec![],
             }),
-            fixed_size: Some(MozAdsSize {
-                width: 200,
-                height: 200,
-            }),
         });
 
         let mut api_resp = get_example_happy_ad_response();
@@ -501,10 +478,6 @@ mod tests {
                 taxonomy: IABContentTaxonomy::IAB2_1,
                 category_ids: vec![],
             }),
-            fixed_size: Some(MozAdsSize {
-                width: 200,
-                height: 200,
-            }),
         });
 
         let placements = inner_component
@@ -532,10 +505,6 @@ mod tests {
             iab_content: Some(IABContent {
                 taxonomy: IABContentTaxonomy::IAB2_1,
                 category_ids: vec![],
-            }),
-            fixed_size: Some(MozAdsSize {
-                width: 200,
-                height: 200,
             }),
         });
 

--- a/components/ads-client/src/test_utils.rs
+++ b/components/ads-client/src/test_utils.rs
@@ -21,7 +21,6 @@ pub fn get_example_happy_placement_config() -> Vec<MozAdsPlacementConfig> {
                 taxonomy: IABContentTaxonomy::IAB2_1,
                 category_ids: vec!["entertainment".to_string()],
             }),
-            fixed_size: None,
         },
         MozAdsPlacementConfig {
             placement_id: "example_placement_2".to_string(),
@@ -29,7 +28,6 @@ pub fn get_example_happy_placement_config() -> Vec<MozAdsPlacementConfig> {
                 taxonomy: IABContentTaxonomy::IAB3_0,
                 category_ids: vec![],
             }),
-            fixed_size: None,
         },
     ]
 }
@@ -86,7 +84,6 @@ pub fn get_example_happy_placements() -> HashMap<String, MozAdsPlacement> {
                     taxonomy: IABContentTaxonomy::IAB2_1,
                     category_ids: vec!["entertainment".to_string()],
                 }),
-                fixed_size: None,
             },
             content: MozAd {
                 url: Some("https://ads.fakeexample.org/example_ad_1".to_string()),
@@ -113,7 +110,6 @@ pub fn get_example_happy_placements() -> HashMap<String, MozAdsPlacement> {
                     taxonomy: IABContentTaxonomy::IAB3_0,
                     category_ids: vec![],
                 }),
-                fixed_size: None,
             },
             content: MozAd {
                 url: Some("https://ads.fakeexample.org/example_ad_2".to_string()),


### PR DESCRIPTION
Small refactor to remove an unnecessary field in the placement config.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
