### PR TITLE
feat(ads-client): add OHTTP support (AC-94)

### DIFF
--- a/.github/workflows/ads-client-tests.yaml
+++ b/.github/workflows/ads-client-tests.yaml
@@ -24,5 +24,21 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
           rustup toolchain install
+      - name: Build NSS
+        env:
+          NSS_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/nss
+          NSS_STATIC: 1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build zlib1g-dev tclsh python3
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install --upgrade pip setuptools six
+          git clone https://chromium.googlesource.com/external/gyp.git tools/gyp
+          cd tools/gyp && pip install . && cd ../..
+          ./libs/verify-desktop-environment.sh
       - name: Run ads-client integration tests against MARS staging
+        env:
+          NSS_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/nss
+          NSS_STATIC: 1
         run: cargo test -p ads-client-integration-tests -- --ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## ✨ What's New ✨
 
+### Ads Client
+- Add per-request OHTTP support via the `ohttp` flag on `MozAdsRequestOptions` and `MozAdsCallbackOptions`. When enabled, individual MARS requests are routed through viaduct's OHTTP layer with automatic preflight for geo/user-agent override headers.
+
 ### Logins
 - New `allow_empty_passwords` feature flag to allow storing logins with empty passwords. This feature is intended to be enabled on desktop during the migration.
 - Add `ignore_form_action_origin_validation_errors` feature flag that allows logins with non-URL `form_action_origin` values (e.g. "email", "UserCode") to be imported without error. URL normalization for valid URLs is still applied.

--- a/components/ads-client/Cargo.toml
+++ b/components/ads-client/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1.5"
 uniffi = { version = "0.31" }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4"] }
-viaduct = { path = "../viaduct" }
+viaduct = { path = "../viaduct", features = ["ohttp"] }
 sql-support = { path = "../support/sql" }
 
 [dev-dependencies]

--- a/components/ads-client/docs/usage-javascript.md
+++ b/components/ads-client/docs/usage-javascript.md
@@ -37,9 +37,9 @@ const client = MozAdsClientBuilder()
 | Method                                                                              | Return Type                               | Description                                                                                                                                                                          |
 | ----------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `clearCache()`                                                                      | `void`                                    | Clears the client's HTTP cache. Throws on failure.                                                                                                                                   |
-| `recordClick(clickUrl)`                                                             | `void`                                    | Records a click using the provided callback URL (typically from `ad.callbacks.click`).                                                                                               |
-| `recordImpression(impressionUrl)`                                                   | `void`                                    | Records an impression using the provided callback URL (typically from `ad.callbacks.impression`).                                                                                    |
-| `reportAd(reportUrl)`                                                               | `void`                                    | Reports an ad using the provided callback URL (typically from `ad.callbacks.report`).                                                                                                |
+| `recordClick(clickUrl, options?)`                                                   | `void`                                    | Records a click using the provided callback URL (typically from `ad.callbacks.click`). Optional `MozAdsCallbackOptions` can enable OHTTP.                                            |
+| `recordImpression(impressionUrl, options?)`                                         | `void`                                    | Records an impression using the provided callback URL (typically from `ad.callbacks.impression`). Optional `MozAdsCallbackOptions` can enable OHTTP.                                 |
+| `reportAd(reportUrl, reason, options?)`                                             | `void`                                    | Reports an ad using the provided callback URL (typically from `ad.callbacks.report`). Optional `MozAdsCallbackOptions` can enable OHTTP.                                             |
 | `requestImageAds(mozAdRequests, options?)`                                          | `Object.<string, MozAdsImage>`            | Requests one image ad per placement. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns an object keyed by `placementId`.                                          |
 | `requestSpocAds(mozAdRequests, options?)`                                           | `Object.<string, Array.<MozAdsSpoc>>`     | Requests spoc ads per placement. Each placement request specifies its own count. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns an object keyed by `placementId`. |
 | `requestTileAds(mozAdRequests, options?)`                                           | `Object.<string, MozAdsTile>`             | Requests one tile ad per placement. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns an object keyed by `placementId`.                                           |
