### PR TITLE
Add breadcrumb when rate limiting fails to read the clock

### DIFF
--- a/components/support/error/src/error_tracing.rs
+++ b/components/support/error/src/error_tracing.rs
@@ -9,6 +9,8 @@ use std::{
 
 use parking_lot::Mutex;
 
+use crate::breadcrumb;
+
 static GLOBALS: Mutex<Globals> = Mutex::new(Globals::new());
 
 pub fn report_error_to_app(type_name: String, message: String) {
@@ -139,7 +141,9 @@ impl RateLimiter {
                 // with NTP, if users manually adjust their clocks, etc.  Letting an extra event
                 // through seems okay in this case. We should get back into a good state soon
                 // after.
-                _ => (),
+                _ => {
+                    breadcrumb!("error_support: checked_duration_since failed");
+                }
             }
         }
         last_report.insert(component.to_string(), now);


### PR DESCRIPTION
This rate limit check doesn't seem to be working in same cases, for example for https://bugzilla.mozilla.org/show_bug.cgi?id=2004954 I saw many reports per minute from the same user.  I'm wondering if the cause is this check failing.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
