### PR TITLE
Bug 2032652 - Adds ability to insert a tree of bookmarks at a time with [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Added a client for the merino suggest endpoint
 - Added a `suggest` subcommand to `merino-cli` for locally testing the suggest endpoint.
 
+### Places
+- Adds ability to insert a tree of bookmarks with `insertBookmarkTree`.
+
 ## ✨ What's Changed ✨
 
 ### Merino Client

--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -5,6 +5,7 @@
 package mozilla.appservices.places
 
 import mozilla.appservices.places.uniffi.BookmarkItem
+import mozilla.appservices.places.uniffi.InsertableBookmarkFolder
 
 /**
  * Enumeration of the ids of the roots of the bookmarks tree.
@@ -242,4 +243,20 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
      * folder node.
      */
     fun updateBookmark(guid: Guid, parentGuid: Guid?, position: UInt?, title: String?, url: Url?)
+
+    /**
+     * Insert an entire bookmark folder tree, returning the GUID of the root folder.
+     *
+     * This is intended for restoring from a parsed backup. The [folder] may contain
+     * arbitrarily nested children (bookmarks, separators, and sub-folders), and the
+     * entire tree is inserted in a single transaction.
+     *
+     * @param folder The folder tree to insert, including all descendants.
+     * @return The GUID of the newly inserted root folder.
+     *
+     * @throws CannotUpdateRoot If [folder]'s `parentGuid` is [BookmarkRoot.Root].
+     * @throws UnknownBookmarkItem If [folder]'s `parentGuid` does not refer to a known bookmark.
+     * @throws InvalidParent If [folder]'s `parentGuid` does not refer to a folder node.
+     */
+    fun insertBookmarkTree(folder: InsertableBookmarkFolder): Guid
 }

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -381,6 +381,10 @@ class PlacesWriterConnection internal constructor(conn: UniffiPlacesConnection, 
         return this.doInsert(InsertableBookmarkItem.Bookmark(bm))
     }
 
+    override fun insertBookmarkTree(folder: InsertableBookmarkFolder): Guid {
+        return this.doInsert(InsertableBookmarkItem.Folder(folder))
+    }
+
     override fun updateBookmark(guid: Guid, parentGuid: Guid?, position: UInt?, title: String?, url: Url?) {
         val p: UInt? = if (position == null) {
             null

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -7,9 +7,14 @@ package mozilla.appservices.places
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import mozilla.appservices.places.uniffi.BookmarkItem
+import mozilla.appservices.places.uniffi.BookmarkPosition
 import mozilla.appservices.places.uniffi.DocumentType
 import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.places.uniffi.HistoryMetadataPageMissingBehavior
+import mozilla.appservices.places.uniffi.InsertableBookmark
+import mozilla.appservices.places.uniffi.InsertableBookmarkFolder
+import mozilla.appservices.places.uniffi.InsertableBookmarkItem
+import mozilla.appservices.places.uniffi.InsertableBookmarkSeparator
 import mozilla.appservices.places.uniffi.NoteHistoryMetadataObservationOptions
 import mozilla.appservices.places.uniffi.PlacesApiException
 import mozilla.appservices.places.uniffi.VisitObservation
@@ -229,7 +234,12 @@ class PlacesConnectionTest {
         db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.DOWNLOAD))
         db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.EMBED))
         db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.REDIRECT_PERMANENT))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.REDIRECT_TEMPORARY))
+        db.noteObservation(
+            VisitObservation(
+                url = "https://www.example.com/1",
+                visitType = VisitType.REDIRECT_TEMPORARY,
+            ),
+        )
         db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.FRAMED_LINK))
         db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.RELOAD))
 
@@ -382,6 +392,73 @@ class PlacesConnectionTest {
         assertEquals(folder.f.title, "example folder")
         assertEquals(folder.f.position, 2u)
         assertEquals(folder.f.parentGuid, BookmarkRoot.Unfiled.id)
+    }
+
+    @Test
+    fun testInsertBookmarkTree() {
+        val tree = InsertableBookmarkFolder(
+            parentGuid = BookmarkRoot.Unfiled.id,
+            position = BookmarkPosition.Append,
+            title = "restored root",
+            children = listOf(
+                InsertableBookmarkItem.Bookmark(
+                    InsertableBookmark(
+                        parentGuid = "",
+                        position = BookmarkPosition.Append,
+                        url = "https://www.example.com/",
+                        title = "example bookmark",
+                    ),
+                ),
+                InsertableBookmarkItem.Separator(
+                    InsertableBookmarkSeparator(
+                        parentGuid = "",
+                        position = BookmarkPosition.Append,
+                    ),
+                ),
+                InsertableBookmarkItem.Folder(
+                    InsertableBookmarkFolder(
+                        parentGuid = "",
+                        position = BookmarkPosition.Append,
+                        title = "sub-folder",
+                        children = listOf(
+                            InsertableBookmarkItem.Bookmark(
+                                InsertableBookmark(
+                                    parentGuid = "",
+                                    position = BookmarkPosition.Append,
+                                    url = "https://www.nested.com/",
+                                    title = "nested bookmark",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val rootGuid = db.insertBookmarkTree(tree)
+
+        val root = db.getBookmarksTree(rootGuid, recursive = true)!! as BookmarkItem.Folder
+        assertEquals("restored root", root.f.title)
+        assertEquals(BookmarkRoot.Unfiled.id, root.f.parentGuid)
+        val rootChildren = root.f.childNodes!!
+        assertEquals(3, rootChildren.size)
+
+        val bm = rootChildren[0] as BookmarkItem.Bookmark
+        assertEquals("example bookmark", bm.b.title)
+        assertEquals("https://www.example.com/", bm.b.url)
+        assertEquals(rootGuid, bm.b.parentGuid)
+
+        assertTrue(rootChildren[1] is BookmarkItem.Separator)
+
+        val sub = rootChildren[2] as BookmarkItem.Folder
+        assertEquals("sub-folder", sub.f.title)
+        assertEquals(rootGuid, sub.f.parentGuid)
+        val subChildren = sub.f.childNodes!!
+        assertEquals(1, subChildren.size)
+
+        val nested = subChildren[0] as BookmarkItem.Bookmark
+        assertEquals("nested bookmark", nested.b.title)
+        assertEquals("https://www.nested.com/", nested.b.url)
     }
 
     @Test


### PR DESCRIPTION
`insertBookmarkTree`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
