### PR TITLE
feat: add caching to ads-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added the Ads Client component to the Megazord.
 - Updated the ApiError enum to AdsClientApiError to avoid naming collision.
 - The `context_id` is now generated and rotated via the existing eponym component crate.
+- Added request caching mechanism using SQLite with configurable TTL and max size.
 
 ### Relay
 - **⚠️ Breaking Change:** The error handling for the Relay component has been refactored for stronger forward compatibility and more transparent error reporting in Swift and Kotlin via UniFFI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,13 +21,16 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 name = "ads-client"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "context_id",
  "error-support",
  "mockall",
  "mockito",
  "parking_lot",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sql-support",
  "thiserror 2.0.3",
  "uniffi",
  "url",

--- a/components/ads-client/Cargo.toml
+++ b/components/ads-client/Cargo.toml
@@ -5,9 +5,16 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
+chrono = "0.4"
 context_id = { path = "../context_id" }
 error-support = { path = "../support/error" }
 parking_lot = "0.12"
+rusqlite = { version = "0.37.0", features = [
+    "functions",
+    "bundled",
+    "serde_json",
+    "unlock_notify",
+] }
 serde = "1"
 serde_json = "1"
 thiserror = "2"
@@ -15,6 +22,7 @@ uniffi = { version = "0.29.0" }
 url = "2"
 uuid = { version = "1.3", features = ["v4"] }
 viaduct = { path = "../viaduct" }
+sql-support = { path = "../support/sql" }
 
 [dev-dependencies]
 mockall = "0.12"

--- a/components/ads-client/android/build.gradle
+++ b/components/ads-client/android/build.gradle
@@ -5,6 +5,10 @@ android {
     namespace 'org.mozilla.appservices.ads_client'
 }
 
+dependencies {
+    api project(":httpconfig")
+}
+
 ext.configureUniFFIBindgen("ads_client")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/ads-client/src/http_cache.rs