@@ -246,12 +246,48 @@ Options passed when making a single ad request.
 /**
  * @typedef {Object} MozAdsRequestOptions
  * @property {MozAdsRequestCachePolicy|null} cachePolicy - Per-request caching policy.
+ * @property {boolean} ohttp - Whether to route this request through OHTTP (default: false).
  */
 ```
 
 | Field          | Type                                  | Description                                                                                     |
 | -------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `cachePolicy`  | `MozAdsRequestCachePolicy \| null`    | Per-request caching policy. If `null`, uses the client's default TTL with a `CacheFirst` mode.  |
+| `ohttp`        | `boolean`                             | Whether to route this request through OHTTP. Defaults to `false`.                               |
+
+---
+
+## `MozAdsCallbackOptions`
+
+Options passed when making callback requests (click, impression, report).
+
+```javascript
+/**
+ * @typedef {Object} MozAdsCallbackOptions
+ * @property {boolean} ohttp - Whether to route this callback through OHTTP (default: false).
+ */
+```
+
+| Field   | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `ohttp` | `boolean` | Whether to route this callback through OHTTP. Defaults to `false`. |
+
+#### OHTTP Usage Example
+
+```javascript
+// Request ads over OHTTP
+const ads = client.requestTileAds(placements, {
+    ohttp: true
+});
+
+// Record a click over OHTTP
+client.recordClick(ad.callbacks.click, { ohttp: true });
+
+// Record an impression over OHTTP
+client.recordImpression(ad.callbacks.impression, { ohttp: true });
+```
+
+> **Note:** OHTTP must be configured at the viaduct level before use. When `ohttp` is `true`, the client automatically performs a preflight request to obtain geo-location and user-agent headers, which are injected into the MARS request.
 
 ---
 

--- a/components/ads-client/docs/usage-kotlin.md
+++ b/components/ads-client/docs/usage-kotlin.md
@@ -34,9 +34,9 @@ val client = MozAdsClientBuilder()
 | Method                                                                                                                  | Return Type                                            | Description                                                                                                                                                                          |
 | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `clearCache()`                                                                                                          | `Unit`                                                 | Clears the client's HTTP cache. Throws on failure.                                                                                                                                   |
-| `recordClick(clickUrl: String)`                                                                                         | `Unit`                                                 | Records a click using the provided callback URL (typically from `ad.callbacks.click`).                                                                                               |
-| `recordImpression(impressionUrl: String)`                                                                               | `Unit`                                                 | Records an impression using the provided callback URL (typically from `ad.callbacks.impression`).                                                                                    |
-| `reportAd(reportUrl: String)`                                                                                           | `Unit`                                                 | Reports an ad using the provided callback URL (typically from `ad.callbacks.report`).                                                                                                |
+| `recordClick(clickUrl: String, options: MozAdsCallbackOptions?)`                                                                                         | `Unit`                                                 | Records a click using the provided callback URL (typically from `ad.callbacks.click`).                                                                                               |
+| `recordImpression(impressionUrl: String, options: MozAdsCallbackOptions?)`                                                                               | `Unit`                                                 | Records an impression using the provided callback URL (typically from `ad.callbacks.impression`).                                                                                    |
+| `reportAd(reportUrl: String, reason: MozAdsReportReason, options: MozAdsCallbackOptions?)`                                                                                           | `Unit`                                                 | Reports an ad using the provided callback URL (typically from `ad.callbacks.report`).                                                                                                |
 | `requestImageAds(mozAdRequests: List<MozAdsPlacementRequest>, options: MozAdsRequestOptions?)`                          | `Map<String, MozAdsImage>`                             | Requests one image ad per placement. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns a map keyed by `placementId`.                                              |
 | `requestSpocAds(mozAdRequests: List<MozAdsPlacementRequestWithCount>, options: MozAdsRequestOptions?)`                  | `Map<String, List<MozAdsSpoc>>`                        | Requests spoc ads per placement. Each placement request specifies its own count. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns a map keyed by `placementId`.  |
 | `requestTileAds(mozAdRequests: List<MozAdsPlacementRequest>, options: MozAdsRequestOptions?)`                           | `Map<String, MozAdsTile>`                              | Requests one tile ad per placement. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns a map keyed by `placementId`.                                               |
@@ -219,13 +219,46 @@ Options passed when making a single ad request.
 
 ```kotlin
 data class MozAdsRequestOptions(
-    val cachePolicy: MozAdsRequestCachePolicy?
+    val cachePolicy: MozAdsRequestCachePolicy?,
+    val ohttp: Boolean = false
 )
 ```
 
 | Field          | Type                         | Description                                                                                    |
 | -------------- | ---------------------------- | ---------------------------------------------------------------------------------------------- |
 | `cachePolicy`  | `MozAdsRequestCachePolicy?`  | Per-request caching policy. If `null`, uses the client's default TTL with a `CacheFirst` mode. |
+| `ohttp`        | `Boolean`                    | Whether to route this request through OHTTP. Defaults to `false`.                              |
+
+---
+
+## `MozAdsCallbackOptions`
+
+Options passed when making callback requests (click, impression, report).
+
+```kotlin
+data class MozAdsCallbackOptions(
+    val ohttp: Boolean = false
+)
+```
+
+| Field   | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `ohttp` | `Boolean` | Whether to route this callback through OHTTP. Defaults to `false`. |
+
+#### OHTTP Usage Example
+
+```kotlin
+// Request ads over OHTTP
+val ads = client.requestTileAds(placements, MozAdsRequestOptions(ohttp = true))
+
+// Record a click over OHTTP
+client.recordClick(ad.callbacks.click, MozAdsCallbackOptions(ohttp = true))
+
+// Record an impression over OHTTP
+client.recordImpression(ad.callbacks.impression, MozAdsCallbackOptions(ohttp = true))
+```
+
+> **Note:** OHTTP must be configured at the viaduct level before use. When `ohttp` is `true`, the client automatically performs a preflight request to obtain geo-location and user-agent headers, which are injected into the MARS request.
 
 ---
 

--- a/components/ads-client/docs/usage-swift.md
+++ b/components/ads-client/docs/usage-swift.md
@@ -34,9 +34,9 @@ let client = MozAdsClientBuilder()
 | Method                                                                                                                       | Return Type                        | Description                                                                                                                                                                          |
 | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `clearCache()`                                                                                                               | `Void`                             | Clears the client's HTTP cache. Throws on failure.                                                                                                                                   |
-| `recordClick(clickUrl: String)`                                                                                              | `Void`                             | Records a click using the provided callback URL (typically from `ad.callbacks.click`).                                                                                               |
-| `recordImpression(impressionUrl: String)`                                                                                    | `Void`                             | Records an impression using the provided callback URL (typically from `ad.callbacks.impression`).                                                                                    |
-| `reportAd(reportUrl: String)`                                                                                                | `Void`                             | Reports an ad using the provided callback URL (typically from `ad.callbacks.report`).                                                                                                |
+| `recordClick(clickUrl: String, options: MozAdsCallbackOptions?)`                                                                                              | `Void`                             | Records a click using the provided callback URL (typically from `ad.callbacks.click`).                                                                                               |
+| `recordImpression(impressionUrl: String, options: MozAdsCallbackOptions?)`                                                                                    | `Void`                             | Records an impression using the provided callback URL (typically from `ad.callbacks.impression`).                                                                                    |
+| `reportAd(reportUrl: String, reason: MozAdsReportReason, options: MozAdsCallbackOptions?)`                                                                                                | `Void`                             | Reports an ad using the provided callback URL (typically from `ad.callbacks.report`).                                                                                                |
 | `requestImageAds(mozAdRequests: [MozAdsPlacementRequest], options: MozAdsRequestOptions?)`                                   | `[String: MozAdsImage]`            | Requests one image ad per placement. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns a dictionary keyed by `placementId`.                                       |
 | `requestSpocAds(mozAdRequests: [MozAdsPlacementRequestWithCount], options: MozAdsRequestOptions?)`                           | `[String: [MozAdsSpoc]]`           | Requests spoc ads per placement. Each placement request specifies its own count. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns a dictionary keyed by `placementId`. |
 | `requestTileAds(mozAdRequests: [MozAdsPlacementRequest], options: MozAdsRequestOptions?)`                                    | `[String: MozAdsTile]`             | Requests one tile ad per placement. Optional `MozAdsRequestOptions` can adjust caching behavior. Returns a dictionary keyed by `placementId`.                                        |
@@ -220,12 +220,45 @@ Options passed when making a single ad request.
 ```swift
 struct MozAdsRequestOptions {
     let cachePolicy: MozAdsRequestCachePolicy?
+    let ohttp: Bool  // default: false
 }
 ```
 
 | Field          | Type                          | Description                                                                                   |
 | -------------- | ----------------------------- | --------------------------------------------------------------------------------------------- |
 | `cachePolicy`  | `MozAdsRequestCachePolicy?`   | Per-request caching policy. If `nil`, uses the client's default TTL with a `cacheFirst` mode. |
+| `ohttp`        | `Bool`                        | Whether to route this request through OHTTP. Defaults to `false`.                             |
+
+---
+
+## `MozAdsCallbackOptions`
+
+Options passed when making callback requests (click, impression, report).
+
+```swift
+struct MozAdsCallbackOptions {
+    let ohttp: Bool  // default: false
+}
+```
+
+| Field   | Type   | Description                                                        |
+| ------- | ------ | ------------------------------------------------------------------ |
+| `ohttp` | `Bool` | Whether to route this callback through OHTTP. Defaults to `false`. |
+
+#### OHTTP Usage Example
+
+```swift
+// Request ads over OHTTP
+let ads = try client.requestTileAds(mozAdRequests: placements, options: MozAdsRequestOptions(ohttp: true))
+
+// Record a click over OHTTP
+try client.recordClick(clickUrl: ad.callbacks.click, options: MozAdsCallbackOptions(ohttp: true))
+
+// Record an impression over OHTTP
+try client.recordImpression(impressionUrl: ad.callbacks.impression, options: MozAdsCallbackOptions(ohttp: true))
+```
+
+> **Note:** OHTTP must be configured at the viaduct level before use. When `ohttp` is `true`, the client automatically performs a preflight request to obtain geo-location and user-agent headers, which are injected into the MARS request.
 
 ---
 

--- a/components/ads-client/integration-tests/Cargo.toml
+++ b/components/ads-client/integration-tests/Cargo.toml
@@ -12,6 +12,6 @@ ads-client = { path = ".." }
 serde_json = "1"
 url = "2"
 mockito = { version = "0.31", default-features = false }
-viaduct = { path = "../../../components/viaduct" }
+viaduct = { path = "../../../components/viaduct", features = ["ohttp"] }
 viaduct-dev = { path = "../../../components/support/viaduct-dev" }
 viaduct-hyper = { path = "../../../components/support/viaduct-hyper" }

--- a/components/ads-client/integration-tests/tests/mars.rs
+++ b/components/ads-client/integration-tests/tests/mars.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use ads_client::{
     MozAdsClientBuilder, MozAdsEnvironment, MozAdsPlacementRequest,
-    MozAdsPlacementRequestWithCount, MozAdsReportReason,
+    MozAdsPlacementRequestWithCount, MozAdsReportReason, MozAdsRequestOptions,
 };
 
 fn init_backend() {
@@ -104,7 +104,7 @@ fn test_record_impression() {
         .get("mock_tile_1")
         .expect("mock_tile_1 placement should be present");
 
-    let result = client.record_impression(ad.callbacks.impression.to_string());
+    let result = client.record_impression(ad.callbacks.impression.to_string(), None);
     assert!(
         result.is_ok(),
         "record_impression failed: {:?}",
@@ -132,7 +132,7 @@ fn test_record_click() {
         .get("mock_tile_1")
         .expect("mock_tile_1 placement should be present");
 
-    let result = client.record_click(ad.callbacks.click.to_string());
+    let result = client.record_click(ad.callbacks.click.to_string(), None);
     assert!(result.is_ok(), "record_click failed: {:?}", result.err());
 }
 
@@ -168,6 +168,43 @@ fn test_report_ad() {
     assert_eq!(placement_id_count, 1, "expected exactly one placement_id");
     assert_eq!(position_count, 1, "expected exactly one position");
 
-    let result = client.report_ad(report_url.to_string(), MozAdsReportReason::NotInterested);
+    let result = client.report_ad(
+        report_url.to_string(),
+        MozAdsReportReason::NotInterested,
+        None,
+    );
     assert!(result.is_ok(), "report_ad failed: {:?}", result.err());
+}
+
+#[test]
+#[ignore = "integration test: run manually with -- --ignored"]
+fn test_contract_tile_ohttp_prod() {
+    init_backend();
+    viaduct::ohttp::configure_ohttp_channel(
+        "ads-client".to_string(),
+        viaduct::ohttp::OhttpConfig {
+            relay_url: "https://mozilla-ohttp.fastly-edge.com/".to_string(),
+            gateway_host: "prod.ohttp-gateway.prod.webservices.mozgcp.net".to_string(),
+        },
+    )
+    .expect("OHTTP channel configuration should succeed");
+
+    let client = prod_client();
+
+    let placements = client
+        .request_tile_ads(
+            vec![MozAdsPlacementRequest {
+                iab_content: None,
+                placement_id: "mock_tile_1".to_string(),
+            }],
+            Some(MozAdsRequestOptions {
+                ohttp: true,
+                ..Default::default()
+            }),
+        )
+        .expect("tile ad request over OHTTP should succeed");
+    assert!(
+        placements.contains_key("mock_tile_1"),
+        "OHTTP response should contain mock_tile_1"
+    );
 }

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -102,7 +102,7 @@ where
         self.context_id_provider.context_id()
     }
 
-    pub fn record_click(&self, click_url: Url) -> Result<(), RecordClickError> {
+    pub fn record_click(&self, click_url: Url, ohttp: bool) -> Result<(), RecordClickError> {
         // TODO: Re-enable cache invalidation behind a Nimbus experiment.
         // The mobile team has requested this be temporarily disabled.
         // let mut click_url = click_url.clone();
@@ -110,7 +110,7 @@ where
         //     let _ = self.client.invalidate_cache_by_hash(&request_hash);
         // }
         self.client
-            .record_click(click_url)
+            .record_click(click_url, ohttp)
             .inspect_err(|e| {
                 self.telemetry.record(e);
             })
@@ -119,7 +119,11 @@ where
             })
     }
 
-    pub fn record_impression(&self, impression_url: Url) -> Result<(), RecordImpressionError> {
+    pub fn record_impression(
+        &self,
+        impression_url: Url,
+        ohttp: bool,
+    ) -> Result<(), RecordImpressionError> {
         // TODO: Re-enable cache invalidation behind a Nimbus experiment.
         // The mobile team has requested this be temporarily disabled.
         // let mut impression_url = impression_url.clone();
@@ -127,7 +131,7 @@ where
         //     let _ = self.client.invalidate_cache_by_hash(&request_hash);
         // }
         self.client
-            .record_impression(impression_url)
+            .record_impression(impression_url, ohttp)
             .inspect_err(|e| {
                 self.telemetry.record(e);
             })
@@ -137,9 +141,14 @@ where
             })
     }
 
-    pub fn report_ad(&self, report_url: Url, reason: ReportReason) -> Result<(), ReportAdError> {
+    pub fn report_ad(
+        &self,
+        report_url: Url,
+        reason: ReportReason,
+        ohttp: bool,
+    ) -> Result<(), ReportAdError> {
         self.client
-            .report_ad(report_url, reason)
+            .report_ad(report_url, reason, ohttp)
             .inspect_err(|e| {
                 self.telemetry.record(e);
             })
@@ -152,9 +161,10 @@ where
         &self,
         ad_placement_requests: Vec<AdPlacementRequest>,
         options: Option<CachePolicy>,
+        ohttp: bool,
     ) -> Result<HashMap<String, AdImage>, RequestAdsError> {
         let response = self
-            .request_ads::<AdImage>(ad_placement_requests, options)
+            .request_ads::<AdImage>(ad_placement_requests, options, ohttp)
             .inspect_err(|e| {
                 self.telemetry.record(e);
             })?;
@@ -166,8 +176,9 @@ where
         &self,
         ad_placement_requests: Vec<AdPlacementRequest>,
         options: Option<CachePolicy>,
+        ohttp: bool,
     ) -> Result<HashMap<String, Vec<AdSpoc>>, RequestAdsError> {
-        let result = self.request_ads::<AdSpoc>(ad_placement_requests, options);
+        let result = self.request_ads::<AdSpoc>(ad_placement_requests, options, ohttp);
         result
             .inspect_err(|e| {
                 self.telemetry.record(e);
@@ -182,8 +193,9 @@ where
         &self,
         ad_placement_requests: Vec<AdPlacementRequest>,
         options: Option<CachePolicy>,
+        ohttp: bool,
     ) -> Result<HashMap<String, AdTile>, RequestAdsError> {
-        let result = self.request_ads::<AdTile>(ad_placement_requests, options);
+        let result = self.request_ads::<AdTile>(ad_placement_requests, options, ohttp);
         result
             .inspect_err(|e| {
                 self.telemetry.record(e);
@@ -198,6 +210,7 @@ where
         &self,
         placements: Vec<AdPlacementRequest>,
         options: Option<CachePolicy>,
+        ohttp: bool,
     ) -> Result<AdResponse<A>, RequestAdsError>
     where
         A: AdResponseValue,
@@ -206,7 +219,7 @@ where
         let cache_policy = options.unwrap_or_default();
         let (mut response, request_hash) =
             self.client
-                .fetch_ads::<A>(context_id, placements, cache_policy)?;
+                .fetch_ads::<A>(context_id, placements, cache_policy, ohttp)?;
         response.enrich_callbacks(&request_hash);
         Ok(response)
     }
@@ -276,7 +289,7 @@ mod tests {
         let mars_client = MARSClient::new(Environment::Test, None, MozAdsTelemetryWrapper::noop());
         let ads_client = new_with_mars_client(mars_client);
 
-        let result = ads_client.request_image_ads(make_happy_placement_requests(), None);
+        let result = ads_client.request_image_ads(make_happy_placement_requests(), None, false);
         assert!(result.is_ok());
     }
 
@@ -294,7 +307,7 @@ mod tests {
         let mars_client = MARSClient::new(Environment::Test, None, MozAdsTelemetryWrapper::noop());
         let ads_client = new_with_mars_client(mars_client);
 
-        let result = ads_client.request_spoc_ads(make_happy_placement_requests(), None);
+        let result = ads_client.request_spoc_ads(make_happy_placement_requests(), None, false);
         assert!(result.is_ok());
     }
 
@@ -312,7 +325,7 @@ mod tests {
         let mars_client = MARSClient::new(Environment::Test, None, MozAdsTelemetryWrapper::noop());
         let ads_client = new_with_mars_client(mars_client);
 
-        let result = ads_client.request_tile_ads(make_happy_placement_requests(), None);
+        let result = ads_client.request_tile_ads(make_happy_placement_requests(), None, false);
         assert!(result.is_ok());
     }
 
@@ -347,7 +360,7 @@ mod tests {
 
         assert_eq!(client.get_context_id().unwrap(), "custom-context-id-12345");
 
-        let result = client.request_image_ads(make_happy_placement_requests(), None);
+        let result = client.request_image_ads(make_happy_placement_requests(), None, false);
         assert!(result.is_ok());
     }
 
@@ -375,7 +388,7 @@ mod tests {
             .create();
 
         let response = ads_client
-            .request_image_ads(make_happy_placement_requests(), None)
+            .request_image_ads(make_happy_placement_requests(), None, false)
             .unwrap();
         let callback_url = response.values().next().unwrap().callbacks.click.clone();
 
@@ -383,17 +396,17 @@ mod tests {
             .with_status(200)
             .create();
 
-        // Doing another request should hit the cache
         ads_client
-            .request_image_ads(make_happy_placement_requests(), None)
+            .request_image_ads(make_happy_placement_requests(), None, false)
             .unwrap();
 
-        ads_client.record_click(callback_url).unwrap();
+        ads_client.record_click(callback_url, false).unwrap();
 
         ads_client
             .request_ads::<AdImage>(
                 make_happy_placement_requests(),
                 Some(CachePolicy::default()),
+                false,
             )
             .unwrap();
     }

--- a/components/ads-client/src/ffi.rs
+++ b/components/ads-client/src/ffi.rs
@@ -55,6 +55,14 @@ impl From<MozAdsContextIdProviderWrapper> for Box<dyn ContextIdProvider> {
 #[derive(Default, uniffi::Record)]
 pub struct MozAdsRequestOptions {
     pub cache_policy: Option<MozAdsCachePolicy>,
+    #[uniffi(default = false)]
+    pub ohttp: bool,
+}
+
+#[derive(Default, uniffi::Record)]
+pub struct MozAdsCallbackOptions {
+    #[uniffi(default = false)]
+    pub ohttp: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, uniffi::Record)]

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -53,39 +53,57 @@ impl MozAdsClient {
     }
 
     #[handle_error(ComponentError)]
-    pub fn record_click(&self, click_url: String) -> AdsClientApiResult<()> {
+    #[uniffi::method(default(options = None))]
+    pub fn record_click(
+        &self,
+        click_url: String,
+        options: Option<MozAdsCallbackOptions>,
+    ) -> AdsClientApiResult<()> {
         let url = AdsClientUrl::parse(&click_url)
             .map_err(|e| ComponentError::RecordClick(CallbackRequestError::InvalidUrl(e).into()))?;
+        let ohttp = options.map(|o| o.ohttp).unwrap_or(false);
         let inner = self.inner.lock();
-        inner.record_click(url).map_err(ComponentError::RecordClick)
+        inner
+            .record_click(url, ohttp)
+            .map_err(ComponentError::RecordClick)
     }
 
     #[handle_error(ComponentError)]
-    pub fn record_impression(&self, impression_url: String) -> AdsClientApiResult<()> {
+    #[uniffi::method(default(options = None))]
+    pub fn record_impression(
+        &self,
+        impression_url: String,
+        options: Option<MozAdsCallbackOptions>,
+    ) -> AdsClientApiResult<()> {
         let url = AdsClientUrl::parse(&impression_url).map_err(|e| {
             ComponentError::RecordImpression(CallbackRequestError::InvalidUrl(e).into())
         })?;
+        let ohttp = options.map(|o| o.ohttp).unwrap_or(false);
         let inner = self.inner.lock();
         inner
-            .record_impression(url)
+            .record_impression(url, ohttp)
             .map_err(ComponentError::RecordImpression)
     }
 
     #[handle_error(ComponentError)]
+    #[uniffi::method(default(options = None))]
     pub fn report_ad(
         &self,
         report_url: String,
         reason: MozAdsReportReason,
+        options: Option<MozAdsCallbackOptions>,
     ) -> AdsClientApiResult<()> {
         let url = AdsClientUrl::parse(&report_url)
             .map_err(|e| ComponentError::ReportAd(CallbackRequestError::InvalidUrl(e).into()))?;
+        let ohttp = options.map(|o| o.ohttp).unwrap_or(false);
         let inner = self.inner.lock();
         inner
-            .report_ad(url, reason.into())
+            .report_ad(url, reason.into(), ohttp)
             .map_err(ComponentError::ReportAd)
     }
 
     #[handle_error(ComponentError)]
+    #[uniffi::method(default(options = None))]
     pub fn request_image_ads(
         &self,
         moz_ad_requests: Vec<MozAdsPlacementRequest>,
@@ -93,14 +111,16 @@ impl MozAdsClient {
     ) -> AdsClientApiResult<HashMap<String, MozAdsImage>> {
         let inner = self.inner.lock();
         let requests: Vec<AdPlacementRequest> = moz_ad_requests.iter().map(|r| r.into()).collect();
+        let ohttp = options.as_ref().map(|o| o.ohttp).unwrap_or(false);
         let cache_policy: CachePolicy = options.into();
         let response = inner
-            .request_image_ads(requests, Some(cache_policy))
+            .request_image_ads(requests, Some(cache_policy), ohttp)
             .map_err(ComponentError::RequestAds)?;
         Ok(response.into_iter().map(|(k, v)| (k, v.into())).collect())
     }
 
     #[handle_error(ComponentError)]
+    #[uniffi::method(default(options = None))]
     pub fn request_spoc_ads(
         &self,
         moz_ad_requests: Vec<MozAdsPlacementRequestWithCount>,
@@ -108,9 +128,10 @@ impl MozAdsClient {
     ) -> AdsClientApiResult<HashMap<String, Vec<MozAdsSpoc>>> {
         let inner = self.inner.lock();
         let requests: Vec<AdPlacementRequest> = moz_ad_requests.iter().map(|r| r.into()).collect();
+        let ohttp = options.as_ref().map(|o| o.ohttp).unwrap_or(false);
         let cache_policy: CachePolicy = options.into();
         let response = inner
-            .request_spoc_ads(requests, Some(cache_policy))
+            .request_spoc_ads(requests, Some(cache_policy), ohttp)
             .map_err(ComponentError::RequestAds)?;
         Ok(response
             .into_iter()
@@ -119,6 +140,7 @@ impl MozAdsClient {
     }
 
     #[handle_error(ComponentError)]
+    #[uniffi::method(default(options = None))]
     pub fn request_tile_ads(
         &self,
         moz_ad_requests: Vec<MozAdsPlacementRequest>,
@@ -126,9 +148,10 @@ impl MozAdsClient {
     ) -> AdsClientApiResult<HashMap<String, MozAdsTile>> {
         let inner = self.inner.lock();
         let requests: Vec<AdPlacementRequest> = moz_ad_requests.iter().map(|r| r.into()).collect();
+        let ohttp = options.as_ref().map(|o| o.ohttp).unwrap_or(false);
         let cache_policy: CachePolicy = options.into();
         let response = inner
-            .request_tile_ads(requests, Some(cache_policy))
+            .request_tile_ads(requests, Some(cache_policy), ohttp)
             .map_err(ComponentError::RequestAds)?;
         Ok(response.into_iter().map(|(k, v)| (k, v.into())).collect())
     }

--- a/components/ads-client/src/mars.rs
+++ b/components/ads-client/src/mars.rs
@@ -7,6 +7,7 @@ pub mod ad_request;
 pub mod ad_response;
 pub mod environment;
 pub mod error;
+mod preflight;
 pub mod report_reason;
 
 pub use environment::Environment;
@@ -26,8 +27,11 @@ use crate::{
     CachePolicy,
 };
 
+pub const OHTTP_CHANNEL_ID: &str = "ads-client";
+
+use self::preflight::{PreflightRequest, PreflightResponse};
 use url::Url;
-use viaduct::{Client, ClientSettings, Request};
+use viaduct::{Client, ClientSettings, Headers, Request};
 
 pub struct MARSClient<T>
 where
@@ -62,15 +66,22 @@ where
         context_id: String,
         placements: Vec<AdPlacementRequest>,
         cache_policy: CachePolicy,
+        ohttp: bool,
     ) -> Result<(AdResponse<A>, RequestHash), FetchAdsError>
     where
         A: AdResponseValue,
     {
         let url = self.environment.into_url("ads");
-        let ad_request = AdRequest::try_new(context_id, placements, url)?;
+        let mut ad_request = AdRequest::try_new(context_id, placements, url)?;
         let request_hash = RequestHash::new(&ad_request);
 
-        let client = self.client_for();
+        if ohttp {
+            ad_request
+                .headers
+                .extend(Headers::from(self.fetch_preflight()?));
+        }
+
+        let client = self.client_for(ohttp)?;
         let response: AdResponse<A> = if let Some(cache) = self.http_cache.as_ref() {
             let (response, cache_outcomes) =
                 cache.send_with_policy(&client, ad_request, &cache_policy)?;
@@ -100,28 +111,69 @@ where
         Ok(())
     }
 
-    pub fn record_click(&self, callback: Url) -> Result<(), RecordClickError> {
-        Ok(self.make_callback_request(callback)?)
+    pub fn record_click(&self, callback: Url, ohttp: bool) -> Result<(), RecordClickError> {
+        Ok(self.make_callback_request(callback, ohttp)?)
     }
 
-    pub fn record_impression(&self, callback: Url) -> Result<(), RecordImpressionError> {
-        Ok(self.make_callback_request(callback)?)
+    pub fn record_impression(
+        &self,
+        callback: Url,
+        ohttp: bool,
+    ) -> Result<(), RecordImpressionError> {
+        Ok(self.make_callback_request(callback, ohttp)?)
     }
 
-    pub fn report_ad(&self, mut callback: Url, reason: ReportReason) -> Result<(), ReportAdError> {
+    pub fn report_ad(
+        &self,
+        mut callback: Url,
+        reason: ReportReason,
+        ohttp: bool,
+    ) -> Result<(), ReportAdError> {
         callback
             .query_pairs_mut()
             .append_pair("reason", reason.as_str());
-        Ok(self.make_callback_request(callback)?)
+        Ok(self.make_callback_request(callback, ohttp)?)
     }
 
-    fn client_for(&self) -> Client {
-        Client::new(ClientSettings::default())
+    fn client_for(&self, ohttp: bool) -> Result<Client, viaduct::ViaductError> {
+        if ohttp {
+            Client::with_ohttp_channel(OHTTP_CHANNEL_ID, ClientSettings::default())
+        } else {
+            Ok(Client::new(ClientSettings::default()))
+        }
     }
 
-    fn make_callback_request(&self, callback: Url) -> Result<(), CallbackRequestError> {
+    fn fetch_preflight(&self) -> Result<PreflightResponse, CallbackRequestError> {
         let client = Client::new(ClientSettings::default());
-        let request = Request::get(callback);
+        let preflight_request = PreflightRequest(self.environment.into_url("ads-preflight"));
+        if let Some(cache) = &self.http_cache {
+            let (response, _) = cache.send_with_policy(
+                &client,
+                preflight_request,
+                &CachePolicy::CacheFirst { ttl: None },
+            )?;
+            check_http_status_for_error(&response)?;
+            Ok(response.json()?)
+        } else {
+            let request: Request = preflight_request.into();
+            let response = client.send_sync(request)?;
+            check_http_status_for_error(&response)?;
+            Ok(response.json()?)
+        }
+    }
+
+    fn make_callback_request(
+        &self,
+        callback: Url,
+        ohttp: bool,
+    ) -> Result<(), CallbackRequestError> {
+        let mut request = Request::get(callback);
+        if ohttp {
+            request
+                .headers
+                .extend(Headers::from(self.fetch_preflight()?));
+        }
+        let client = self.client_for(ohttp)?;
         let response = client.send_sync(request)?;
         check_http_status_for_error(&response).map_err(Into::into)
     }
@@ -158,7 +210,7 @@ mod tests {
             &mockito::server_url()
         ))
         .unwrap();
-        let result = client.record_impression(url);
+        let result = client.record_impression(url, false);
         assert!(result.is_ok());
     }
 
@@ -169,7 +221,7 @@ mod tests {
 
         let client = make_test_client(None);
         let url = Url::parse(&format!("{}/click_callback_url", &mockito::server_url())).unwrap();
-        let result = client.record_click(url);
+        let result = client.record_click(url, false);
         assert!(result.is_ok());
     }
 
@@ -190,7 +242,7 @@ mod tests {
             &mockito::server_url()
         ))
         .unwrap();
-        let result = client.report_ad(url, ReportReason::NotInterested);
+        let result = client.report_ad(url, ReportReason::NotInterested, false);
         assert!(result.is_ok());
     }
 
@@ -212,6 +264,7 @@ mod tests {
             TEST_CONTEXT_ID.to_string(),
             make_happy_placement_requests(),
             CachePolicy::default(),
+            false,
         );
         assert!(result.is_ok());
         let (response, _request_hash) = result.unwrap();
@@ -237,6 +290,7 @@ mod tests {
                 TEST_CONTEXT_ID.to_string(),
                 make_happy_placement_requests(),
                 CachePolicy::default(),
+                false,
             )
             .unwrap();
         assert_eq!(response1, expected);
@@ -247,6 +301,7 @@ mod tests {
                 TEST_CONTEXT_ID.to_string(),
                 make_happy_placement_requests(),
                 CachePolicy::default(),
+                false,
             )
             .unwrap();
         assert_eq!(response2, expected);
@@ -266,7 +321,7 @@ mod tests {
 
         let _m = mock("GET", "/click").with_status(200).create();
 
-        let result = client.record_click(callback_url);
+        let result = client.record_click(callback_url, false);
         assert!(result.is_ok());
     }
 
@@ -284,7 +339,7 @@ mod tests {
 
         let _m = mock("GET", "/impression").with_status(200).create();
 
-        let result = client.record_impression(callback_url);
+        let result = client.record_impression(callback_url, false);
         assert!(result.is_ok());
     }
 }

--- a/components/ads-client/src/mars.rs
+++ b/components/ads-client/src/mars.rs
@@ -9,6 +9,7 @@ pub mod environment;
 pub mod error;
 mod preflight;
 pub mod report_reason;
+mod transport;
 
 pub use environment::Environment;
 pub use report_reason::ReportReason;
@@ -17,48 +18,43 @@ use self::{
     ad_request::{AdPlacementRequest, AdRequest},
     ad_response::{AdResponse, AdResponseValue},
     error::{
-        check_http_status_for_error, CallbackRequestError, FetchAdsError, RecordClickError,
-        RecordImpressionError, ReportAdError,
+        CallbackRequestError, FetchAdsError, RecordClickError, RecordImpressionError, ReportAdError,
     },
+    preflight::PreflightRequest,
+    transport::MARSTransport,
 };
 use crate::{
     http_cache::{HttpCache, RequestHash},
     telemetry::Telemetry,
     CachePolicy,
 };
-
-pub const OHTTP_CHANNEL_ID: &str = "ads-client";
-
-use self::preflight::{PreflightRequest, PreflightResponse};
 use url::Url;
-use viaduct::{Client, ClientSettings, Headers, Request};
+use viaduct::{Headers, Request};
 
 pub struct MARSClient<T>
 where
-    T: Telemetry,
+    T: Clone + Telemetry,
 {
     environment: Environment,
-    http_cache: Option<HttpCache>,
     telemetry: T,
+    transport: MARSTransport<T>,
 }
 
 impl<T> MARSClient<T>
 where
-    T: Telemetry,
+    T: Clone + Telemetry,
 {
     pub fn new(environment: Environment, http_cache: Option<HttpCache>, telemetry: T) -> Self {
+        let transport = MARSTransport::new(http_cache, telemetry.clone());
         Self {
             environment,
-            http_cache,
             telemetry,
+            transport,
         }
     }
 
     pub fn clear_cache(&self) -> Result<(), rusqlite::Error> {
-        if let Some(cache) = &self.http_cache {
-            cache.clear()?;
-        }
-        Ok(())
+        self.transport.clear_cache()
     }
 
     pub fn fetch_ads<A>(
@@ -72,7 +68,7 @@ where
         A: AdResponseValue,
     {
         let url = self.environment.into_url("ads");
-        let mut ad_request = AdRequest::try_new(context_id, placements, url)?;
+        let mut ad_request = AdRequest::try_new(context_id, placements, url, ohttp)?;
         let request_hash = RequestHash::new(&ad_request);
 
         if ohttp {
@@ -81,34 +77,18 @@ where
                 .extend(Headers::from(self.fetch_preflight()?));
         }
 
-        let client = self.client_for(ohttp)?;
-        let response: AdResponse<A> = if let Some(cache) = self.http_cache.as_ref() {
-            let (response, cache_outcomes) =
-                cache.send_with_policy(&client, ad_request, &cache_policy)?;
-            for outcome in &cache_outcomes {
-                self.telemetry.record(outcome);
-            }
-            check_http_status_for_error(&response)?;
-            AdResponse::<A>::parse(response.json()?, &self.telemetry)?
-        } else {
-            let request: Request = ad_request.into();
-            let response = client.send_sync(request)?;
-            check_http_status_for_error(&response)?;
-            AdResponse::<A>::parse(response.json()?, &self.telemetry)?
-        };
-        Ok((response, request_hash))
+        let response = self.transport.send(ad_request, &cache_policy, ohttp)?;
+        let ads = AdResponse::<A>::parse(response.json()?, &self.telemetry)?;
+        Ok((ads, request_hash))
     }
 
     // TODO: Remove this allow(dead_code) when cache invalidation is re-enabled behind Nimbus experiment
     #[allow(dead_code)]
     pub fn invalidate_cache_by_hash(
         &self,
-        request_hash: &crate::http_cache::RequestHash,
+        request_hash: &RequestHash,
     ) -> Result<(), rusqlite::Error> {
-        if let Some(cache) = &self.http_cache {
-            cache.invalidate_by_hash(request_hash)?;
-        }
-        Ok(())
+        self.transport.invalidate_cache_by_hash(request_hash)
     }
 
     pub fn record_click(&self, callback: Url, ohttp: bool) -> Result<(), RecordClickError> {
@@ -135,31 +115,13 @@ where
         Ok(self.make_callback_request(callback, ohttp)?)
     }
 
-    fn client_for(&self, ohttp: bool) -> Result<Client, viaduct::ViaductError> {
-        if ohttp {
-            Client::with_ohttp_channel(OHTTP_CHANNEL_ID, ClientSettings::default())
-        } else {
-            Ok(Client::new(ClientSettings::default()))
-        }
-    }
-
-    fn fetch_preflight(&self) -> Result<PreflightResponse, CallbackRequestError> {
-        let client = Client::new(ClientSettings::default());
-        let preflight_request = PreflightRequest(self.environment.into_url("ads-preflight"));
-        if let Some(cache) = &self.http_cache {
-            let (response, _) = cache.send_with_policy(
-                &client,
-                preflight_request,
-                &CachePolicy::CacheFirst { ttl: None },
-            )?;
-            check_http_status_for_error(&response)?;
-            Ok(response.json()?)
-        } else {
-            let request: Request = preflight_request.into();
-            let response = client.send_sync(request)?;
-            check_http_status_for_error(&response)?;
-            Ok(response.json()?)
-        }
+    fn fetch_preflight(&self) -> Result<preflight::PreflightResponse, CallbackRequestError> {
+        let response = self.transport.send(
+            PreflightRequest(self.environment.into_url("ads-preflight")),
+            &CachePolicy::CacheFirst { ttl: None },
+            false,
+        )?;
+        Ok(response.json()?)
     }
 
     fn make_callback_request(
@@ -173,9 +135,7 @@ where
                 .headers
                 .extend(Headers::from(self.fetch_preflight()?));
         }
-        let client = self.client_for(ohttp)?;
-        let response = client.send_sync(request)?;
-        check_http_status_for_error(&response).map_err(Into::into)
+        self.transport.fire(request, ohttp).map_err(Into::into)
     }
 }
 

--- a/components/ads-client/src/mars/ad_request.rs
+++ b/components/ads-client/src/mars/ad_request.rs
@@ -17,6 +17,8 @@ pub struct AdRequest {
     pub context_id: String,
     #[serde(skip)]
     pub headers: Headers,
+    #[serde(skip)]
+    pub ohttp: bool,
     pub placements: Vec<AdPlacementRequest>,
     /// Skipped to exclude from the request body
     #[serde(skip)]
@@ -30,6 +32,7 @@ impl Hash for AdRequest {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.url.as_str().hash(state);
         self.placements.hash(state);
+        self.ohttp.hash(state);
     }
 }
 
@@ -47,6 +50,7 @@ impl AdRequest {
         context_id: String,
         placements: Vec<AdPlacementRequest>,
         url: Url,
+        ohttp: bool,
     ) -> Result<Self, BuildRequestError> {
         if placements.is_empty() {
             return Err(BuildRequestError::EmptyConfig);
@@ -55,6 +59,7 @@ impl AdRequest {
         let mut request = AdRequest {
             context_id,
             headers: Headers::new(),
+            ohttp,
             placements: vec![],
             url,
         };
@@ -194,12 +199,14 @@ mod tests {
                 },
             ],
             url.clone(),
+            false,
         )
         .unwrap();
 
         let expected_request = AdRequest {
             context_id: TEST_CONTEXT_ID.to_string(),
             headers: Headers::new(),
+            ohttp: false,
             placements: vec![
                 AdPlacementRequest {
                     content: Some(AdContentCategory {
@@ -248,6 +255,7 @@ mod tests {
                 },
             ],
             url,
+            false,
         );
         assert!(request.is_err());
     }
@@ -255,7 +263,7 @@ mod tests {
     #[test]
     fn test_build_ad_request_fails_on_empty_request() {
         let url: Url = "https://example.com/ads".parse().unwrap();
-        let request = AdRequest::try_new(TEST_CONTEXT_ID.to_string(), vec![], url);
+        let request = AdRequest::try_new(TEST_CONTEXT_ID.to_string(), vec![], url, false);
         assert!(request.is_err());
     }
 
@@ -275,8 +283,8 @@ mod tests {
         let context_id_a = "aaaa-bbbb-cccc".to_string();
         let context_id_b = "dddd-eeee-ffff".to_string();
 
-        let req1 = AdRequest::try_new(context_id_a, make_placements(), url.clone()).unwrap();
-        let req2 = AdRequest::try_new(context_id_b, make_placements(), url).unwrap();
+        let req1 = AdRequest::try_new(context_id_a, make_placements(), url.clone(), false).unwrap();
+        let req2 = AdRequest::try_new(context_id_b, make_placements(), url, false).unwrap();
 
         assert_eq!(RequestHash::new(&req1), RequestHash::new(&req2));
     }
@@ -295,6 +303,7 @@ mod tests {
                 placement: "tile_1".to_string(),
             }],
             url.clone(),
+            false,
         )
         .unwrap();
 
@@ -306,9 +315,32 @@ mod tests {
                 placement: "tile_2".to_string(),
             }],
             url,
+            false,
         )
         .unwrap();
 
         assert_ne!(RequestHash::new(&req1), RequestHash::new(&req2));
+    }
+
+    #[test]
+    fn test_ohttp_flag_produces_different_hash() {
+        use crate::http_cache::RequestHash;
+
+        let url: Url = "https://example.com/ads".parse().unwrap();
+        let make_placements = || {
+            vec![AdPlacementRequest {
+                content: None,
+                count: 1,
+                placement: "tile_1".to_string(),
+            }]
+        };
+
+        let req_direct =
+            AdRequest::try_new("same-id".to_string(), make_placements(), url.clone(), false)
+                .unwrap();
+        let req_ohttp =
+            AdRequest::try_new("same-id".to_string(), make_placements(), url, true).unwrap();
+
+        assert_ne!(RequestHash::new(&req_direct), RequestHash::new(&req_ohttp));
     }
 }

--- a/components/ads-client/src/mars/error.rs
+++ b/components/ads-client/src/mars/error.rs
@@ -61,6 +61,9 @@ pub enum FetchAdsError {
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("OHTTP preflight failed: {0}")]
+    Preflight(#[from] CallbackRequestError),
+
     #[error("Error sending request: {0}")]
     Request(#[from] viaduct::ViaductError),
 

--- a/components/ads-client/src/mars/error.rs
+++ b/components/ads-client/src/mars/error.rs
@@ -6,48 +6,27 @@
 use viaduct::Response;
 
 #[derive(Debug, thiserror::Error)]
-pub enum HTTPError {
-    #[error("Bad request ({code}): {message}")]
-    BadRequest { code: u16, message: String },
-
-    #[error("Server error ({code}): {message}")]
-    Server { code: u16, message: String },
-
-    #[error("Unexpected error ({code}): {message}")]
-    Unexpected { code: u16, message: String },
-}
-
-pub fn check_http_status_for_error(response: &Response) -> Result<(), HTTPError> {
-    let status = response.status;
-
-    if status == 200 {
-        return Ok(());
-    }
-    let error_message = response.text();
-    let error = match status {
-        400 => HTTPError::BadRequest {
-            code: status,
-            message: error_message.to_string(),
-        },
-        500..=599 => HTTPError::Server {
-            code: status,
-            message: error_message.to_string(),
-        },
-        _ => HTTPError::Unexpected {
-            code: status,
-            message: error_message.to_string(),
-        },
-    };
-    Err(error)
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum BuildRequestError {
     #[error("Duplicate placement_id found: {placement_id}. Placement_ids must be unique.")]
     DuplicatePlacementId { placement_id: String },
 
     #[error("Could not build request with empty placement configs")]
     EmptyConfig,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CallbackRequestError {
+    #[error("Could not fetch ads, MARS responded with: {0}")]
+    HTTPError(#[from] HTTPError),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Invalid callback URL: {0}")]
+    InvalidUrl(#[from] url::ParseError),
+
+    #[error("Error sending request: {0}")]
+    Request(#[from] viaduct::ViaductError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,18 +51,41 @@ pub enum FetchAdsError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CallbackRequestError {
-    #[error("Could not fetch ads, MARS responded with: {0}")]
-    HTTPError(#[from] HTTPError),
+pub enum HTTPError {
+    #[error("Bad request ({code}): {message}")]
+    BadRequest { code: u16, message: String },
 
-    #[error("JSON error: {0}")]
-    Json(#[from] serde_json::Error),
+    #[error("Server error ({code}): {message}")]
+    Server { code: u16, message: String },
 
-    #[error("Invalid callback URL: {0}")]
-    InvalidUrl(#[from] url::ParseError),
+    #[error("Unexpected error ({code}): {message}")]
+    Unexpected { code: u16, message: String },
+}
 
-    #[error("Error sending request: {0}")]
-    Request(#[from] viaduct::ViaductError),
+impl HTTPError {
+    pub fn check(response: &Response) -> Result<(), Self> {
+        let status = response.status;
+
+        if status == 200 {
+            return Ok(());
+        }
+        let error_message = response.text();
+        let error = match status {
+            400 => Self::BadRequest {
+                code: status,
+                message: error_message.to_string(),
+            },
+            500..=599 => Self::Server {
+                code: status,
+                message: error_message.to_string(),
+            },
+            _ => Self::Unexpected {
+                code: status,
+                message: error_message.to_string(),
+            },
+        };
+        Err(error)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -104,6 +106,38 @@ pub enum ReportAdError {
     CallbackRequest(#[from] CallbackRequestError),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] HTTPError),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Request error: {0}")]
+    Request(#[from] viaduct::ViaductError),
+}
+
+impl From<TransportError> for FetchAdsError {
+    fn from(err: TransportError) -> Self {
+        match err {
+            TransportError::Http(e) => Self::HTTPError(e),
+            TransportError::Json(e) => Self::Json(e),
+            TransportError::Request(e) => Self::Request(e),
+        }
+    }
+}
+
+impl From<TransportError> for CallbackRequestError {
+    fn from(err: TransportError) -> Self {
+        match err {
+            TransportError::Http(e) => Self::HTTPError(e),
+            TransportError::Json(e) => Self::Json(e),
+            TransportError::Request(e) => Self::Request(e),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,14 +156,14 @@ mod tests {
     #[test]
     fn test_ok_status_returns_ok() {
         let response = mock_response(200, "OK");
-        let result = check_http_status_for_error(&response);
+        let result = HTTPError::check(&response);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_bad_request_returns_http_error() {
         let response = mock_response(400, "Bad input");
-        let result = check_http_status_for_error(&response);
+        let result = HTTPError::check(&response);
         assert!(
             matches!(result, Err(HTTPError::BadRequest { code, message }) if code == 400 && message == "Bad input")
         );
@@ -138,7 +172,7 @@ mod tests {
     #[test]
     fn test_server_error_500() {
         let response = mock_response(500, "Something broke");
-        let result = check_http_status_for_error(&response);
+        let result = HTTPError::check(&response);
         assert!(
             matches!(result, Err(HTTPError::Server { code, message }) if code == 500 && message == "Something broke")
         );

--- a/components/ads-client/src/mars/preflight.rs
+++ b/components/ads-client/src/mars/preflight.rs
@@ -8,6 +8,20 @@ use std::hash::{Hash, Hasher};
 use url::Url;
 use viaduct::{Headers, Request};
 
+pub struct PreflightRequest(pub Url);
+
+impl Hash for PreflightRequest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state);
+    }
+}
+
+impl From<PreflightRequest> for Request {
+    fn from(req: PreflightRequest) -> Self {
+        Request::get(req.0)
+    }
+}
+
 /// Response from the MARS `/v1/ads-preflight` endpoint.
 #[derive(Debug, Deserialize)]
 pub struct PreflightResponse {
@@ -29,19 +43,5 @@ impl From<PreflightResponse> for Headers {
                 .expect("valid header");
         }
         headers
-    }
-}
-
-pub(super) struct PreflightRequest(pub Url);
-
-impl Hash for PreflightRequest {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_str().hash(state);
-    }
-}
-
-impl From<PreflightRequest> for Request {
-    fn from(req: PreflightRequest) -> Self {
-        Request::get(req.0)
     }
 }

--- a/components/ads-client/src/mars/preflight.rs
+++ b/components/ads-client/src/mars/preflight.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use serde::Deserialize;
+use std::hash::{Hash, Hasher};
+use url::Url;
+use viaduct::{Headers, Request};
+
+/// Response from the MARS `/v1/ads-preflight` endpoint.
+#[derive(Debug, Deserialize)]
+pub struct PreflightResponse {
+    #[serde(default)]
+    pub geo_location: String,
+    #[serde(default)]
+    pub normalized_ua: String,
+}
+
+impl From<PreflightResponse> for Headers {
+    fn from(preflight: PreflightResponse) -> Self {
+        let mut headers = Headers::new();
+        headers
+            .insert("X-Geo-Location", preflight.geo_location)
+            .expect("valid header");
+        if !preflight.normalized_ua.is_empty() {
+            headers
+                .insert("X-User-Agent", preflight.normalized_ua)
+                .expect("valid header");
+        }
+        headers
+    }
+}
+
+pub(super) struct PreflightRequest(pub Url);
+
+impl Hash for PreflightRequest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state);
+    }
+}
+
+impl From<PreflightRequest> for Request {
+    fn from(req: PreflightRequest) -> Self {
+        Request::get(req.0)
+    }
+}

--- a/components/ads-client/src/mars/transport.rs
+++ b/components/ads-client/src/mars/transport.rs
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+use std::hash::Hash;
+
+use viaduct::{Client, ClientSettings, Request, Response};
+
+use super::error::{HTTPError, TransportError};
+use crate::{
+    http_cache::{HttpCache, RequestHash},
+    telemetry::Telemetry,
+    CachePolicy,
+};
+
+const OHTTP_CHANNEL_ID: &str = "ads-client";
+
+pub struct MARSTransport<T: Telemetry> {
+    http_cache: Option<HttpCache>,
+    telemetry: T,
+}
+
+impl<T: Telemetry> MARSTransport<T> {
+    pub fn new(http_cache: Option<HttpCache>, telemetry: T) -> Self {
+        Self {
+            http_cache,
+            telemetry,
+        }
+    }
+
+    pub fn clear_cache(&self) -> Result<(), rusqlite::Error> {
+        if let Some(cache) = &self.http_cache {
+            cache.clear()?;
+        }
+        Ok(())
+    }
+
+    pub fn fire(&self, request: Request, ohttp: bool) -> Result<(), TransportError> {
+        let client = Self::client_for(ohttp)?;
+        let response = client.send_sync(request)?;
+        HTTPError::check(&response)?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn invalidate_cache_by_hash(
+        &self,
+        request_hash: &RequestHash,
+    ) -> Result<(), rusqlite::Error> {
+        if let Some(cache) = &self.http_cache {
+            cache.invalidate_by_hash(request_hash)?;
+        }
+        Ok(())
+    }
+
+    pub fn send<R: Hash + Into<Request>>(
+        &self,
+        request: R,
+        policy: &CachePolicy,
+        ohttp: bool,
+    ) -> Result<Response, TransportError> {
+        let client = Self::client_for(ohttp)?;
+        if let Some(cache) = &self.http_cache {
+            let (response, outcomes) = cache.send_with_policy(&client, request, policy)?;
+            for outcome in &outcomes {
+                self.telemetry.record(outcome);
+            }
+            HTTPError::check(&response)?;
+            Ok(response)
+        } else {
+            let response = client.send_sync(request.into())?;
+            HTTPError::check(&response)?;
+            Ok(response)
+        }
+    }
+
+    fn client_for(ohttp: bool) -> Result<Client, viaduct::ViaductError> {
+        if ohttp {
+            Client::with_ohttp_channel(OHTTP_CHANNEL_ID, ClientSettings::default())
+        } else {
+            Ok(Client::new(ClientSettings::default()))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ohttp: bool` field to `MozAdsRequestOptions` and new `MozAdsCallbackOptions { ohttp: bool }` to opt individual requests into OHTTP routing
- Add OHTTP support to all MARS request paths: `request_tile_ads`, `request_image_ads`, `request_spoc_ads`, `record_impression`, `record_click`, `report_ad`
- All new `options` parameters use UniFFI defaults so existing callers require no changes
- Move `OHTTP_CHANNEL_ID` from `http_cache` into `client` — http_cache is now generic and has no ads-client knowledge
- Add `#[uniffi(default = None/false)]` to optional fields across `MozAdsPlacementRequest`, `MozAdsCacheConfig`, `MozAdsRequestCachePolicy` for better ergonomics in consumer code
- Split `docs/usage.md` into per-language files (`usage-javascript.md`, `usage-kotlin.md`, `usage-swift.md`) with correct language-specific examples
- Add NSS build steps to CI workflow (required since `viaduct`'s `ohttp` feature depends on NSS)
- Add integration test `test_contract_tile_ohttp_prod` against production MARS over OHTTP

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.