### PR TITLE
Bug 1991442 - Glean error ping

### DIFF
--- a/components/init_rust_components/android/build.gradle
+++ b/components/init_rust_components/android/build.gradle
@@ -9,6 +9,10 @@ android {
     }
 }
 
+dependencies {
+    implementation project(':errorsupport')
+}
+
 ext.configureUniFFIBindgen("init_rust_components")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/init_rust_components/android/src/main/java/mozilla/appservices/RustComponentsInitializer.kt
+++ b/components/init_rust_components/android/src/main/java/mozilla/appservices/RustComponentsInitializer.kt
@@ -4,6 +4,7 @@
 
 package mozilla.appservices
 
+import mozilla.appservices.errorsupport.RustComponentsErrorTelemetry
 import mozilla.appservices.init_rust_components.initialize
 import org.mozilla.appservices.init_rust_components.BuildConfig
 
@@ -12,6 +13,8 @@ object RustComponentsInitializer {
     fun init() {
         // Rust components must be initialized at the very beginning, before any other Rust call, ...
         initialize()
+
+        RustComponentsErrorTelemetry.register()
 
         // This code was originally in the `Megazord.init` that was moved here to have the initialize
         // done in this particular sequence without needing to have the embedder have to do it within

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -1,5 +1,29 @@
+plugins {
+    alias libs.plugins.python.envs.plugin
+    alias libs.plugins.kotlinx.serialization
+}
+
+apply plugin: 'kotlinx-serialization'
+
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
 apply from: "$appServicesRootDir/publish.gradle"
+
+// Needs to happen before `dependencies` in order for the variables
+// exposed by the plugin to be available for this project.
+ext {
+    gleanNamespace = "mozilla.telemetry.glean"
+    gleanYamlFiles = ["${project.projectDir}/../metrics.yaml", "${project.projectDir}/../pings.yaml"]
+    if (gradle.hasProperty("mozconfig")) {
+        gleanPythonEnvDir = gradle.mozconfig.substs.GRADLE_GLEAN_PARSER_VENV
+    }
+}
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
+
+dependencies {
+    implementation libs.mozilla.glean
+    implementation libs.kotlinx.serialization
+    implementation project(':tracing')
+}
 
 android {
     namespace 'org.mozilla.appservices.errorsupport'

--- a/components/support/error/android/src/main/java/mozilla/appservices/errorsupport/RustComponentsErrorTelemetry.kt
+++ b/components/support/error/android/src/main/java/mozilla/appservices/errorsupport/RustComponentsErrorTelemetry.kt
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.errorsupport
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import mozilla.appservices.tracing.EventSink
+import mozilla.appservices.tracing.TracingEvent
+import mozilla.appservices.tracing.TracingLevel
+import mozilla.appservices.tracing.registerEventSink
+import mozilla.telemetry.glean.Glean
+import org.mozilla.appservices.errorsupport.GleanMetrics.Pings
+import org.mozilla.appservices.errorsupport.GleanMetrics.RustComponentErrors
+
+/**
+ * RustErrorTelemetry forwarder
+ *
+ * This receives error pings from Rust and sends them to Glean.
+ * It's only necessary because we currently can't call Glean directly from Rust
+ */
+public object RustComponentsErrorTelemetry {
+    /**
+     * Register the RustComponentsErrorTelemetry and start forwarding telemetry to glean
+     */
+    fun register() {
+        Glean.registerPings(Pings)
+        registerEventSink("app-services-error-reporter", TracingLevel.DEBUG, ErrorEventSink())
+    }
+}
+
+@Serializable
+internal data class TracingErrorFields(
+    @SerialName("type_name")
+    val typeName: String,
+    val breadcrumbs: String,
+)
+
+@Serializable
+internal data class TracingBreadcrumbFields(
+    val module: String,
+    val line: UInt,
+    val column: UInt,
+)
+
+private class ErrorEventSink : EventSink {
+    val json = Json { ignoreUnknownKeys = true }
+
+    override fun onEvent(event: TracingEvent) {
+        if (event.target == "app-services-error-reporter::error") {
+            val fields = json.decodeFromString<TracingErrorFields>(event.fields)
+            RustComponentErrors.errorType.set(fields.typeName)
+            RustComponentErrors.details.set(event.message)
+            RustComponentErrors.breadcrumbs.set(fields.breadcrumbs.split("\n"))
+            Pings.rustComponentErrors.submit()
+
+            ApplicationErrorReporterRegistry.errorReporter?.reportError(fields.typeName, event.message)
+        } else if (event.target == "app-services-error-reporter::breadcrumb") {
+            val fields = json.decodeFromString<TracingBreadcrumbFields>(event.fields)
+
+            ApplicationErrorReporterRegistry.errorReporter?.reportBreadcrumb(
+                event.message, fields.module, fields.line, fields.column,
+            )
+        }
+    }
+}
+
+/**
+ * Report Rust errors to Sentry (supplied by the application
+ *
+ * This represents the legacy error reporting interface. We're keeping this around for now so that
+ * Android can send errors to Sentry.  At some point we should migrate Android to only use
+ * Glean-based error reporting.
+ */
+public interface ApplicationErrorReporter {
+    /**
+     * Report an error
+     */
+    fun reportError(typeName: String, message: String)
+
+    /**
+     * Report a breadbcrumb
+     */
+    fun reportBreadcrumb(message: String, module: String, line: UInt, column: UInt)
+}
+
+/**
+ * Set the global ApplicationErrorReporter
+ */
+public fun setApplicationErrorReporter(errorReporter: ApplicationErrorReporter) {
+    ApplicationErrorReporterRegistry.errorReporter = errorReporter
+}
+
+/**
+ * Unset the global ApplicationErrorReporter
+ */
+public fun unsetApplicationErrorReporter() {
+    ApplicationErrorReporterRegistry.errorReporter = null
+}
+
+internal object ApplicationErrorReporterRegistry {
+    var errorReporter: ApplicationErrorReporter? = null
+}

--- a/components/support/error/metrics.yaml
+++ b/components/support/error/metrics.yaml
@@ -1,0 +1,59 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+rust_component_errors:
+  error_type:
+    type: string
+    description: >
+      Component supplied error type name.  Used to aggregate error pings.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1991442
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1992235
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - bdk@mozilla.com
+    expires: never
+    send_in_pings:
+      - rust-component-errors
+  details:
+    type: string
+    description: >
+      Components supplied error details.
+      Components are responsible for avoiding personal identifying information in this field,
+      use the `error_support::redact` crate to help with this.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1991442
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1992235
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - bdk@mozilla.com
+    expires: never
+    send_in_pings:
+      - rust-component-errors
+  breadcrumbs:
+    type: string_list
+    description: >
+      Most recent 20 breadcrubs recorded by any component.
+      Like `description`, components are responsible for avoiding PII in this data.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1991442
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1992235
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - synced-client-integrations@mozilla.com
+      - bdk@mozilla.com
+    expires: never
+    send_in_pings:
+      - rust-component-errors

--- a/components/support/error/pings.yaml
+++ b/components/support/error/pings.yaml
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+rust-component-errors:
+  description: >
+    Ping containing details about an error in a Rust component.
+    The Rust code rate limits error pings are limited to 20/component/day.
+  notification_emails:
+    - sync-team@mozilla.com
+    - bdk@mozilla.com
+  include_client_id: true
+  bugs:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1991442
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1992235

--- a/components/support/error/src/error_tracing.rs
+++ b/components/support/error/src/error_tracing.rs
@@ -1,0 +1,190 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use parking_lot::Mutex;
+
+static RECENT_BREADCRUMBS: Mutex<BreadcrumbRingBuffer> = Mutex::new(BreadcrumbRingBuffer::new());
+
+pub fn report_error_to_app(type_name: String, message: String) {
+    // Report errors by sending a tracing event to the `app-services-error-reporter::error` target.
+    //
+    // Applications should register for these events and send a glean error ping when they occur.
+    //
+    // breadcrumbs will be sent in the `breadcrumbs` field as a single string, with each individual
+    // breadcrumb joined by newlines.
+    let breadcrumbs = RECENT_BREADCRUMBS.lock().get_breadcrumbs().join("\n");
+    tracing_support::error!(target: "app-services-error-reporter::error", message, type_name, breadcrumbs);
+}
+
+pub fn report_breadcrumb(message: String, module: String, line: u32, column: u32) {
+    // When we see a breadcrumb:
+    //   - Push it to the `RECENT_BREADCRUMBS` list
+    //   - Send out the `app-services-error-reporter::breadcrumb`.  Applications can register for
+    //     these events and log them.
+    RECENT_BREADCRUMBS.lock().push(message.clone());
+    tracing_support::info!(target: "app-services-error-reporter::breadcrumb", message, module, line, column);
+}
+
+/// Ring buffer implementation that we use to store the most recent 20 breadcrumbs
+#[derive(Default)]
+struct BreadcrumbRingBuffer {
+    breadcrumbs: Vec<String>,
+    pos: usize,
+}
+
+impl BreadcrumbRingBuffer {
+    const MAX_ITEMS: usize = 20;
+
+    const fn new() -> Self {
+        Self {
+            breadcrumbs: Vec::new(),
+            pos: 0,
+        }
+    }
+
+    fn push(&mut self, breadcrumb: impl Into<String>) {
+        let breadcrumb = breadcrumb.into();
+        if self.breadcrumbs.len() < Self::MAX_ITEMS {
+            self.breadcrumbs.push(breadcrumb);
+        } else {
+            self.breadcrumbs[self.pos] = breadcrumb;
+            self.pos = (self.pos + 1) % Self::MAX_ITEMS;
+        }
+    }
+
+    fn get_breadcrumbs(&self) -> Vec<String> {
+        let mut breadcrumbs = Vec::from(&self.breadcrumbs[self.pos..]);
+        breadcrumbs.extend(self.breadcrumbs[..self.pos].iter().map(|s| s.to_string()));
+        breadcrumbs
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_buffer() {
+        let mut buf = BreadcrumbRingBuffer::default();
+        buf.push("00");
+        buf.push("01");
+        buf.push("02");
+        buf.push("03");
+        buf.push("04");
+        buf.push("05");
+        buf.push("06");
+        buf.push("07");
+        buf.push("08");
+        buf.push("09");
+        assert_eq!(
+            buf.get_breadcrumbs(),
+            vec![
+                "00".to_string(),
+                "01".to_string(),
+                "02".to_string(),
+                "03".to_string(),
+                "04".to_string(),
+                "05".to_string(),
+                "06".to_string(),
+                "07".to_string(),
+                "08".to_string(),
+                "09".to_string(),
+            ]
+        );
+
+        buf.push("10");
+        buf.push("11");
+        buf.push("12");
+        buf.push("13");
+        buf.push("14");
+        buf.push("15");
+        buf.push("16");
+        buf.push("17");
+        buf.push("18");
+        buf.push("19");
+        assert_eq!(
+            buf.get_breadcrumbs(),
+            vec![
+                "00".to_string(),
+                "01".to_string(),
+                "02".to_string(),
+                "03".to_string(),
+                "04".to_string(),
+                "05".to_string(),
+                "06".to_string(),
+                "07".to_string(),
+                "08".to_string(),
+                "09".to_string(),
+                "10".to_string(),
+                "11".to_string(),
+                "12".to_string(),
+                "13".to_string(),
+                "14".to_string(),
+                "15".to_string(),
+                "16".to_string(),
+                "17".to_string(),
+                "18".to_string(),
+                "19".to_string(),
+            ]
+        );
+
+        buf.push("20");
+        assert_eq!(
+            buf.get_breadcrumbs(),
+            vec![
+                "01".to_string(),
+                "02".to_string(),
+                "03".to_string(),
+                "04".to_string(),
+                "05".to_string(),
+                "06".to_string(),
+                "07".to_string(),
+                "08".to_string(),
+                "09".to_string(),
+                "10".to_string(),
+                "11".to_string(),
+                "12".to_string(),
+                "13".to_string(),
+                "14".to_string(),
+                "15".to_string(),
+                "16".to_string(),
+                "17".to_string(),
+                "18".to_string(),
+                "19".to_string(),
+                "20".to_string(),
+            ]
+        );
+
+        buf.push("21");
+        buf.push("22");
+        buf.push("23");
+        buf.push("24");
+        buf.push("25");
+        assert_eq!(
+            buf.get_breadcrumbs(),
+            vec![
+                "06".to_string(),
+                "07".to_string(),
+                "08".to_string(),
+                "09".to_string(),
+                "10".to_string(),
+                "11".to_string(),
+                "12".to_string(),
+                "13".to_string(),
+                "14".to_string(),
+                "15".to_string(),
+                "16".to_string(),
+                "17".to_string(),
+                "18".to_string(),
+                "19".to_string(),
+                "20".to_string(),
+                "21".to_string(),
+                "22".to_string(),
+                "23".to_string(),
+                "24".to_string(),
+                "25".to_string(),
+            ]
+        );
+    }
+}

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -71,21 +71,14 @@ pub use redact::*;
 mod reporting;
 #[cfg(not(feature = "tracing-reporting"))]
 pub use reporting::{
-    set_application_error_reporter, unset_application_error_reporter, ApplicationErrorReporter,
+    report_breadcrumb, report_error_to_app, set_application_error_reporter,
+    unset_application_error_reporter, ApplicationErrorReporter,
 };
 
 #[cfg(feature = "tracing-reporting")]
-mod reporting {
-    pub fn report_error_to_app(type_name: String, message: String) {
-        tracing_support::error!(target: "app-services-error-reporter::error", message, type_name);
-    }
-
-    pub fn report_breadcrumb(message: String, module: String, line: u32, column: u32) {
-        tracing_support::info!(target: "app-services-error-reporter::breadcrumb", message, module, line, column);
-    }
-}
-
-pub use reporting::{report_breadcrumb, report_error_to_app};
+mod error_tracing;
+#[cfg(feature = "tracing-reporting")]
+pub use error_tracing::{report_breadcrumb, report_error_to_app};
 
 pub use error_support_macros::handle_error;
 

--- a/components/support/rust-log-forwarder/src/lib.rs
+++ b/components/support/rust-log-forwarder/src/lib.rs
@@ -147,12 +147,10 @@ mod test {
         let logger = TestLogger::new();
         set_max_level(Level::Debug);
         set_logger(Some(Box::new(logger.clone())));
-        // new tracing subscriber for our test.
-        let sink = Arc::new(ForwarderEventSink {});
-        tracing_support::register_event_sink("rust_log_forwarder", Level::Debug.into(), sink);
 
         tracing_support::info!("Test message");
         tracing_support::warn!("Test message2");
+        tracing_support::trace!("Test message3 (should be filtered out)");
         logger.check_records(vec![
             Record {
                 level: Level::Info,
@@ -167,8 +165,8 @@ mod test {
         ]);
         logger.clear_records();
         set_logger(None);
-        //log::info!("Test message");
-        //log::warn!("Test message2");
+        tracing_support::info!("Test message");
+        tracing_support::warn!("Test message2");
         logger.check_records(vec![]);
     }
 }

--- a/components/support/tracing/src/layer.rs
+++ b/components/support/tracing/src/layer.rs
@@ -37,7 +37,7 @@ pub fn register_event_sink(target: &str, level: crate::Level, sink: Arc<dyn Even
 /// Register an event sink that will receive events based on a minimum level
 ///
 /// If an event's level is at least `level`, then the event will be sent to this sink.
-/// If so, sinks registered with `register_event_sink` will be skiped.
+/// If so, sinks registered with `register_event_sink` will still be processed.
 ///
 /// There can only be 1 min-level sink registered at once.
 pub fn register_min_level_event_sink(level: crate::Level, sink: Arc<dyn EventSink>) {
@@ -96,7 +96,6 @@ where
         if let Some(entry) = &*MIN_LEVEL_SINK.read() {
             if entry.level >= *event.metadata().level() {
                 entry.send_event(event);
-                return;
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ protobuf-plugin = "0.9.5"
 # Kotlin
 kotlin = "2.2.20"
 coroutines = "1.10.2"
+kotlinx-serialization = "1.9.0"
 
 # Mozilla
 android-components = "143.0"
@@ -59,6 +60,7 @@ protobuf-compiler = { group = "com.google.protobuf", name = "protoc", version.re
 # Kotlin
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Mozilla
 mozilla-concept-fetch = { group = "org.mozilla.components", name = "concept-fetch", version.ref = "android-components" }
@@ -96,5 +98,6 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 gradle-download-task = { id = "de.undercouch.download", version.ref = "gradle-download-task" }
+kotlinx-serialization = { id = 'org.jetbrains.kotlin.plugin.serialization', version.ref = "kotlinx-serialization" }
 python-envs-plugin = {id = "com.jetbrains.python.envs", version.ref = "python-envs-plugin"}
 protobuf-plugin = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }

--- a/megazords/full/Cargo.toml
+++ b/megazords/full/Cargo.toml
@@ -23,7 +23,7 @@ viaduct = { path = "../../components/viaduct" }
 nimbus-sdk = { path = "../../components/nimbus" }
 autofill = { path = "../../components/autofill" }
 crashtest = { path = "../../components/crashtest" }
-error-support = { path = "../../components/support/error" }
+error-support = { path = "../../components/support/error", features = ["tracing-reporting"] }
 suggest = { path = "../../components/suggest" }
 search = { path = "../../components/search" }
 tracing-support = { path = "../../components/support/tracing" }


### PR DESCRIPTION
Adding a Glean ping to record errors in Rust components. In addition to the error type and details, we send the 20 most recent breadcrumbs.

This currently only works on Android and needs to go through Kotlin because we don't have access to Glean from Rust.  The plan is to experiment on Android, trying to create a system for nice team dashboards.  If that works, and once we're in the monorepo, we'll work to get Rust -> Glean calls work, which will allow us to also capture errors from Desktop and iOS.

Background and details are in the RFC: https://docs.google.com/document/d/1aK9AhYP65rEwADvx5vRiSC_RCtMfaZOBfoZDPKPThVk/

I'm hoping for both code review (am I making the Glean calls right) and data review (https://bugzilla.mozilla.org/show_bug.cgi?id=1992235).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
