### PR TITLE
Update some dependencies to help with m-c vendoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,15 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,17 +177,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -597,21 +577,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width 0.1.11",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
@@ -628,7 +593,7 @@ checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -637,7 +602,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -813,7 +778,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.39",
+ "clap",
  "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
@@ -1212,7 +1177,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "autofill",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "error-support",
  "fxa-client",
@@ -1250,7 +1215,7 @@ name = "example-places-autocomplete"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "find-places-db",
  "interrupt-support",
  "log",
@@ -1269,7 +1234,7 @@ name = "example-places-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "error-support",
  "fxa-client",
@@ -1309,7 +1274,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.2",
  "chrono",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "fxa-client",
  "init_rust_components",
@@ -1334,7 +1299,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.2",
  "chrono",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "interrupt-support",
  "log",
@@ -1352,7 +1317,7 @@ name = "examples-example-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "example-component",
  "viaduct",
@@ -1364,7 +1329,7 @@ name = "examples-fxa-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "fxa-client",
  "log",
@@ -1379,7 +1344,7 @@ dependencies = [
 name = "examples-nimbus-experiment"
 version = "0.0.0"
 dependencies = [
- "clap 4.5.39",
+ "clap",
  "error-support",
  "nimbus-sdk",
  "serde_json",
@@ -1392,7 +1357,7 @@ name = "examples-relay-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "log",
  "relay",
@@ -1405,7 +1370,7 @@ name = "examples-relevancy-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "env_logger",
  "interrupt-support",
@@ -1423,7 +1388,7 @@ name = "examples-remote-settings-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "futures",
  "indicatif",
@@ -1446,7 +1411,7 @@ name = "examples-suggest-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "cli-support",
  "log",
  "nss",
@@ -1460,7 +1425,7 @@ dependencies = [
 name = "examples-viaduct-cli"
 version = "0.1.0"
 dependencies = [
- "clap 4.5.39",
+ "clap",
  "serde",
  "url",
  "viaduct",
@@ -1524,7 +1489,7 @@ name = "filter_adult"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "clap 4.5.39",
+ "clap",
  "error-support",
  "md-5",
  "regex",
@@ -1862,21 +1827,6 @@ dependencies = [
  "thiserror 1.0.69",
  "url",
 ]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2783,7 +2733,7 @@ name = "merino-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap",
  "merino",
  "serde_json",
  "viaduct",
@@ -2927,10 +2877,10 @@ dependencies = [
  "axum",
  "cfg-if",
  "chrono",
- "clap 4.5.39",
+ "clap",
  "copypasta",
  "glob",
- "heck 0.4.1",
+ "heck",
  "hyper",
  "local-ip-address",
  "nimbus-fml",
@@ -2967,9 +2917,10 @@ dependencies = [
  "anyhow",
  "askama",
  "cfg-if",
- "clap 4.5.39",
+ "clap",
  "glob",
- "heck 0.5.0",
+ "heck",
+ "icu_segmenter",
  "itertools 0.14.0",
  "lazy_static",
  "regex",
@@ -2979,9 +2930,8 @@ dependencies = [
  "sha2",
  "tempfile",
  "termcolor",
- "textwrap 0.16.1",
+ "textwrap",
  "thiserror 2.0.3",
- "unicode-segmentation",
  "uniffi",
  "url",
  "viaduct",
@@ -2994,7 +2944,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "chrono",
- "clap 4.5.39",
+ "clap",
  "ctor",
  "error-support",
  "firefox-versioning",
@@ -3497,30 +3447,6 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -4326,7 +4252,7 @@ dependencies = [
  "askama",
  "camino",
  "cargo_metadata 0.15.2",
- "clap 4.5.39",
+ "clap",
  "serde_yaml 0.8.24",
  "toml",
  "toml_edit",
@@ -4340,39 +4266,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "subtle"
@@ -4467,6 +4363,7 @@ dependencies = [
  "anyhow",
  "autofill",
  "base64 0.21.2",
+ "clap",
  "cli-support",
  "env_logger",
  "fxa-client",
@@ -4480,7 +4377,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "structopt",
  "sync-guid",
  "sync15",
  "sync_manager",
@@ -4622,15 +4518,6 @@ name = "text-table"
 version = "0.1.0"
 dependencies = [
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -5046,7 +4933,7 @@ dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata 0.19.2",
- "clap 4.5.39",
+ "clap",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
@@ -5061,7 +4948,7 @@ dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata 0.19.2",
- "clap 4.5.39",
+ "clap",
  "uniffi",
  "uniffi_bindgen",
 ]
@@ -5079,12 +4966,12 @@ dependencies = [
  "fs-err",
  "glob",
  "goblin",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.5.0",
  "once_cell",
  "serde",
  "tempfile",
- "textwrap 0.16.1",
+ "textwrap",
  "toml",
  "uniffi_internal_macros",
  "uniffi_meta",
@@ -5164,7 +5051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b147e133ad7824e32426b90bc41fda584363563f2ba747f590eca1fd6fd14e6"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.5.0",
  "tempfile",
  "uniffi_internal_macros",
@@ -5177,7 +5064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caed654fb73da5abbc7a7e9c741532284532ba4762d6fe5071372df22a41730a"
 dependencies = [
  "anyhow",
- "textwrap 0.16.1",
+ "textwrap",
  "uniffi_meta",
  "weedle2",
 ]
@@ -5239,12 +5126,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -22,7 +22,7 @@ unicode-segmentation = "1.8.0"
 viaduct = { path = "../../viaduct" }
 viaduct-hyper = { path = "../../support/viaduct-hyper" }
 glob = "0.3.1"
-heck = "0.4.1"
+heck = "0.5"
 whoami = "1.4.0"
 update-informer = { version = "1.0.0", default-features = false }
 serde_yaml = "0.9.21"

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = "2"
 askama = "0.13"
 textwrap = { version = "0.16", default-features = false }
 heck = "0.5"
-unicode-segmentation = "1.8.0"
+icu_segmenter = "2"
 url = { version = "2", features = ["serde"] }
 glob = "0.3.0"
 uniffi = { version = "0.29.0", optional = true }

--- a/components/support/nimbus-fml/src/editing/cursor_position.rs
+++ b/components/support/nimbus-fml/src/editing/cursor_position.rs
@@ -4,7 +4,7 @@
 
 use std::ops::Add;
 
-use unicode_segmentation::UnicodeSegmentation;
+use icu_segmenter::GraphemeClusterSegmenter;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct CursorPosition {
@@ -56,7 +56,16 @@ impl Add<&str> for CursorPosition {
         }
 
         let last_line_length = match last_line {
-            Some(line) => UnicodeSegmentation::graphemes(line, true).count(),
+            Some(line) => {
+                let segmenter = GraphemeClusterSegmenter::new();
+                let boundary_count = segmenter.segment_str(line).count();
+                // segment_str returns N+1 boundaries for N graphemes, so subtract 1
+                if boundary_count > 0 {
+                    boundary_count - 1
+                } else {
+                    0
+                }
+            }
             None => 0,
         } as u32;
 

--- a/components/support/nimbus-fml/src/editing/error_path.rs
+++ b/components/support/nimbus-fml/src/editing/error_path.rs
@@ -267,11 +267,24 @@ fn line_col_from_lines<'a>(
 ///
 #[cfg(feature = "client-lib")]
 fn find_index(line: &str, pattern: &str, start: usize) -> Option<usize> {
-    use unicode_segmentation::UnicodeSegmentation;
-    let line: Vec<&str> = UnicodeSegmentation::graphemes(line, true).collect();
+    use icu_segmenter::GraphemeClusterSegmenter;
+
+    let segmenter = GraphemeClusterSegmenter::new();
+
+    // Convert line boundaries to grapheme slices
+    let line_boundaries: Vec<usize> = segmenter.segment_str(line).collect();
+    let line: Vec<&str> = line_boundaries
+        .windows(2)
+        .map(|w| &line[w[0]..w[1]])
+        .collect();
     let line_from_start = &line[start..];
 
-    let pattern: Vec<&str> = UnicodeSegmentation::graphemes(pattern, true).collect();
+    // Convert pattern boundaries to grapheme slices
+    let pattern_boundaries: Vec<usize> = segmenter.segment_str(pattern).collect();
+    let pattern: Vec<&str> = pattern_boundaries
+        .windows(2)
+        .map(|w| &pattern[w[0]..w[1]])
+        .collect();
     let pattern = pattern.as_slice();
 
     line_from_start

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -210,7 +210,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: hashlink</name>
-    <url>https://github.com/kyren/hashlink/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/kyren/hashlink/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: heck</name>

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 anyhow = "1.0"
 rand = "0.8"
 lazy_static = "1.4"
-structopt = "0.3"
+clap = { version = "4.5.39", default-features = false, features = ["std", "derive"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -4,11 +4,11 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
+use clap::Parser;
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
 use nss::ensure_initialized;
 use std::sync::Arc;
 use std::{collections::HashSet, process};
-use structopt::StructOpt;
 
 mod auth;
 mod autofill;
@@ -101,36 +101,36 @@ pub fn run_test_group(opts: &Opts, group: TestGroup) {
 }
 
 // Note: this uses doc comments to generate the help text.
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(name = "sync-test", about = "Sync integration tests")]
+#[derive(Clone, Debug, Parser)]
+#[command(name = "sync-test", about = "Sync integration tests")]
 pub struct Opts {
-    #[structopt(name = "oauth-retries", long, short = "r", default_value = "0")]
+    #[arg(long = "oauth-retries", short = 'r', default_value = "0")]
     /// Number of times to retry authentication with FxA if automatically
     /// logging in with OAuth fails (Sadly, it seems inherently finnicky).
     pub oauth_retries: u64,
 
-    #[structopt(name = "oauth-retry-delay", long, default_value = "5000")]
+    #[arg(long = "oauth-retry-delay", default_value = "5000")]
     /// Number of milliseconds to wait between retries. Does nothing if
     /// `oauth-retries` is 0.
     pub oauth_delay_time: u64,
 
-    #[structopt(name = "oauth-retry-delay-backoff", long, default_value = "2000")]
+    #[arg(long = "oauth-retry-delay-backoff", default_value = "2000")]
     /// Number of milliseconds to increase `oauth-retry-delay` with after each
     /// failure. Does nothing if `oauth-retries` is 0.
     pub oauth_retry_backoff: u64,
 
-    #[structopt(name = "fxa-stack", short = "s", long, default_value = "stable-dev")]
+    #[arg(long = "fxa-stack", short = 's', default_value = "stable-dev")]
     /// Either 'release', 'stage', 'stable-dev', or a URL.
     pub fxa_stack: FxaConfigUrl,
 
-    #[structopt(name = "credentials", long, default_value = "./credentials.json")]
+    #[arg(long = "credentials", default_value = "./credentials.json")]
     credential_file: String,
 
-    #[structopt(name = "helper-debug", long)]
+    #[arg(long = "helper-debug")]
     /// Run the helper browser as non-headless, and enable extra logging
     pub helper_debug: bool,
 
-    #[structopt(name = "show-groups", long)]
+    #[arg(long = "show-groups")]
     /// Show the test groups and exit.
     pub show_groups: bool,
 
@@ -139,7 +139,7 @@ pub struct Opts {
 }
 
 pub fn main() {
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
     println!("### Running sync integration tests ###");
     init_testing();
     let groups = vec![


### PR DESCRIPTION
* unicode-segmenter is replaced with icu_segmenter in nimbus-fml
* Upgrade heck
* Replace structopt with clap in our sync-test crate.

(Not strictly *blocking* the monorepo, but this is a worthwhile cleanup regardless)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
