### PR TITLE
Bug 2022743: Use 'async' for NimbusInterface.recordEventOrThrow [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Nimbus
 * The `MetricsHandler` interface now requires two additional methods: `record_database_load()` and `record_database_migration()`
 * In Kotlin expose `GleanMetrics.Pings.nimbusTargetingContext` as `Nimbus.Pings.nimbusTargetingContext` for downstream tests. ([#14542](https://github.com/mozilla/experimenter/issues/14542))
+* `recordEventOrThrow()` now returns `Deferred<Unit>` instead of `Job`. Callers must use `.await()` (instead of `.join()`) to observe exceptions thrown during event recording.
 
 [Full Changelog](In progress)
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -19,8 +19,10 @@ import androidx.annotation.WorkerThread
 import androidx.core.content.pm.PackageInfoCompat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -511,8 +513,8 @@ open class Nimbus(
     }
 
     @AnyThread
-    override fun recordEventOrThrow(count: Long, eventId: String): Job =
-        dbScope.launch {
+    override fun recordEventOrThrow(count: Long, eventId: String): Deferred<Unit> =
+        dbScope.async {
             nimbusClient.recordEvent(eventId, count)
         }
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -9,6 +9,8 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.AnyThread
 import androidx.annotation.RawRes
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import org.mozilla.experiments.nimbus.GleanMetrics.NimbusEvents
 import org.mozilla.experiments.nimbus.internal.AvailableExperiment
@@ -291,9 +293,9 @@ interface NimbusEventStore {
     fun recordEventSync(count: Long = 1, eventId: String) = Unit
 
     /**
-     * Records an event, returning a Job that allows the caller to catch any errors.
+     * Records an event, returning a Deferred that allows the caller to catch any errors via await().
      */
-    fun recordEventOrThrow(count: Long = 1, eventId: String): Job = Job()
+    fun recordEventOrThrow(count: Long = 1, eventId: String): Deferred<Unit> = CompletableDeferred(Unit)
 
     /**
      * Records an event as if it were emitted in the past.


### PR DESCRIPTION
In order to actually propegate the errors to the caller, we need to run the coroutine with 'async' instead of 'launch'.

https://kotlinlang.org/docs/exception-handling.html#exception-propagation

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - We added this recently for fenix which has not started using it yet. This fixes for fenix needs.
- [X] **Quality**: This PR builds and tests run cleanly
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - Consumer is fenix which will receive through nightly process automatically.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - We don't currently have the ability to force `recordEvent` failures with current interface. 
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - N/A
