### PR TITLE
Add the ability to start a new OAuth flow while authenticated, so you can authorize additional scopes [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - It is now enforced by `nimbus-fml` that feature variables using gecko-pref must be have `type: Option<T>`, for `T` in `Boolean`, `Int`, and `String`.
 - `nimbus-fml` commands now all have a `--lax-gecko-pref-validation` flag to bypass the above restriction, as well as the restriction that `gecko-pref` and `default` are mutually exclusive.
 - The `FmlLoaderConfig` now has a `lax_gecko_pref_validation` field to allow `FmlClient` consumers (i.e., Experimenter) to opt-in to lax validation.
+- The `fxa-client` crate's events for signing in now accept a "service" parameter. Specifying an empty string or "sync" are both suitable for now.
 
 ## ✨ What's New ✨
 

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -84,9 +84,12 @@ impl FirefoxAccount {
         // Allow both &[String] and &[&str] since UniFFI can't represent `&[&str]` yet,
         scopes: &[T],
         entrypoint: &str,
+        service: &str,
     ) -> ApiResult<String> {
         let scopes = scopes.iter().map(T::as_ref).collect::<Vec<_>>();
-        self.internal.lock().begin_oauth_flow(&scopes, entrypoint)
+        self.internal
+            .lock()
+            .begin_oauth_flow(service, &scopes, entrypoint)
     }
 
     /// Get the URL at which to begin a device-pairing signin flow.
@@ -129,12 +132,13 @@ impl FirefoxAccount {
         pairing_url: &str,
         scopes: &[String],
         entrypoint: &str,
+        service: &str,
     ) -> ApiResult<String> {
         // UniFFI can't represent `&[&str]` yet, so convert it internally here.
         let scopes = scopes.iter().map(String::as_str).collect::<Vec<_>>();
         self.internal
             .lock()
-            .begin_pairing_flow(pairing_url, &scopes, entrypoint)
+            .begin_pairing_flow(pairing_url, service, &scopes, entrypoint)
     }
 
     /// Complete an OAuth flow.
@@ -220,7 +224,7 @@ pub struct AuthorizationInfo {
 ///
 /// In the long-term, we should track that data in Rust, remove the wrapper, and rename this to
 /// `FxaAuthState`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FxaRustAuthState {
     Disconnected,
     Connected,
@@ -236,13 +240,27 @@ pub enum FxaState {
     Uninitialized,
     /// User has not connected to FxA or has logged out
     Disconnected,
-    /// User is currently performing an OAuth flow
-    Authenticating { oauth_url: String },
+    /// User is currently performing an OAuth flow - our existing initial state
+    /// when we transition to this state will influence what this means exactly.
+    Authenticating {
+        oauth_url: String,
+        initial_state: FxaRustAuthState,
+    },
     /// User is currently connected to FxA
     Connected,
     /// User was connected to FxA, but we observed issues with the auth tokens.
     /// The user needs to reauthenticate before the account can be used.
     AuthIssues,
+}
+
+impl From<FxaRustAuthState> for FxaState {
+    fn from(value: FxaRustAuthState) -> Self {
+        match value {
+            FxaRustAuthState::Connected => FxaState::Connected,
+            FxaRustAuthState::Disconnected => FxaState::Disconnected,
+            FxaRustAuthState::AuthIssues => FxaState::AuthIssues,
+        }
+    }
 }
 
 /// Fxa event
@@ -261,6 +279,7 @@ pub enum FxaEvent {
     /// the state machine is in the `Authenticating` state, then this will forget the current OAuth
     /// flow and start a new one.
     BeginOAuthFlow {
+        service: String,
         scopes: Vec<String>,
         entrypoint: String,
     },
@@ -274,6 +293,7 @@ pub enum FxaEvent {
     /// flow and start a new one.
     BeginPairingFlow {
         pairing_url: String,
+        service: String,
         scopes: Vec<String>,
         entrypoint: String,
     },

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -195,12 +195,10 @@ interface FirefoxAccount {
   ///       - This parameter is used for metrics purposes, to identify the
   ///         UX entrypoint from which the user triggered the signin request.
   ///         For example, the application toolbar, on the onboarding flow.
-  ///   - `metrics` - optionally, additional metrics tracking parameters.
-  ///       - These will be included as query parameters in the resulting URL.
-  ///
+  ///   - `service` - The service being signed up for.
+  //        - The combination of service and entrypoint may impact the UI shown.  
   [Throws=FxaError]
-  string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint);
-  
+  string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint, [ByRef] optional string service = "");
 
   /// Get the URL at which to begin a device-pairing signin flow.
   ///
@@ -234,11 +232,10 @@ interface FirefoxAccount {
   ///       - This parameter is used for metrics purposes, to identify the
   ///         UX entrypoint from which the user triggered the signin request.
   ///         For example, the application toolbar, on the onboarding flow.
-  ///   - `metrics` - optionally, additional metrics tracking parameters.
-  ///       - These will be included as query parameters in the resulting URL.
-  ///
+  ///   - `service` - The service being signed up for.
+  //        - The combination of service and entrypoint may impact the UI shown.  
   [Throws=FxaError]
-  string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint);
+  string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint, [ByRef] optional string service = "");
   
 
   /// Complete an OAuth flow.
@@ -258,7 +255,6 @@ interface FirefoxAccount {
   [Throws=FxaError]
   void complete_oauth_flow([ByRef] string code, [ByRef] string state );
   
-
   /// Check authorization status for this application.
   ///
   /// **💾 This method alters the persisted account state.**
@@ -1003,7 +999,7 @@ dictionary Profile {
 interface FxaState {
   Uninitialized();
   Disconnected();
-  Authenticating(string oauth_url);
+  Authenticating(string oauth_url, FxaRustAuthState initial_state);
   Connected();
   AuthIssues();
 };
@@ -1011,8 +1007,8 @@ interface FxaState {
 [Enum]
 interface FxaEvent {
   Initialize(DeviceConfig device_config);
-  BeginOAuthFlow(sequence<string> scopes, string entrypoint);
-  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint);
+  BeginOAuthFlow(string service, sequence<string> scopes, string entrypoint);
+  BeginPairingFlow(string pairing_url, string service, sequence<string> scopes, string entrypoint);
   CompleteOAuthFlow(string code, string state);
   CancelOAuthFlow();
   CheckAuthorizationStatus();

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -12,7 +12,9 @@ use super::{
     util, FirefoxAccount,
 };
 use crate::auth::UserData;
-use crate::{error, warn, AuthorizationParameters, Error, FxaServer, Result, ScopedKey};
+use crate::{
+    debug, error, info, warn, AuthorizationParameters, Error, FxaServer, Result, ScopedKey,
+};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use jwcrypto::{EncryptionAlgorithm, EncryptionParameters};
 use rate_limiter::RateLimiter;
@@ -20,7 +22,6 @@ use rc_crypto::digest;
 use serde_derive::*;
 use std::{
     collections::{HashMap, HashSet},
-    iter::FromIterator,
     time::{SystemTime, UNIX_EPOCH},
 };
 use url::Url;
@@ -165,11 +166,15 @@ impl FirefoxAccount {
     pub fn begin_pairing_flow(
         &mut self,
         pairing_url: &str,
+        service: &str,
         scopes: &[&str],
         entrypoint: &str,
     ) -> Result<String> {
         let mut url = self.state.config().pair_supp_url()?;
         url.query_pairs_mut().append_pair("entrypoint", entrypoint);
+        if !service.is_empty() {
+            url.query_pairs_mut().append_pair("service", service);
+        }
         let pairing_url = util::parse_url(pairing_url, "begin_pairing_flow")?;
         if url.host_str() != pairing_url.host_str() {
             let fxa_server = FxaServer::from(&url);
@@ -187,39 +192,50 @@ impl FirefoxAccount {
     /// * `scopes` - Space-separated list of requested scopes.
     /// * `entrypoint` - The entrypoint to be used for metrics
     /// * `metrics` - Optional metrics parameters
-    pub fn begin_oauth_flow(&mut self, scopes: &[&str], entrypoint: &str) -> Result<String> {
-        self.state.on_begin_oauth();
-        let mut url = if self.state.last_seen_profile().is_some() {
+    ///
+    /// Note that you can use this to either perform an initial signin, or use this on
+    /// an already signed in account to get more scopes for that account.
+    /// When obtaining more scopes, only the new scopes needed should be requested
+    /// rather than the union of all scopes - this is because asking for a scope with
+    /// keys (eg, sync) would force the UI to go through a different UI flow - eg, always
+    /// asking for your password, even though the new scopes requested doesn't actually
+    /// require that. This code therefore knows how to merge the scopes at the end of the
+    /// flow, so the end result remains a new refresh token with the union of scopes.
+    pub fn begin_oauth_flow(
+        &mut self,
+        service: &str,
+        scopes: &[&str],
+        entrypoint: &str,
+    ) -> Result<String> {
+        let needs_reauth =
+            self.state.last_seen_profile().is_some() && self.state.session_token().is_none();
+        let mut url = if needs_reauth {
+            // must be in a needs-reauth or other odd state. Not clear this is strictly needed.
+            // further, this is still somewhat wrong in a "needs reauth" state - there we will be
+            // looking to get back all scopes we previously had - and it's not really expected the client
+            // knows that. We probably need to stash the old scopes when we enter the needsreauth
+            // state. But that's a todo.
             self.state.config().oauth_force_auth_url()?
         } else {
             self.state.config().authorization_endpoint()?
         };
 
+        info!("starting oauth flow via {url} for service={service:?}, scopes={scopes:?}, entrypoint={entrypoint:?}");
         url.query_pairs_mut()
             .append_pair("action", "email")
             .append_pair("response_type", "code")
             .append_pair("entrypoint", entrypoint);
 
+        if !service.is_empty() {
+            url.query_pairs_mut().append_pair("service", service);
+        }
         if let Some(cached_profile) = self.state.last_seen_profile() {
             url.query_pairs_mut()
                 .append_pair("email", &cached_profile.response.email);
         }
 
-        let scopes: Vec<String> = match self.state.refresh_token() {
-            Some(refresh_token) => {
-                // Union of the already held scopes and the one requested.
-                let mut all_scopes: Vec<String> = vec![];
-                all_scopes.extend(scopes.iter().map(ToString::to_string));
-                let existing_scopes = refresh_token.scopes.clone();
-                all_scopes.extend(existing_scopes);
-                HashSet::<String>::from_iter(all_scopes)
-                    .into_iter()
-                    .collect()
-            }
-            None => scopes.iter().map(ToString::to_string).collect(),
-        };
-        let scopes: Vec<&str> = scopes.iter().map(<_>::as_ref).collect();
-        self.oauth_flow(url, &scopes)
+        debug!("oauth flow final set of requested scopes now {scopes:?}");
+        self.oauth_flow(url, scopes)
     }
 
     /// Fetch an OAuth code for a particular client using a session token from the account state.
@@ -350,13 +366,21 @@ impl FirefoxAccount {
             Some(oauth_flow) => oauth_flow,
             None => return Err(Error::UnknownOAuthState),
         };
+        // This new flow is going to end up with us having a refresh token, but with only the newly
+        // requested scopes. We'll then exchange that for one with the old scopes added.
         let resp = self.client.create_refresh_token_using_authorization_code(
             self.state.config(),
             self.state.session_token(),
             code,
             &oauth_flow.code_verifier,
         )?;
-        self.handle_oauth_response(resp, oauth_flow.scoped_keys_flow)
+        info!(
+            "complete oauth flow - new session token={}, new refresh token={}",
+            resp.session_token.is_some(),
+            resp.refresh_token.is_some()
+        );
+        self.handle_oauth_response(resp, oauth_flow.scoped_keys_flow)?;
+        Ok(())
     }
 
     /// Cancel any in-progress oauth flows
@@ -412,9 +436,11 @@ impl FirefoxAccount {
             warn!("Access token destruction failure: {:?}", err);
         }
         let old_refresh_token = self.state.refresh_token().cloned();
-        let new_refresh_token = resp
-            .refresh_token
-            .ok_or(Error::ApiClientError("No refresh token in response"))?;
+        let mut new_refresh_token = RefreshToken::new(
+            resp.refresh_token
+                .ok_or(Error::ApiClientError("No refresh token in response"))?,
+            resp.scope,
+        );
         // Destroying a refresh token also destroys its associated device,
         // grab the device information for replication later.
         let old_device_info = match old_refresh_token {
@@ -427,16 +453,78 @@ impl FirefoxAccount {
             },
             None => None,
         };
-        // In order to keep 1 and only 1 refresh token alive per client instance,
-        // we also destroy the existing refresh token.
-        if let Some(ref refresh_token) = old_refresh_token {
+
+        if let Some(ref old_refresh_token) = old_refresh_token {
+            // As described in the docs for `begin_oauth_flow`, we now have a new refresh token,
+            // but only with new scopes we explicitly requested.
+            // We possibly had an old refresh token with only the scopes we had before.
+            // In that scenario, we need to create yet another refresh token with merged scopes.
+            let existing_scopes = &old_refresh_token.scopes;
+            let all_scopes: HashSet<_> = existing_scopes
+                .union(&new_refresh_token.scopes)
+                .cloned()
+                .collect();
+            if all_scopes != new_refresh_token.scopes {
+                if let Some(session_token) = self.state.session_token() {
+                    info!("New refresh token is missing some of our old scopes, upgrading");
+                    // We'd prefer to call `exchange_token_for_scope` instead of `create_refresh_token_using_session_token`,
+                    // but that's not currently setup correctly for this.
+                    // NOTE: when we *do* call `exchange_token_for_scope` we shouldn't need to do the device reregistration
+                    // this as that's handled by the server in that scenario.
+                    let scopes_slice = all_scopes.iter().map(|s| s.as_ref()).collect::<Vec<&str>>();
+                    let merged_refresh_token_resp =
+                        self.client.create_refresh_token_using_session_token(
+                            self.state.config(),
+                            session_token,
+                            &scopes_slice,
+                        )?;
+                    let Some(merged_refresh_token_str) = merged_refresh_token_resp.refresh_token
+                    else {
+                        log::error!("server failed to give a new refresh token");
+                        return Err(Error::NoRefreshToken);
+                    };
+
+                    // now destroy the one we got from this response.
+                    if let Err(err) = self
+                        .client
+                        .destroy_refresh_token(self.state.config(), &new_refresh_token.token)
+                    {
+                        warn!(
+                            "Refresh token destruction failure of new refresh token: {:?}",
+                            err
+                        );
+                    }
+
+                    new_refresh_token = RefreshToken::new(
+                        merged_refresh_token_str,
+                        merged_refresh_token_resp.scope,
+                    );
+                } else {
+                    warn!("New refresh token is missing some of our old scopes, but don't have a session token to use to upgrade");
+                }
+            } else {
+                // this seems odd, but I guess not bad?
+                info!("New refresh token has the same scopes we started with");
+            }
+
+            // In order to keep 1 and only 1 refresh token alive per client instance,
+            // we also destroy the old refresh token.
             if let Err(err) = self
                 .client
-                .destroy_refresh_token(self.state.config(), &refresh_token.token)
+                .destroy_refresh_token(self.state.config(), &old_refresh_token.token)
             {
-                warn!("Refresh token destruction failure: {:?}", err);
+                warn!(
+                    "Refresh token destruction failure of old refresh token: {:?}",
+                    err
+                );
             }
+            // and clear the old refresh token from our state, just in case we encounter an error before
+            // we've set the new one as current.
+            self.state.clear_refresh_token();
         }
+
+        self.state
+            .complete_oauth_flow(scoped_keys, new_refresh_token, resp.session_token);
         if let Some(ref device_info) = old_device_info {
             if let Err(err) = self.replace_device(
                 &device_info.display_name,
@@ -446,12 +534,8 @@ impl FirefoxAccount {
             ) {
                 warn!("Device information restoration failed: {:?}", err);
             }
+            info!("restored device information with new refresh token");
         }
-        self.state.complete_oauth_flow(
-            scoped_keys,
-            RefreshToken::new(new_refresh_token, resp.scope),
-            resp.session_token,
-        );
         Ok(())
     }
 
@@ -658,7 +742,7 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_oauth_flow(&["profile"], "test_oauth_flow_url")
+            .begin_oauth_flow("", &["profile"], "test_oauth_flow_url")
             .unwrap();
         let flow_url = Url::parse(&url).unwrap();
 
@@ -728,7 +812,7 @@ mod tests {
         let email = "test@example.com";
         fxa.add_cached_profile("123", email);
         let url = fxa
-            .begin_oauth_flow(&["profile"], "test_force_auth_url")
+            .begin_oauth_flow("", &["profile"], "test_force_auth_url")
             .unwrap();
         let url = Url::parse(&url).unwrap();
         assert_eq!(url.path(), "/oauth/force_auth");
@@ -750,7 +834,7 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_oauth_flow(SCOPES, "test_webchannel_context_url")
+            .begin_oauth_flow("", SCOPES, "test_webchannel_context_url")
             .unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -772,7 +856,12 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_pairing_flow(PAIRING_URL, SCOPES, "test_webchannel_pairing_context_url")
+            .begin_pairing_flow(
+                PAIRING_URL,
+                "service",
+                SCOPES,
+                "test_webchannel_pairing_context_url",
+            )
             .unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -796,7 +885,7 @@ mod tests {
 
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_pairing_flow(PAIRING_URL, SCOPES, "test_pairing_flow_url")
+            .begin_pairing_flow(PAIRING_URL, "", SCOPES, "test_pairing_flow_url")
             .unwrap();
         let flow_url = Url::parse(&url).unwrap();
         let expected_parsed_url = Url::parse(EXPECTED_URL).unwrap();
@@ -864,6 +953,7 @@ mod tests {
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa.begin_pairing_flow(
             PAIRING_URL,
+            "service",
             &["https://identity.mozilla.com/apps/oldsync"],
             "test_pairiong_flow_origin_mismatch",
         );
@@ -1132,7 +1222,7 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_oauth_flow(&[OLD_SYNC, "profile"], "test_entrypoint")
+            .begin_oauth_flow("", &[OLD_SYNC, "profile"], "test_entrypoint")
             .unwrap();
         let url = Url::parse(&url).unwrap();
         let state = url.query_pairs().find(|(name, _)| name == "state").unwrap();
@@ -1171,5 +1261,230 @@ mod tests {
 
         fxa.complete_oauth_flow("mock_code", state.1.as_ref())
             .unwrap();
+    }
+
+    fn make_mock_device(name: &str) -> GetDeviceResponse {
+        use sync15::DeviceType;
+        GetDeviceResponse {
+            common: DeviceResponseCommon {
+                id: "device1".into(),
+                display_name: name.to_string(),
+                device_type: DeviceType::Desktop,
+                push_subscription: None,
+                available_commands: HashMap::new(),
+                push_endpoint_expired: false,
+            },
+            is_current_device: true,
+            location: DeviceLocation {
+                city: None,
+                country: None,
+                state: None,
+                state_code: None,
+            },
+            last_access_time: None,
+        }
+    }
+
+    fn make_mock_update_device_response() -> UpdateDeviceResponse {
+        use sync15::DeviceType;
+        UpdateDeviceResponse {
+            id: "device1".into(),
+            display_name: "Test Device".to_string(),
+            device_type: DeviceType::Desktop,
+            push_subscription: None,
+            available_commands: HashMap::new(),
+            push_endpoint_expired: false,
+        }
+    }
+
+    // Test that when we complete an oauth flow while already having a refresh token with
+    // different scopes, the new token is merged with the old scopes and the device is restored.
+    #[test]
+    fn test_complete_oauth_flow_merges_scopes_and_restores_device() {
+        nss::ensure_initialized();
+        let config = Config::new_with_mock_well_known_fxa_client_configuration(
+            "mock-fxa.example.com",
+            "12345678",
+            "https://foo.bar",
+        );
+        let mut fxa = FirefoxAccount::with_config(config);
+
+        // Start a flow before setting state, to register the pending oauth flow.
+        let url = fxa
+            .begin_oauth_flow("", &["new_scope"], "test_entrypoint")
+            .unwrap();
+        let url = Url::parse(&url).unwrap();
+        let state = url.query_pairs().find(|(name, _)| name == "state").unwrap();
+
+        // Pre-populate: existing refresh token (different scope) and a session token.
+        fxa.state.force_refresh_token(RefreshToken {
+            token: "old_refresh".to_string(),
+            scopes: ["profile".to_string()].into(),
+        });
+        fxa.set_session_token("mock_session_token");
+
+        let mut client = MockFxAClient::new();
+
+        // 1. Exchange auth code — returns narrow token with only the new scope.
+        client
+            .expect_create_refresh_token_using_authorization_code()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(OAuthTokenResponse {
+                    keys_jwe: None,
+                    refresh_token: Some("new_narrow_refresh".to_string()),
+                    session_token: None,
+                    expires_in: 3600,
+                    scope: "new_scope".to_string(),
+                    access_token: "access_token".to_string(),
+                })
+            });
+
+        // 2. Destroy the over-scoped access token.
+        client
+            .expect_destroy_access_token()
+            .with(always(), always())
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // 3. Fetch current device so it can be restored after token swap.
+        client
+            .expect_get_devices()
+            .with(always(), eq("old_refresh"))
+            .times(1)
+            .returning(|_, _| Ok(vec![make_mock_device("Test Device")]));
+
+        // 4. Get merged refresh token covering both old and new scopes.
+        client
+            .expect_create_refresh_token_using_session_token()
+            .withf(|_, session_token, _| session_token == "mock_session_token")
+            .times(1)
+            .returning(|_, _, _| {
+                Ok(OAuthTokenResponse {
+                    keys_jwe: None,
+                    refresh_token: Some("merged_refresh".to_string()),
+                    session_token: None,
+                    expires_in: 3600,
+                    scope: "profile new_scope".to_string(),
+                    access_token: "access_token2".to_string(),
+                })
+            });
+
+        // 5. Destroy the narrow new token (replaced by the merged one).
+        client
+            .expect_destroy_refresh_token()
+            .with(always(), eq("new_narrow_refresh"))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // 6. Destroy the old refresh token.
+        client
+            .expect_destroy_refresh_token()
+            .with(always(), eq("old_refresh"))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // 7. Restore the device record using the new merged refresh token.
+        client
+            .expect_update_device_record()
+            .times(1)
+            .returning(|_, _, _| Ok(make_mock_update_device_response()));
+
+        fxa.set_client(Arc::new(client));
+
+        fxa.complete_oauth_flow("mock_code", state.1.as_ref())
+            .unwrap();
+
+        let scopes = &fxa.state.refresh_token().unwrap().scopes;
+        assert!(
+            scopes.contains("profile"),
+            "expected profile scope, got {scopes:?}"
+        );
+        assert!(
+            scopes.contains("new_scope"),
+            "expected new_scope, got {scopes:?}"
+        );
+        assert_eq!(scopes.len(), 2);
+    }
+
+    // Test that when the new refresh token already covers all existing scopes, no merge
+    // is performed (no extra token request), but the old token is still destroyed and
+    // the device is restored.
+    #[test]
+    fn test_complete_oauth_flow_no_merge_when_scopes_match() {
+        nss::ensure_initialized();
+        let config = Config::new_with_mock_well_known_fxa_client_configuration(
+            "mock-fxa.example.com",
+            "12345678",
+            "https://foo.bar",
+        );
+        let mut fxa = FirefoxAccount::with_config(config);
+
+        let url = fxa
+            .begin_oauth_flow("", &["profile"], "test_entrypoint")
+            .unwrap();
+        let url = Url::parse(&url).unwrap();
+        let state = url.query_pairs().find(|(name, _)| name == "state").unwrap();
+
+        fxa.state.force_refresh_token(RefreshToken {
+            token: "old_refresh".to_string(),
+            scopes: ["profile".to_string()].into(),
+        });
+        fxa.set_session_token("mock_session_token");
+
+        let mut client = MockFxAClient::new();
+
+        // 1. Exchange auth code — returns token with same scopes as before.
+        client
+            .expect_create_refresh_token_using_authorization_code()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(OAuthTokenResponse {
+                    keys_jwe: None,
+                    refresh_token: Some("new_refresh".to_string()),
+                    session_token: None,
+                    expires_in: 3600,
+                    scope: "profile".to_string(),
+                    access_token: "access_token".to_string(),
+                })
+            });
+
+        // 2. Destroy the over-scoped access token.
+        client
+            .expect_destroy_access_token()
+            .with(always(), always())
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // 3. Fetch current device for restoration.
+        client
+            .expect_get_devices()
+            .with(always(), eq("old_refresh"))
+            .times(1)
+            .returning(|_, _| Ok(vec![make_mock_device("Test Device")]));
+
+        // No create_refresh_token_using_session_token — scopes already match.
+        // No destroy of the new token — it becomes our token directly.
+
+        // 4. Destroy only the old refresh token.
+        client
+            .expect_destroy_refresh_token()
+            .with(always(), eq("old_refresh"))
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // 5. Restore the device record.
+        client
+            .expect_update_device_record()
+            .times(1)
+            .returning(|_, _, _| Ok(make_mock_update_device_response()));
+
+        fxa.set_client(Arc::new(client));
+
+        fxa.complete_oauth_flow("mock_code", state.1.as_ref())
+            .unwrap();
+
+        let scopes = &fxa.state.refresh_token().unwrap().scopes;
+        assert_eq!(scopes, &["profile".to_string()].into());
     }
 }

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -231,19 +231,6 @@ impl StateManager {
         self.flow_store.clear();
     }
 
-    /// Called when we begin an OAuth flow.
-    ///
-    /// This clears out tokens/keys set from the previous time we completed an oauth flow.  In
-    /// particular, it clears the session token to avoid
-    /// https://bugzilla.mozilla.org/show_bug.cgi?id=1887071.
-    pub fn on_begin_oauth(&mut self) {
-        self.persisted_state.refresh_token = None;
-        self.persisted_state.scoped_keys = HashMap::new();
-        self.persisted_state.commands_data = HashMap::new();
-        self.persisted_state.access_token_cache = HashMap::new();
-        self.persisted_state.session_token = None;
-    }
-
     pub fn get_auth_state(&self) -> FxaRustAuthState {
         if self.persisted_state.refresh_token.is_some() {
             FxaRustAuthState::Connected
@@ -268,6 +255,12 @@ impl StateManager {
     /// Update the refresh token only
     pub fn update_refresh_token(&mut self, token: RefreshToken) {
         self.persisted_state.refresh_token = Some(token);
+        self.persisted_state.access_token_cache.clear();
+    }
+
+    /// Clear the refresh token after it was revoked.
+    pub fn clear_refresh_token(&mut self) {
+        self.persisted_state.refresh_token = None;
         self.persisted_state.access_token_cache.clear();
     }
 

--- a/components/fxa-client/src/state_machine/internal_machines/auth_issues.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/auth_issues.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{invalid_transition, Event, InternalStateMachine, State};
-use crate::{Error, FxaEvent, FxaState, Result};
+use crate::{Error, FxaEvent, FxaRustAuthState, FxaState, Result};
 use error_support::report_error;
 
 pub struct AuthIssuesStateMachine;
@@ -15,9 +15,15 @@ use State::*;
 impl InternalStateMachine for AuthIssuesStateMachine {
     fn initial_state(&self, event: FxaEvent) -> Result<State> {
         match event {
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => Ok(BeginOAuthFlow {
+            FxaEvent::BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+            } => Ok(BeginOAuthFlow {
+                service: service.clone(),
                 scopes: scopes.clone(),
                 entrypoint: entrypoint.clone(),
+                initial_state: FxaRustAuthState::AuthIssues,
             }),
             FxaEvent::Disconnect => Ok(Disconnect),
             e => Err(Error::InvalidStateTransition(format!("AuthIssues -> {e}"))),
@@ -34,7 +40,10 @@ impl InternalStateMachine for AuthIssuesStateMachine {
                 Complete(FxaState::Disconnected)
             }
             (BeginOAuthFlow { .. }, BeginOAuthFlowSuccess { oauth_url }) => {
-                Complete(FxaState::Authenticating { oauth_url })
+                Complete(FxaState::Authenticating {
+                    oauth_url,
+                    initial_state: FxaRustAuthState::AuthIssues,
+                })
             }
             (BeginOAuthFlow { .. }, CallError) => Cancel,
             (state, event) => return invalid_transition(state, event),
@@ -52,6 +61,7 @@ mod test {
         let tester = StateMachineTester::new(
             AuthIssuesStateMachine,
             FxaEvent::BeginOAuthFlow {
+                service: "service".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
             },
@@ -60,17 +70,20 @@ mod test {
         assert_eq!(
             tester.state,
             BeginOAuthFlow {
+                service: "service".to_owned(),
                 scopes: vec!["profile".to_owned()],
-                entrypoint: "test-entrypoint".to_owned()
+                entrypoint: "test-entrypoint".to_owned(),
+                initial_state: FxaRustAuthState::AuthIssues,
             }
         );
         assert_eq!(tester.peek_next_state(CallError), Cancel);
         assert_eq!(
             tester.peek_next_state(BeginOAuthFlowSuccess {
-                oauth_url: "http://example.com/oauth-start".to_owned()
+                oauth_url: "http://example.com/oauth-start".to_owned(),
             }),
             Complete(FxaState::Authenticating {
                 oauth_url: "http://example.com/oauth-start".to_owned(),
+                initial_state: FxaRustAuthState::AuthIssues,
             })
         );
     }

--- a/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{invalid_transition, Event, InternalStateMachine, State};
-use crate::{Error, FxaEvent, FxaState, Result};
+use crate::{Error, FxaEvent, FxaRustAuthState, FxaState, Result};
 use error_support::report_error;
 
-pub struct AuthenticatingStateMachine;
+pub struct AuthenticatingStateMachine {
+    pub initial_state: FxaRustAuthState,
+}
 
 // Save some typing
 use Event::*;
@@ -18,22 +20,34 @@ impl InternalStateMachine for AuthenticatingStateMachine {
             FxaEvent::CompleteOAuthFlow { code, state } => Ok(CompleteOAuthFlow {
                 code: code.clone(),
                 state: state.clone(),
+                initial_state: self.initial_state,
             }),
-            FxaEvent::CancelOAuthFlow => Ok(Complete(FxaState::Disconnected)),
+            FxaEvent::CancelOAuthFlow => Ok(Complete(self.initial_state.into())),
             FxaEvent::Disconnect => Ok(Disconnect),
             // These next 2 cases allow apps to begin a new oauth flow when we're already in the
-            // middle of an existing one.
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => {
-                Ok(State::BeginOAuthFlow { scopes, entrypoint })
-            }
+            // middle of an existing one. (Supporting new flows in this state makes sense, but
+            // allowing multiple active flows, which we kinda do, probably doesn't really work?)
+            FxaEvent::BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+            } => Ok(State::BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+                initial_state: self.initial_state,
+            }),
             FxaEvent::BeginPairingFlow {
+                service,
                 pairing_url,
                 scopes,
                 entrypoint,
             } => Ok(State::BeginPairingFlow {
+                service,
                 pairing_url,
                 scopes,
                 entrypoint,
+                initial_state: self.initial_state,
             }),
             e => Err(Error::InvalidStateTransition(format!(
                 "Authenticating -> {e}"
@@ -43,8 +57,15 @@ impl InternalStateMachine for AuthenticatingStateMachine {
 
     fn next_state(&self, state: State, event: Event) -> Result<State> {
         Ok(match (state, event) {
+            (
+                CompleteOAuthFlow {
+                    initial_state: FxaRustAuthState::Connected,
+                    ..
+                },
+                CompleteOAuthFlowSuccess,
+            ) => Complete(FxaState::Connected),
             (CompleteOAuthFlow { .. }, CompleteOAuthFlowSuccess) => InitializeDevice,
-            (CompleteOAuthFlow { .. }, CallError) => Complete(FxaState::Disconnected),
+            (CompleteOAuthFlow { .. }, CallError) => Complete(self.initial_state.into()),
             (Disconnect, DisconnectSuccess) => Complete(FxaState::Disconnected),
             (Disconnect, CallError) => {
                 // disconnect() is currently infallible, but let's handle errors anyway in case we
@@ -54,14 +75,20 @@ impl InternalStateMachine for AuthenticatingStateMachine {
             }
             (InitializeDevice, InitializeDeviceSuccess) => Complete(FxaState::Connected),
             (InitializeDevice, CallError) => Complete(FxaState::Disconnected),
-            (BeginOAuthFlow { .. }, BeginOAuthFlowSuccess { oauth_url }) => {
-                Complete(FxaState::Authenticating { oauth_url })
+            (BeginOAuthFlow { initial_state, .. }, BeginOAuthFlowSuccess { oauth_url }) => {
+                Complete(FxaState::Authenticating {
+                    oauth_url,
+                    initial_state,
+                })
             }
-            (BeginPairingFlow { .. }, BeginPairingFlowSuccess { oauth_url }) => {
-                Complete(FxaState::Authenticating { oauth_url })
+            (BeginPairingFlow { initial_state, .. }, BeginPairingFlowSuccess { oauth_url }) => {
+                Complete(FxaState::Authenticating {
+                    oauth_url,
+                    initial_state,
+                })
             }
-            (BeginOAuthFlow { .. }, CallError) => Complete(FxaState::Disconnected),
-            (BeginPairingFlow { .. }, CallError) => Complete(FxaState::Disconnected),
+            (BeginOAuthFlow { .. }, CallError) => Complete(self.initial_state.into()),
+            (BeginPairingFlow { .. }, CallError) => Complete(self.initial_state.into()),
             (state, event) => return invalid_transition(state, event),
         })
     }
@@ -75,7 +102,9 @@ mod test {
     #[test]
     fn test_complete_oauth_flow() {
         let mut tester = StateMachineTester::new(
-            AuthenticatingStateMachine,
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Disconnected,
+            },
             FxaEvent::CompleteOAuthFlow {
                 code: "test-code".to_owned(),
                 state: "test-state".to_owned(),
@@ -86,6 +115,7 @@ mod test {
             CompleteOAuthFlow {
                 code: "test-code".to_owned(),
                 state: "test-state".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             }
         );
         assert_eq!(
@@ -106,9 +136,58 @@ mod test {
     }
 
     #[test]
+    fn test_complete_oauth_flow_connected() {
+        let mut tester = StateMachineTester::new(
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Connected,
+            },
+            FxaEvent::CompleteOAuthFlow {
+                code: "test-code".to_owned(),
+                state: "test-state".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.state,
+            CompleteOAuthFlow {
+                code: "test-code".to_owned(),
+                state: "test-state".to_owned(),
+                initial_state: FxaRustAuthState::Connected,
+            }
+        );
+        assert_eq!(
+            tester.peek_next_state(CallError),
+            Complete(FxaState::Connected)
+        );
+
+        tester.next_state(CompleteOAuthFlowSuccess);
+        assert_eq!(tester.state, Complete(FxaState::Connected));
+    }
+
+    #[test]
     fn test_cancel_oauth_flow() {
-        let tester = StateMachineTester::new(AuthenticatingStateMachine, FxaEvent::CancelOAuthFlow);
+        let tester = StateMachineTester::new(
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Connected,
+            },
+            FxaEvent::CancelOAuthFlow,
+        );
+        assert_eq!(tester.state, Complete(FxaState::Connected));
+
+        let tester = StateMachineTester::new(
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Disconnected,
+            },
+            FxaEvent::CancelOAuthFlow,
+        );
         assert_eq!(tester.state, Complete(FxaState::Disconnected));
+
+        let tester = StateMachineTester::new(
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::AuthIssues,
+            },
+            FxaEvent::CancelOAuthFlow,
+        );
+        assert_eq!(tester.state, Complete(FxaState::AuthIssues));
     }
 
     /// Test what happens if we get the `BeginOAuthFlow` when we're already in the middle of
@@ -119,8 +198,11 @@ mod test {
     #[test]
     fn test_begin_oauth_flow() {
         let tester = StateMachineTester::new(
-            AuthenticatingStateMachine,
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Disconnected,
+            },
             FxaEvent::BeginOAuthFlow {
+                service: "service".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
             },
@@ -128,8 +210,10 @@ mod test {
         assert_eq!(
             tester.state,
             BeginOAuthFlow {
+                service: "service".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             }
         );
         assert_eq!(
@@ -142,6 +226,7 @@ mod test {
             }),
             Complete(FxaState::Authenticating {
                 oauth_url: "http://example.com/oauth-start".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             })
         );
     }
@@ -150,8 +235,11 @@ mod test {
     #[test]
     fn test_begin_pairing_flow() {
         let tester = StateMachineTester::new(
-            AuthenticatingStateMachine,
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Disconnected,
+            },
             FxaEvent::BeginPairingFlow {
+                service: "service".to_owned(),
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
@@ -160,9 +248,11 @@ mod test {
         assert_eq!(
             tester.state,
             BeginPairingFlow {
+                service: "service".to_owned(),
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             }
         );
         assert_eq!(
@@ -175,13 +265,19 @@ mod test {
             }),
             Complete(FxaState::Authenticating {
                 oauth_url: "http://example.com/oauth-start".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             })
         );
     }
 
     #[test]
     fn test_disconnect_during_oauth_flow() {
-        let tester = StateMachineTester::new(AuthenticatingStateMachine, FxaEvent::Disconnect);
+        let tester = StateMachineTester::new(
+            AuthenticatingStateMachine {
+                initial_state: FxaRustAuthState::Disconnected,
+            },
+            FxaEvent::Disconnect,
+        );
         assert_eq!(
             tester.peek_next_state(CallError),
             Complete(FxaState::Disconnected)

--- a/components/fxa-client/src/state_machine/internal_machines/connected.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/connected.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{invalid_transition, Event, InternalStateMachine, State};
-use crate::{Error, FxaEvent, FxaState, Result};
+use crate::{Error, FxaEvent, FxaRustAuthState, FxaState, Result};
 use error_support::report_error;
 
 pub struct ConnectedStateMachine;
@@ -18,6 +18,16 @@ impl InternalStateMachine for ConnectedStateMachine {
             FxaEvent::Disconnect => Ok(Disconnect),
             FxaEvent::CheckAuthorizationStatus => Ok(CheckAuthorizationStatus),
             FxaEvent::CallGetProfile => Ok(GetProfile),
+            FxaEvent::BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+            } => Ok(BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+                initial_state: FxaRustAuthState::Connected,
+            }),
             e => Err(Error::InvalidStateTransition(format!("Connected -> {e}"))),
         }
     }
@@ -41,6 +51,13 @@ impl InternalStateMachine for ConnectedStateMachine {
             (GetProfile, GetProfileSuccess) => Complete(FxaState::Connected),
             (GetProfile, CallError) => Complete(FxaState::AuthIssues),
             (CheckAuthorizationStatus, CallError) => Complete(FxaState::AuthIssues),
+            (BeginOAuthFlow { initial_state, .. }, BeginOAuthFlowSuccess { oauth_url }) => {
+                Complete(FxaState::Authenticating {
+                    oauth_url,
+                    initial_state,
+                })
+            }
+            (BeginOAuthFlow { .. }, CallError) => Cancel,
             (state, event) => return invalid_transition(state, event),
         })
     }

--- a/components/fxa-client/src/state_machine/internal_machines/disconnected.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/disconnected.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{invalid_transition, Event, InternalStateMachine, State};
-use crate::{Error, FxaEvent, FxaState, Result};
+use crate::{Error, FxaEvent, FxaRustAuthState, FxaState, Result};
 
 pub struct DisconnectedStateMachine;
 
@@ -14,17 +14,27 @@ use State::*;
 impl InternalStateMachine for DisconnectedStateMachine {
     fn initial_state(&self, event: FxaEvent) -> Result<State> {
         match event {
-            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => {
-                Ok(State::BeginOAuthFlow { scopes, entrypoint })
-            }
+            FxaEvent::BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+            } => Ok(State::BeginOAuthFlow {
+                service,
+                scopes,
+                entrypoint,
+                initial_state: FxaRustAuthState::Disconnected,
+            }),
             FxaEvent::BeginPairingFlow {
                 pairing_url,
+                service,
                 scopes,
                 entrypoint,
             } => Ok(State::BeginPairingFlow {
                 pairing_url,
+                service,
                 scopes,
                 entrypoint,
+                initial_state: FxaRustAuthState::Disconnected,
             }),
             e => Err(Error::InvalidStateTransition(format!(
                 "Disconnected -> {e}"
@@ -35,10 +45,16 @@ impl InternalStateMachine for DisconnectedStateMachine {
     fn next_state(&self, state: State, event: Event) -> Result<State> {
         Ok(match (state, event) {
             (BeginOAuthFlow { .. }, BeginOAuthFlowSuccess { oauth_url }) => {
-                Complete(FxaState::Authenticating { oauth_url })
+                Complete(FxaState::Authenticating {
+                    oauth_url,
+                    initial_state: FxaRustAuthState::Disconnected,
+                })
             }
             (BeginPairingFlow { .. }, BeginPairingFlowSuccess { oauth_url }) => {
-                Complete(FxaState::Authenticating { oauth_url })
+                Complete(FxaState::Authenticating {
+                    oauth_url,
+                    initial_state: FxaRustAuthState::Disconnected,
+                })
             }
             (BeginOAuthFlow { .. }, CallError) => Cancel,
             (BeginPairingFlow { .. }, CallError) => Cancel,
@@ -57,6 +73,7 @@ mod test {
         let tester = StateMachineTester::new(
             DisconnectedStateMachine,
             FxaEvent::BeginOAuthFlow {
+                service: "service".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
             },
@@ -64,8 +81,10 @@ mod test {
         assert_eq!(
             tester.state,
             BeginOAuthFlow {
+                service: "service".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             }
         );
         assert_eq!(tester.peek_next_state(CallError), Cancel);
@@ -75,6 +94,7 @@ mod test {
             }),
             Complete(FxaState::Authenticating {
                 oauth_url: "http://example.com/oauth-start".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             })
         );
     }
@@ -84,6 +104,7 @@ mod test {
         let tester = StateMachineTester::new(
             DisconnectedStateMachine,
             FxaEvent::BeginPairingFlow {
+                service: "service".to_owned(),
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
@@ -92,9 +113,11 @@ mod test {
         assert_eq!(
             tester.state,
             BeginPairingFlow {
+                service: "service".to_owned(),
                 pairing_url: "https://example.com/pairing-url".to_owned(),
                 scopes: vec!["profile".to_owned()],
                 entrypoint: "test-entrypoint".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             }
         );
         assert_eq!(tester.peek_next_state(CallError), Cancel);
@@ -104,6 +127,7 @@ mod test {
             }),
             Complete(FxaState::Authenticating {
                 oauth_url: "http://example.com/oauth-start".to_owned(),
+                initial_state: FxaRustAuthState::Disconnected,
             })
         );
     }

--- a/components/fxa-client/src/state_machine/internal_machines/mod.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/mod.rs
@@ -39,17 +39,24 @@ pub trait InternalStateMachine {
 pub enum State {
     GetAuthState,
     BeginOAuthFlow {
+        service: String,
         scopes: Vec<String>,
         entrypoint: String,
+        // The auth state of the account when beginning the flow.
+        initial_state: FxaRustAuthState,
     },
     BeginPairingFlow {
+        service: String,
         pairing_url: String,
         scopes: Vec<String>,
         entrypoint: String,
+        // The auth state of the account when beginning the flow.
+        initial_state: FxaRustAuthState,
     },
     CompleteOAuthFlow {
         code: String,
         state: String,
+        initial_state: FxaRustAuthState,
     },
     InitializeDevice,
     EnsureDeviceCapabilities,
@@ -124,23 +131,31 @@ impl State {
                 account.ensure_capabilities(&device_config.capabilities)?;
                 Event::EnsureDeviceCapabilitiesSuccess
             }
-            State::BeginOAuthFlow { scopes, entrypoint } => {
-                account.cancel_existing_oauth_flows();
-                let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
-                let oauth_url = account.begin_oauth_flow(&scopes, entrypoint)?;
-                Event::BeginOAuthFlowSuccess { oauth_url }
-            }
-            State::BeginPairingFlow {
-                pairing_url,
+            State::BeginOAuthFlow {
+                service,
                 scopes,
                 entrypoint,
+                ..
             } => {
                 account.cancel_existing_oauth_flows();
                 let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
-                let oauth_url = account.begin_pairing_flow(pairing_url, &scopes, entrypoint)?;
+                let oauth_url = account.begin_oauth_flow(service, &scopes, entrypoint)?;
+                Event::BeginOAuthFlowSuccess { oauth_url }
+            }
+            State::BeginPairingFlow {
+                service,
+                pairing_url,
+                scopes,
+                entrypoint,
+                ..
+            } => {
+                account.cancel_existing_oauth_flows();
+                let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
+                let oauth_url =
+                    account.begin_pairing_flow(pairing_url, service, &scopes, entrypoint)?;
                 Event::BeginPairingFlowSuccess { oauth_url }
             }
-            State::CompleteOAuthFlow { code, state } => {
+            State::CompleteOAuthFlow { code, state, .. } => {
                 account.complete_oauth_flow(code, state)?;
                 Event::CompleteOAuthFlowSuccess
             }

--- a/components/fxa-client/src/state_machine/mod.rs
+++ b/components/fxa-client/src/state_machine/mod.rs
@@ -42,10 +42,13 @@ impl FirefoxAccount {
                 internal_machines::DisconnectedStateMachine,
                 event,
             )?,
-            FxaState::Authenticating { .. } => self.process_event_with_internal_state_machine(
-                internal_machines::AuthenticatingStateMachine,
-                event,
-            )?,
+            FxaState::Authenticating { initial_state, .. } => self
+                .process_event_with_internal_state_machine(
+                    internal_machines::AuthenticatingStateMachine {
+                        initial_state: *initial_state,
+                    },
+                    event,
+                )?,
             FxaState::Connected => self.process_event_with_internal_state_machine(
                 internal_machines::ConnectedStateMachine,
                 event,
@@ -95,8 +98,9 @@ impl FirefoxAccount {
                 state => {
                     let event = state.make_call(self, &device_config)?;
                     let event_msg = event.to_string();
-                    internal_state = state_machine.next_state(state, event)?;
-                    breadcrumb!("FxaStateMachine.process_event {event_msg} -> {internal_state}")
+                    let next_state = state_machine.next_state(state, event);
+                    breadcrumb!("FxaStateMachine.process_event {event_msg} -> {next_state:?}");
+                    internal_state = next_state?;
                 }
             }
         }

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -8,7 +8,9 @@ use std::{collections::HashMap, fs, io::Write};
 use anyhow::Result;
 use url::Url;
 
-use fxa_client::{DeviceConfig, DeviceType, FirefoxAccount, FxaConfig, FxaEvent, FxaState};
+use fxa_client::{
+    DeviceConfig, DeviceType, FirefoxAccount, FxaConfig, FxaError, FxaEvent, FxaState,
+};
 use sync15::{client::Sync15StorageClientInit, KeyBundle};
 
 use crate::{prompt::prompt_string, workspace_root_dir};
@@ -113,6 +115,7 @@ impl CliFxa {
     /// Uses the state machine: `Initialize` → `BeginOAuthFlow` if needed → `CompleteOAuthFlow`.
     /// Persists credentials after a successful login.
     pub fn ensure_logged_in(&mut self, scopes: &[&str]) -> Result<&FirefoxAccount> {
+        let service = ""; // TODO: expose this.
         if self.account.is_none() {
             crate::info!("Creating new FxA account object");
             self.account = Some(FirefoxAccount::new(self.config.clone()));
@@ -124,20 +127,36 @@ impl CliFxa {
             capabilities: vec![],
         };
 
-        let state = self
-            .account
-            .as_mut()
-            .unwrap()
-            .process_event(FxaEvent::Initialize { device_config })?;
+        let account = self.account.as_mut().unwrap();
+
+        let state = account.process_event(FxaEvent::Initialize { device_config })?;
 
         match state {
             FxaState::Connected => {
-                crate::info!("FxA: already connected");
+                crate::info!("FxA: already connected - checking if we have all the scopes.");
+                let mut have_all_scopes = true;
+                for scope in scopes {
+                    match account.get_access_token(scope, true) {
+                        Ok(_) => crate::debug!("Do already have the {scope:?} scope"),
+                        Err(FxaError::Forbidden) => {
+                            crate::info!("Don't have the {scope:?} scope, re-authenticating");
+                            have_all_scopes = false;
+                            break;
+                        }
+                        Err(e) => {
+                            crate::error!("Error checking for the {scope:?} scope: {e}");
+                            return Err(e.into());
+                        }
+                    }
+                }
+                if !have_all_scopes {
+                    self.handle_oauth_flow(service, scopes)?;
+                }
                 self.persist()?;
             }
             FxaState::Disconnected | FxaState::AuthIssues => {
                 crate::info!("FxA: need to authenticate (state was {state:?})");
-                self.handle_oauth_flow(scopes)?;
+                self.handle_oauth_flow(service, scopes)?;
             }
             other => {
                 anyhow::bail!("Unexpected FxA state after Initialize: {other:?}");
@@ -210,7 +229,7 @@ impl CliFxa {
     }
 
     /// Run the interactive browser OAuth flow and complete the login.
-    fn handle_oauth_flow(&mut self, scopes: &[&str]) -> Result<()> {
+    fn handle_oauth_flow(&mut self, service: &str, scopes: &[&str]) -> Result<()> {
         let scopes: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
 
         let state = self
@@ -218,12 +237,13 @@ impl CliFxa {
             .as_mut()
             .unwrap()
             .process_event(FxaEvent::BeginOAuthFlow {
+                service: service.to_owned(),
                 scopes,
                 entrypoint: OAUTH_ENTRYPOINT.to_owned(),
             })?;
 
         let oauth_url = match state {
-            FxaState::Authenticating { oauth_url } => oauth_url,
+            FxaState::Authenticating { oauth_url, .. } => oauth_url,
             other => anyhow::bail!("Unexpected FxA state after BeginOAuthFlow: {other:?}"),
         };
 
@@ -249,6 +269,10 @@ impl CliFxa {
         match state {
             FxaState::Connected => {
                 crate::info!("FxA: OAuth flow complete, now connected");
+                self.persist()
+            }
+            FxaState::Disconnected => {
+                crate::warn!("FxA: OAuth flow failed to complete, account is not connected");
                 self.persist()
             }
             other => anyhow::bail!("Unexpected FxA state after CompleteOAuthFlow: {other:?}"),

--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use remote_settings::{RemoteSettingsConfig, RemoteSettingsServer, RemoteSettingsService};
-pub use tracing_support::{debug, error, info, warn};
+pub use tracing_support::{debug, error, info, trace, warn};
 
 pub mod fxa_creds;
 pub mod prompt;

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -109,8 +109,8 @@ fn main() -> Result<()> {
                 Command::SendTab(args) => send_tab::run(account, args)?,
                 Command::GetAccessToken { scope } => {
                     println!("Requesting access token with scope: {scope}");
-                    account.get_access_token(&scope, false)?;
-                    println!("Success");
+                    let tok = account.get_access_token(&scope, false)?;
+                    println!("Success: {tok:?}");
                 }
                 Command::Disconnect => {
                     account.disconnect();


### PR DESCRIPTION
As @jonalmeida and I were chatting about. @bendk does this look correct to you? @LZoog and @skhamis for some context for our slack messages.

This supports desktop-like flows, where a user is already signed in to (say) Sync, but not wants to authorize "vpn" or "smartwindow".

I used the term "Authorization" to try and reflect we aren't expected to "authenticate" here - we are already authenticated - we typically expect just a confirmation button. I'm not entirely convinced the distinction between "authorize" and "authenticate" is enough, so the names might be confusing - I started with something like "UpgradeScopes" etc. Regardless, better names welcome here.

I've tried to keep the names consistent, which made them verbose. Better names welcome here too.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