+++ b/components/ads-client/src/http_cache.rs
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod builder;
+mod bytesize;
+mod cache_control;
+mod connection_initializer;
+mod request_hash;
+mod store;
+
+use self::{
+    builder::HttpCacheBuilder, cache_control::CacheControl, request_hash::RequestHash,
+    store::HttpCacheStore,
+};
+
+use viaduct::{Request, Response};
+
+pub use self::bytesize::ByteSize;
+use std::path::Path;
+use std::time::Duration;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Could not build cache: {0}")]
+    Builder(#[from] builder::Error),
+
+    #[error("SQLite operation failed: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("Error sending request: {0}")]
+    Viaduct(#[from] viaduct::ViaductError),
+}
+
+pub struct HttpCache {
+    max_size: ByteSize,
+    store: HttpCacheStore,
+    ttl: Duration,
+}
+
+impl HttpCache {
+    pub fn builder<P: AsRef<Path>>(db_path: P) -> HttpCacheBuilder {
+        HttpCacheBuilder::new(db_path.as_ref())
+    }
+
+    pub fn clear(&self) -> Result<(), Error> {
+        self.store.clear_all().map_err(Error::from)?;
+        Ok(())
+    }
+
+    pub fn send(&self, request: Request) -> Result<(Response, Option<RequestHash>), Error> {
+        let cutoff = chrono::Utc::now().timestamp() - self.ttl.as_secs() as i64;
+        self.store.delete_expired_entries(cutoff)?;
+
+        if let Some((response, request_hash)) = self.store.lookup(&request)? {
+            return Ok((response, Some(request_hash)));
+        }
+
+        let response = request.clone().send()?;
+        let cache_control = CacheControl::from(&response);
+        if cache_control.should_cache() {
+            self.store.store(&request, &response)?;
+            self.store.trim_to_max_size(self.max_size.as_u64() as i64)?;
+        }
+        Ok((response, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_http_cache_creation() {
+        // Test that HttpCache can be created successfully with test config
+        let cache = HttpCache::builder("test_cache.db").build();
+        assert!(cache.is_ok());
+
+        // Test with custom config
+        let cache_with_config = HttpCache::builder("custom_test.db")
+            .max_size(ByteSize::mib(1))
+            .ttl(Duration::from_secs(60))
+            .build();
+        assert!(cache_with_config.is_ok());
+    }
+
+    #[test]
+    fn test_clear_cache() {
+        let cache = HttpCache::builder("test_clear.db").build().unwrap();
+
+        // Create a test request and response
+        let request = viaduct::Request {
+            method: viaduct::Method::Get,
+            url: "https://example.com/test".parse().unwrap(),
+            headers: viaduct::Headers::new(),
+            body: None,
+        };
+
+        let response = viaduct::Response {
+            request_method: viaduct::Method::Get,
+            url: "https://example.com/test".parse().unwrap(),
+            status: 200,
+            headers: viaduct::Headers::new(),
+            body: b"test response".to_vec(),
+        };
+
+        // Store something in the cache
+        cache.store.store(&request, &response).unwrap();
+
+        // Verify it's cached
+        let retrieved = cache.store.lookup(&request).unwrap();
+        assert!(retrieved.is_some());
+
+        // Clear the cache
+        cache.clear().unwrap();
+
+        // Verify it's cleared
+        let retrieved_after_clear = cache.store.lookup(&request).unwrap();
+        assert!(retrieved_after_clear.is_none());
+    }
+}

--- a/components/ads-client/src/http_cache/builder.rs
+++ b/components/ads-client/src/http_cache/builder.rs
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::http_cache::HttpCache;
+
+use super::bytesize::ByteSize;
+use super::connection_initializer::HttpCacheConnectionInitializer;
+use super::store::HttpCacheStore;
+use sql_support::open_database;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_MAX_SIZE: ByteSize = ByteSize::mib(10);
+const DEFAULT_TTL: Duration = Duration::from_secs(300);
+
+const MIN_CACHE_SIZE: ByteSize = ByteSize::kib(1);
+const MAX_CACHE_SIZE: ByteSize = ByteSize::mib(100);
+const MIN_TTL: Duration = Duration::from_secs(1);
+const MAX_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 7); // 7 days
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Database path cannot be empty")]
+    EmptyDbPath,
+    #[error("Database error: {0}")]
+    Database(#[from] open_database::Error),
+    #[error(
+        "Maximum cache size must be between {min_size} and {max_size}, got {size_bytes} bytes"
+    )]
+    InvalidMaxSize {
+        max_size: String,
+        min_size: String,
+        size_bytes: u64,
+    },
+    #[error("TTL must be between {min_ttl} and {max_ttl}, got {ttl} seconds")]
+    InvalidTtl {
+        max_ttl: String,
+        min_ttl: String,
+        ttl: u64,
+    },
+}
+
+#[derive(Debug)]
+pub struct HttpCacheBuilder {
+    db_path: PathBuf,
+    max_size: Option<ByteSize>,
+    ttl: Option<Duration>,
+}
+
+impl HttpCacheBuilder {
+    pub fn new(db_path: impl Into<PathBuf>) -> Self {
+        Self {
+            db_path: db_path.into(),
+            max_size: None,
+            ttl: None,
+        }
+    }
+
+    pub fn max_size(mut self, max_size: ByteSize) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+
+    pub fn ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        if self.db_path.to_string_lossy().trim().is_empty() {
+            return Err(Error::EmptyDbPath);
+        }
+
+        if let Some(max_size) = self.max_size {
+            if max_size < MIN_CACHE_SIZE || max_size > MAX_CACHE_SIZE {
+                return Err(Error::InvalidMaxSize {
+                    size_bytes: max_size.as_u64(),
+                    min_size: MIN_CACHE_SIZE.to_string(),
+                    max_size: MAX_CACHE_SIZE.to_string(),
+                });
+            }
+        }
+
+        if let Some(ttl) = self.ttl {
+            if !(MIN_TTL..=MAX_TTL).contains(&ttl) {
+                return Err(Error::InvalidTtl {
+                    ttl: ttl.as_secs(),
+                    min_ttl: format!("{} seconds", MIN_TTL.as_secs()),
+                    max_ttl: format!("{} seconds", MAX_TTL.as_secs()),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn build(self) -> Result<HttpCache, Error> {
+        self.validate()?;
+
+        let initializer = HttpCacheConnectionInitializer {};
+        let conn = if cfg!(test) {
+            open_database::open_memory_database(&initializer)?
+        } else {
+            open_database::open_database(&self.db_path, &initializer)?
+        };
+
+        let max_size = self.max_size.unwrap_or(DEFAULT_MAX_SIZE);
+        let store = HttpCacheStore::new(conn);
+        let ttl = self.ttl.unwrap_or(DEFAULT_TTL);
+
+        Ok(HttpCache {
+            max_size,
+            store,
+            ttl,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_builder_with_defaults() {
+        let builder = HttpCacheBuilder::new("test.db".to_string());
+        assert_eq!(builder.db_path, PathBuf::from("test.db"));
+        assert_eq!(builder.max_size, None);
+        assert_eq!(builder.ttl, None);
+        assert!(builder.build().is_ok());
+    }
+
+    #[test]
+    fn test_cache_builder_valid_custom() {
+        let builder = HttpCacheBuilder::new("custom.db".to_string())
+            .max_size(ByteSize::b(1024))
+            .ttl(Duration::from_secs(60));
+
+        assert_eq!(builder.db_path, PathBuf::from("custom.db"));
+        assert_eq!(builder.max_size, Some(ByteSize::b(1024)));
+        assert_eq!(builder.ttl, Some(Duration::from_secs(60)));
+        assert!(builder.build().is_ok());
+    }
+
+    #[test]
+    fn test_validation_empty_db_path() {
+        let builder = HttpCacheBuilder::new("   ".to_string());
+
+        let result = builder.build();
+        assert!(matches!(result, Err(Error::EmptyDbPath)));
+    }
+
+    #[test]
+    fn test_validation_max_size_too_small() {
+        let builder = HttpCacheBuilder::new("test.db".to_string()).max_size(ByteSize::b(512));
+
+        let result = builder.build();
+        assert!(matches!(
+            result,
+            Err(Error::InvalidMaxSize {
+                size_bytes: 512,
+                min_size: _,
+                max_size: _,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_validation_max_size_too_large() {
+        let builder = HttpCacheBuilder::new("test.db".to_string())
+            .max_size(ByteSize::b(2 * 1024 * 1024 * 1024));
+
+        let result = builder.build();
+        assert!(matches!(
+            result,
+            Err(Error::InvalidMaxSize {
+                size_bytes: 2147483648,
+                min_size: _,
+                max_size: _,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_validation_max_size_boundaries() {
+        let builder_min = HttpCacheBuilder::new("test.db".to_string()).max_size(MIN_CACHE_SIZE);
+        assert!(builder_min.build().is_ok());
+
+        let builder_max = HttpCacheBuilder::new("test.db".to_string()).max_size(MAX_CACHE_SIZE);
+        assert!(builder_max.build().is_ok());
+    }
+
+    #[test]
+    fn test_validation_ttl_too_small() {
+        let builder = HttpCacheBuilder::new("test.db".to_string()).ttl(Duration::from_secs(0));
+
+        let result = builder.build();
+        assert!(matches!(
+            result,
+            Err(Error::InvalidTtl {
+                ttl: 0,
+                min_ttl: _,
+                max_ttl: _,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_validation_ttl_too_large() {
+        let builder =
+            HttpCacheBuilder::new("test.db".to_string()).ttl(Duration::from_secs(8 * 24 * 60 * 60));
+
+        let result = builder.build();
+        assert!(matches!(
+            result,
+            Err(Error::InvalidTtl {
+                ttl: 691200,
+                min_ttl: _,
+                max_ttl: _,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_validation_ttl_boundaries() {
+        let builder_min = HttpCacheBuilder::new("test.db".to_string()).ttl(MIN_TTL);
+        assert!(builder_min.build().is_ok());
+
+        let builder_max = HttpCacheBuilder::new("test.db".to_string()).ttl(MAX_TTL);
+        assert!(builder_max.build().is_ok());
+    }
+}

--- a/components/ads-client/src/http_cache/bytesize.rs
+++ b/components/ads-client/src/http_cache/bytesize.rs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::fmt;
+use std::ops;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ByteSize(u64);
+
+impl ByteSize {
+    pub const fn b(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn kib(value: u64) -> Self {
+        Self(Self::b(1024).0.saturating_mul(value))
+    }
+
+    pub const fn mib(value: u64) -> Self {
+        Self(Self::kib(1024).0.saturating_mul(value))
+    }
+
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+impl ops::Mul<u64> for ByteSize {
+    type Output = Self;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        Self(self.0.saturating_mul(rhs))
+    }
+}
+
+impl fmt::Display for ByteSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes_u64 = self.0;
+        if bytes_u64 >= 1024 * 1024 {
+            write!(f, "{} MB", bytes_u64 / (1024 * 1024))
+        } else if bytes_u64 >= 1024 {
+            write!(f, "{} KB", bytes_u64 / 1024)
+        } else {
+            write!(f, "{} bytes", bytes_u64)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_byte_size_constructors() {
+        assert_eq!(ByteSize::b(1024).as_u64(), 1024);
+        assert_eq!(ByteSize::mib(1).as_u64(), 1024 * 1024);
+        assert_eq!(ByteSize::mib(10).as_u64(), 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_byte_size_overflow() {
+        assert_eq!(ByteSize::mib(u64::MAX).as_u64(), u64::MAX);
+    }
+
+    #[test]
+    fn test_byte_size_display() {
+        assert_eq!(ByteSize::b(512).to_string(), "512 bytes");
+        assert_eq!(ByteSize::kib(1).to_string(), "1 KB");
+        assert_eq!(ByteSize::kib(1024).to_string(), "1 MB");
+        assert_eq!(ByteSize::mib(1).to_string(), "1 MB");
+        assert_eq!(ByteSize::mib(100).to_string(), "100 MB");
+    }
+
+    #[test]
+    fn test_byte_size_comparison() {
+        let small = ByteSize::b(1024);
+        let medium = ByteSize::kib(1);
+        let large = ByteSize::mib(1);
+
+        assert_eq!(small, medium);
+        assert!(small < large);
+        assert!(large > small);
+        assert!(small <= medium);
+        assert!(large >= small);
+        assert!(small != large);
+    }
+
+    #[test]
+    fn test_byte_size_ordering() {
+        let sizes = vec![
+            ByteSize::mib(10),
+            ByteSize::b(100),
+            ByteSize::kib(5),
+            ByteSize::mib(1),
+        ];
+        let mut sorted = sizes.clone();
+        sorted.sort();
+
+        assert_eq!(
+            sorted,
+            vec![
+                ByteSize::b(100),
+                ByteSize::kib(5),
+                ByteSize::mib(1),
+                ByteSize::mib(10),
+            ]
+        );
+    }
+}

--- a/components/ads-client/src/http_cache/cache_control.rs
+++ b/components/ads-client/src/http_cache/cache_control.rs
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use serde::{Deserialize, Serialize};
+use viaduct::{header_names, Response};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CacheControl {
+    pub max_age: Option<u64>,
+    pub must_revalidate: bool,
+    pub no_cache: bool,
+    pub no_store: bool,
+    pub private: bool,
+}
+
+impl From<&Response> for CacheControl {
+    fn from(response: &Response) -> Self {
+        let mut cache_control = Self {
+            max_age: None,
+            must_revalidate: false,
+            no_cache: false,
+            no_store: false,
+            private: false,
+        };
+
+        if let Some(header) = response.headers.get(header_names::CACHE_CONTROL) {
+            for directive in header.split(',').map(|s| s.trim()) {
+                match directive {
+                    "must-revalidate" => cache_control.must_revalidate = true,
+                    "no-cache" => cache_control.no_cache = true,
+                    "no-store" => cache_control.no_store = true,
+                    "private" => cache_control.private = true,
+                    s if s.starts_with("max-age=") => {
+                        if let Some(age_str) = s.strip_prefix("max-age=") {
+                            cache_control.max_age = age_str.parse().ok();
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        cache_control
+    }
+}
+
+impl CacheControl {
+    pub fn should_cache(&self) -> bool {
+        !self.no_store
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use viaduct::{Headers, Method};
+
+    fn from_header(header: Option<&str>) -> CacheControl {
+        let mut headers = Headers::new();
+        if let Some(header) = header {
+            headers.insert(header_names::CACHE_CONTROL, header).unwrap();
+        }
+        CacheControl::from(&Response {
+            body: b"".to_vec(),
+            headers,
+            request_method: Method::Get,
+            status: 200,
+            url: "https://example.com".parse().unwrap(),
+        })
+    }
+
+    #[test]
+    fn test_cache_control_parsing() {
+        // Test max-age
+        let directives = from_header(Some("max-age=3600"));
+        assert_eq!(directives.max_age, Some(3600));
+        assert!(!directives.no_cache);
+        assert!(!directives.no_store);
+
+        // Test no-cache and no-store
+        let directives = from_header(Some("no-cache, no-store"));
+        assert!(directives.no_cache);
+        assert!(directives.no_store);
+
+        // Test multiple directives
+        let directives = from_header(Some("max-age=1800, must-revalidate, private"));
+        assert_eq!(directives.max_age, Some(1800));
+        assert!(directives.must_revalidate);
+        assert!(directives.private);
+
+        // Test empty header
+        let directives = from_header(None);
+        assert_eq!(directives.max_age, None);
+        assert!(!directives.no_cache);
+        assert!(!directives.no_store);
+        assert!(directives.should_cache());
+    }
+}

--- a/components/ads-client/src/http_cache/connection_initializer.rs
+++ b/components/ads-client/src/http_cache/connection_initializer.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use rusqlite::Connection;
+use sql_support::open_database;
+use std::time::Duration;
+
+pub struct HttpCacheConnectionInitializer {}
+
+impl open_database::ConnectionInitializer for HttpCacheConnectionInitializer {
+    const NAME: &'static str = "http_cache";
+    const END_VERSION: u32 = 1;
+
+    fn prepare(&self, conn: &Connection, _db_empty: bool) -> open_database::Result<()> {
+        conn.execute_batch("PRAGMA journal_mode=wal;")?;
+        conn.busy_timeout(Duration::from_secs(5))?;
+        Ok(())
+    }
+
+    fn init(&self, tx: &rusqlite::Transaction<'_>) -> open_database::Result<()> {
+        const SCHEMA: &str = "
+            CREATE TABLE IF NOT EXISTS http_cache (
+                cached_at INTEGER NOT NULL,
+                request_hash TEXT NOT NULL,
+                response_body BLOB NOT NULL,
+                response_headers BLOB,
+                response_status INTEGER NOT NULL,
+                size INTEGER NOT NULL,
+                PRIMARY KEY (request_hash)
+            );
+            CREATE INDEX IF NOT EXISTS idx_http_cache_cached_at ON http_cache(cached_at);
+        ";
+        tx.execute_batch(SCHEMA)?;
+        Ok(())
+    }
+
+    fn upgrade_from(
+        &self,
+        conn: &rusqlite::Transaction<'_>,
+        version: u32,
+    ) -> open_database::Result<()> {
+        match version {
+            0 => {
+                // Version 0 means we need to create the initial schema
+                self.init(conn)
+            }
+            _ => Err(open_database::Error::IncompatibleVersion(version)),
+        }
+    }
+}

--- a/components/ads-client/src/http_cache/request_hash.rs
+++ b/components/ads-client/src/http_cache/request_hash.rs
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use viaduct::Request;
+
+pub struct RequestHash(String);
+
+impl From<&Request> for RequestHash {
+    fn from(request: &Request) -> Self {
+        let mut hasher = DefaultHasher::new();
+        request.method.hash(&mut hasher);
+        request.url.hash(&mut hasher);
+
+        let mut headers: Vec<_> = request.headers.clone().into_iter().collect();
+        headers.sort_by_key(|header| header.name.to_ascii_lowercase());
+        for header in headers {
+            header.name.hash(&mut hasher);
+            header.value.hash(&mut hasher);
+        }
+
+        request.body.hash(&mut hasher);
+        RequestHash(format!("{:x}", hasher.finish()))
+    }
+}
+
+impl std::fmt::Display for RequestHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use viaduct::{Headers, Method, Request};
+
+    fn create_test_request(url: &str, body: &[u8]) -> Request {
+        Request {
+            method: Method::Get,
+            url: url.parse().unwrap(),
+            headers: Headers::new(),
+            body: Some(body.to_vec()),
+        }
+    }
+
+    #[test]
+    fn test_request_hashing() {
+        let request1 = create_test_request("https://example.com/api1", b"body1");
+        let request2 = create_test_request("https://example.com/api2", b"body2");
+        let request3 = create_test_request("https://example.com/api", b"body");
+
+        let hash1 = RequestHash::from(&request1);
+        let hash2 = RequestHash::from(&request2);
+        let hash3 = RequestHash::from(&request3);
+
+        assert_ne!(hash1.to_string(), hash2.to_string());
+        assert_ne!(hash1.to_string(), hash3.to_string());
+        assert_ne!(hash2.to_string(), hash3.to_string());
+
+        let same_request = create_test_request("https://example.com/api", b"body");
+        let hash4 = RequestHash::from(&same_request);
+        assert_eq!(hash3.to_string(), hash4.to_string());
+    }
+
+    #[test]
+    fn test_request_hashing_header_order_and_case() {
+        let base_url = "https://example.com/api";
+        let body = b"body";
+
+        let req_base = create_test_request(base_url, body);
+        let mut h1 = Headers::new();
+        h1.insert("Accept", "text/plain").unwrap();
+        h1.insert("X-Test", "1").unwrap();
+        let req1 = Request {
+            headers: h1,
+            ..req_base.clone()
+        };
+
+        let req_base = create_test_request(base_url, body);
+        let mut h2 = Headers::new();
+        h2.insert("X-Test", "1").unwrap();
+        h2.insert("Accept", "text/plain").unwrap();
+        let req2 = Request {
+            headers: h2,
+            ..req_base.clone()
+        };
+
+        let req_base = create_test_request(base_url, body);
+        let mut h3 = Headers::new();
+        h3.insert("accept", "text/plain").unwrap();
+        h3.insert("x-test", "1").unwrap();
+        let req3 = Request {
+            headers: h3,
+            ..req_base
+        };
+
+        let h_req1 = RequestHash::from(&req1);
+        let h_req2 = RequestHash::from(&req2);
+        let h_req3 = RequestHash::from(&req3);
+
+        assert_eq!(h_req1.to_string(), h_req2.to_string());
+        assert_eq!(h_req1.to_string(), h_req3.to_string());
+    }
+}

--- a/components/ads-client/src/http_cache/store.rs
+++ b/components/ads-client/src/http_cache/store.rs
@@ -1,0 +1,285 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+
+use crate::http_cache::request_hash::RequestHash;
+use parking_lot::Mutex;
+use rusqlite::{params, Connection, OptionalExtension, Result as SqliteResult};
+use viaduct::{Header, Request, Response};
+
+pub struct HttpCacheStore {
+    conn: Mutex<Connection>,
+}
+
+impl HttpCacheStore {
+    pub fn new(conn: Connection) -> Self {
+        Self {
+            conn: Mutex::new(conn),
+        }
+    }
+
+    pub fn clear_all(&self) -> SqliteResult<usize> {
+        let conn = self.conn.lock();
+        conn.execute("DELETE FROM http_cache", [])
+    }
+
+    pub fn current_total_size(&self) -> SqliteResult<i64> {
+        let conn = self.conn.lock();
+        conn.query_row("SELECT COALESCE(SUM(size),0) FROM http_cache", [], |row| {
+            row.get(0)
+        })
+    }
+
+    pub fn delete_expired_entries(&self, cutoff_timestamp: i64) -> SqliteResult<usize> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "DELETE FROM http_cache WHERE cached_at < ?1",
+            params![cutoff_timestamp],
+        )
+    }
+
+    pub fn lookup(&self, request: &Request) -> SqliteResult<Option<(Response, RequestHash)>> {
+        let request_hash = RequestHash::from(request);
+        let conn = self.conn.lock();
+        conn.query_row(
+            "SELECT response_body, response_headers, response_status FROM http_cache WHERE request_hash = ?1",
+            params![request_hash.to_string()],
+            |row| {
+            let response_body = row.get(0)?;
+            let response_headers: Vec<u8> = row.get(1)?;
+            let response_status: i64 = row.get(2)?;
+                let headers = serde_json::from_slice::<HashMap<String, String>>(&response_headers)
+            .map(|map| {
+                map.into_iter()
+                    .filter_map(|(n, v)| Header::new(n, v).ok())
+                    .collect::<Vec<_>>()
+                    .into()
+            })
+            .unwrap_or_else(|_| viaduct::Headers::new());
+
+        let response = Response {
+            body: response_body,
+            headers,
+            request_method: request.method,
+            status: response_status as u16,
+            url: request.url.clone(),
+        };
+        Ok((response, request_hash))
+            },
+        )
+        .optional()
+    }
+
+    pub fn store(&self, request: &Request, response: &Response) -> SqliteResult<RequestHash> {
+        let request_hash = RequestHash::from(request);
+        let headers_map: HashMap<String, String> = response.headers.clone().into();
+        let response_headers = serde_json::to_vec(&headers_map).unwrap_or_default();
+        let size = (response_headers.len() + response.body.len()) as i64;
+
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT INTO http_cache (cached_at, request_hash, response_body, response_headers, response_status, size)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(request_hash) DO UPDATE SET
+                cached_at=excluded.cached_at,
+                response_body=excluded.response_body,
+                response_headers=excluded.response_headers,
+                response_status=excluded.response_status,
+                size=excluded.size",
+            params![
+                chrono::Utc::now().timestamp(),
+                request_hash.to_string(),
+                response.body,
+                response_headers,
+                response.status,
+                size
+            ],
+        )?;
+        Ok(request_hash)
+    }
+
+    pub fn trim_to_max_size(&self, max_size: i64) -> SqliteResult<()> {
+        loop {
+            let total = self.current_total_size()?;
+            if total <= max_size {
+                break;
+            }
+            let conn = self.conn.lock();
+            conn.execute(
+                "DELETE FROM http_cache WHERE rowid IN (
+                    SELECT rowid FROM http_cache ORDER BY cached_at ASC LIMIT 1
+                )",
+                [],
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http_cache::connection_initializer::HttpCacheConnectionInitializer;
+    use sql_support::open_database;
+    use std::time::Duration;
+    use viaduct::{header_names, Headers, Method, Response};
+
+    fn create_test_request(url: &str, body: &[u8]) -> Request {
+        Request {
+            method: Method::Get,
+            url: url.parse().unwrap(),
+            headers: Headers::new(),
+            body: Some(body.to_vec()),
+        }
+    }
+
+    fn create_test_response(status: u16, body: &[u8]) -> Response {
+        let mut headers = Headers::new();
+        headers
+            .insert(header_names::CONTENT_TYPE, "application/json")
+            .unwrap();
+
+        Response {
+            request_method: Method::Get,
+            url: "https://example.com/test".parse().unwrap(),
+            status,
+            headers,
+            body: body.to_vec(),
+        }
+    }
+
+    fn create_test_store() -> HttpCacheStore {
+        let initializer = HttpCacheConnectionInitializer {};
+        let conn = open_database::open_memory_database(&initializer)
+            .expect("failed to open memory cache db");
+        HttpCacheStore::new(conn)
+    }
+
+    #[test]
+    fn test_store_and_retrieve() {
+        let store = create_test_store();
+
+        let request = create_test_request("https://example.com/api", b"test body");
+        let response = create_test_response(200, b"test response");
+
+        store.store(&request, &response).unwrap();
+
+        let retrieved = store.lookup(&request).unwrap().unwrap();
+        assert_eq!(retrieved.0.status, 200);
+        assert_eq!(retrieved.0.body, b"test response");
+    }
+
+    #[test]
+    fn test_ttl_expiration() {
+        let initializer = HttpCacheConnectionInitializer {};
+        let conn = open_database::open_memory_database(&initializer)
+            .expect("failed to open memory cache db");
+        let store = HttpCacheStore::new(conn);
+
+        let request = create_test_request("https://example.com/api", b"test body");
+        let response = create_test_response(200, b"test response");
+
+        store.store(&request, &response).unwrap();
+
+        let retrieved = store.lookup(&request).unwrap().unwrap();
+        assert_eq!(retrieved.0.body, b"test response");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        let retrieved_after_expiry = store.lookup(&request).unwrap();
+        assert!(retrieved_after_expiry.is_some());
+    }
+
+    #[test]
+    fn test_max_size_eviction() {
+        let initializer = HttpCacheConnectionInitializer {};
+        let conn = open_database::open_memory_database(&initializer)
+            .expect("failed to open memory cache db");
+        let store = HttpCacheStore::new(conn);
+
+        for i in 0..5 {
+            let request = create_test_request(&format!("https://example.com/api/{}", i), b"");
+            let large_body = vec![0u8; 300];
+            let response = create_test_response(200, &large_body);
+            store.store(&request, &response).unwrap();
+        }
+
+        // Trim to max size of 1024 bytes
+        store.trim_to_max_size(1024).unwrap();
+
+        let total_size = store.current_total_size().unwrap();
+        assert!(total_size <= 1024);
+
+        let first_request = create_test_request("https://example.com/api/0", b"");
+        let first_cached = store.lookup(&first_request).unwrap();
+        assert!(first_cached.is_none());
+    }
+
+    #[test]
+    fn test_no_store_directive() {
+        let store = create_test_store();
+        let request = create_test_request("https://example.com/api", b"test body");
+
+        let mut response = create_test_response(200, b"test response");
+        response
+            .headers
+            .insert("cache-control", "no-store")
+            .unwrap();
+
+        store.store(&request, &response).unwrap();
+        let retrieved = store.lookup(&request).unwrap();
+        assert!(retrieved.is_some());
+    }
+
+    #[test]
+    fn test_max_age_directive() {
+        let store = create_test_store();
+        let request = create_test_request("https://example.com/api", b"test body");
+
+        let mut response = create_test_response(200, b"test response");
+        response
+            .headers
+            .insert("cache-control", "max-age=1")
+            .unwrap();
+
+        store.store(&request, &response).unwrap();
+
+        // Should be cached initially
+        let retrieved = store.lookup(&request).unwrap();
+        assert!(retrieved.is_some());
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Should still be in store (expiration logic is in cache layer)
+        let retrieved = store.lookup(&request).unwrap();
+        assert!(retrieved.is_some());
+    }
+
+    #[test]
+    fn test_clear_all() {
+        let store = create_test_store();
+
+        let request1 = create_test_request("https://example.com/api1", b"test body 1");
+        let response1 = create_test_response(200, b"test response 1");
+        store.store(&request1, &response1).unwrap();
+
+        let request2 = create_test_request("https://example.com/api2", b"test body 2");
+        let response2 = create_test_response(200, b"test response 2");
+        store.store(&request2, &response2).unwrap();
+
+        // Verify both are cached
+        assert!(store.lookup(&request1).unwrap().is_some());
+        assert!(store.lookup(&request2).unwrap().is_some());
+
+        // Clear all entries
+        let deleted_count = store.clear_all().unwrap();
+        assert_eq!(deleted_count, 2);
+
+        // Verify both are cleared
+        assert!(store.lookup(&request1).unwrap().is_none());
+        assert!(store.lookup(&request2).unwrap().is_none());
+    }
+}

--- a/components/ads-client/src/instrument.rs
+++ b/components/ads-client/src/instrument.rs
@@ -25,7 +25,7 @@ fn get_telemetry_endpoint() -> String {
     TELEMETRY_ENDPONT.read().clone()
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TelemetryEvent {
     Init,

--- a/components/ads-client/src/models.rs
+++ b/components/ads-client/src/models.rs
@@ -18,14 +18,14 @@ where
     })
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
+#[derive(Debug, Deserialize, PartialEq, uniffi::Record, Serialize)]
 pub struct AdPlacementRequest {
     pub placement: String,
     pub count: u32,
     pub content: Option<AdContentCategory>,
 }
 
-#[derive(Debug, Serialize, PartialEq, Deserialize, uniffi::Enum)]
+#[derive(Debug, Deserialize, uniffi::Enum, PartialEq, Serialize)]
 pub enum IABAdUnitFormat {
     Billboard,
     SmartphoneBanner300,
@@ -44,7 +44,7 @@ pub enum IABAdUnitFormat {
     FeaturePhoneLargeBanner,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, Deserialize, uniffi::Enum)]
+#[derive(Clone, Copy, Debug, Deserialize, uniffi::Enum, PartialEq, Serialize)]
 pub enum IABContentTaxonomy {
     #[serde(rename = "IAB-1.0")]
     IAB1_0,
@@ -62,19 +62,19 @@ pub enum IABContentTaxonomy {
     IAB3_0,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
+#[derive(Debug, Deserialize, PartialEq, uniffi::Record, Serialize)]
 pub struct AdContentCategory {
     pub taxonomy: IABContentTaxonomy,
     pub categories: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, uniffi::Record)]
+#[derive(Debug, Deserialize, PartialEq, uniffi::Record, Serialize)]
 pub struct AdRequest {
     pub context_id: String,
     pub placements: Vec<AdPlacementRequest>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Deserialize, PartialEq, uniffi::Record, Serialize)]
 pub struct AdCallbacks {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     pub click: Option<String>,
@@ -84,7 +84,7 @@ pub struct AdCallbacks {
     pub report: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Deserialize, PartialEq, uniffi::Record, Serialize)]
 pub struct MozAd {
     pub alt_text: Option<String>,
     pub block_key: String,
@@ -94,7 +94,7 @@ pub struct MozAd {
     pub url: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Deserialize, PartialEq, uniffi::Record, Serialize)]
 pub struct AdResponse {
     #[serde(flatten)]
     pub data: HashMap<String, Vec<MozAd>>,

--- a/components/ads-client/src/test_utils.rs
+++ b/components/ads-client/src/test_utils.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use crate::{
+    http_cache::HttpCache,
     mars::DefaultMARSClient,
     models::{AdCallbacks, AdResponse, IABContentTaxonomy, MozAd},
     IABContent, MozAdsPlacement, MozAdsPlacementConfig,
@@ -131,5 +132,10 @@ pub fn get_example_happy_placements() -> HashMap<String, MozAdsPlacement> {
 }
 
 pub fn create_test_client(mock_server_url: String) -> DefaultMARSClient {
-    DefaultMARSClient::new_with_endpoint(TEST_CONTEXT_ID.to_string(), mock_server_url)
+    let http_cache = HttpCache::builder("test_client.db").build().unwrap();
+    DefaultMARSClient::new_with_endpoint(
+        TEST_CONTEXT_ID.to_string(),
+        mock_server_url,
+        Some(http_cache),
+    )
 }

--- a/components/viaduct/src/headers.rs
+++ b/components/viaduct/src/headers.rs
@@ -391,6 +391,7 @@ pub mod consts {
         (ACCEPT_ENCODING, "accept-encoding"),
         (ACCEPT, "accept"),
         (AUTHORIZATION, "authorization"),
+        (CACHE_CONTROL, "cache-control"),
         (CONTENT_TYPE, "content-type"),
         (ETAG, "etag"),
         (IF_NONE_MATCH, "if-none-match"),


### PR DESCRIPTION
- Auto-caches successful responses in SQLite to skip redundant API calls for ads data
- Configurable settings: DB path, max size (10MB default), TTL (5min default), auto-cleanup of expired entries
- Honors Cache-Control headers: Respects no-store, max-age, etc.
- LRU eviction: Drops oldest entries when size limit hit
- Drop-in replacement: Just use send() instead of direct HTTP calls and caching happens transparently

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
