### PR TITLE
Perform Additional Origin Fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Logins
 - New `allow_empty_passwords` feature flag to allow storing logins with empty passwords. This feature is intended to be enabled on desktop during the migration.
 - Add `ignore_form_action_origin_validation_errors` feature flag that allows logins with non-URL `form_action_origin` values (e.g. "email", "UserCode") to be imported without error. URL normalization for valid URLs is still applied.
+- Add `perform_additional_origin_fixups` feature flag that repairs `origin` values which fail URL parsing (bare domains, FireFTP quirks, bare `https:` / `https://`, etc.) into parseable URLs instead of rejecting them. Scoped to the `origin` field only; `form_action_origin` keeps the stricter behavior, but can be disabled via `ignore_form_action_origin_validation_errors`. Intended to be enabled on desktop during migration to salvage legacy/addon-generated entries.
 
 ### Merino Client
 - Added a client for the merino suggest endpoint

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -16,6 +16,7 @@ allow_empty_passwords = []
 # errors, allowing non-URL values (e.g. "email", "UserCode") that exist in some
 # Desktop databases to be saved regardless.
 ignore_form_action_origin_validation_errors = []
+perform_additional_origin_fixups = []
 
 [dependencies]
 sync15 = { path = "../sync15" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -8,6 +8,10 @@ exclude = ["/android", "/ios"]
 
 [features]
 default = []
+# Enables `NSSKeyManager`, which stores the logins encryption key in NSS's
+# `key4.db` (wrapped with a key derived from the primary password, if set).
+# Used on Desktop to integrate with the existing NSS key store and primary
+# password flow.
 keydb = ["nss/keydb", "dep:async-trait", "dep:futures"]
 # Allows logins with empty passwords to be imported. Used on Desktop during
 # migration to accept existing logins that have empty passwords.
@@ -16,6 +20,11 @@ allow_empty_passwords = []
 # errors, allowing non-URL values (e.g. "email", "UserCode") that exist in some
 # Desktop databases to be saved regardless.
 ignore_form_action_origin_validation_errors = []
+# Repairs `origin` values that fail URL parsing (bare domains, FireFTP quirks,
+# bare `https:` / `https://`, etc.) into parseable URLs instead of rejecting
+# them. Scoped to the `origin` field; `form_action_origin` keeps the stricter
+# behavior. Used on Desktop during migration to salvage legacy/addon-generated
+# entries that would otherwise be lost.
 perform_additional_origin_fixups = []
 
 [dependencies]

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -167,7 +167,7 @@ impl LoginDb {
     }
 
     pub fn count_by_form_action_origin(&self, form_action_origin: &str) -> Result<i64> {
-        match LoginEntry::validate_and_fixup_origin(form_action_origin) {
+        match LoginEntry::validate_and_normalize_form_action_origin(form_action_origin) {
             Ok(result) => {
                 let form_action_origin = result.unwrap_or(form_action_origin.to_string());
                 let mut stmt = self.db.prepare_cached(&COUNT_BY_FORM_ACTION_ORIGIN_SQL)?;
@@ -177,16 +177,6 @@ impl LoginDb {
                 )?;
                 Ok(count)
             }
-            #[cfg(feature = "ignore_form_action_origin_validation_errors")]
-            Err(_) => {
-                let mut stmt = self.db.prepare_cached(&COUNT_BY_FORM_ACTION_ORIGIN_SQL)?;
-                let count: i64 = stmt.query_row(
-                    named_params! { ":form_action_origin": form_action_origin },
-                    |row| row.get(0),
-                )?;
-                Ok(count)
-            }
-            #[cfg(not(feature = "ignore_form_action_origin_validation_errors"))]
             Err(e) => {
                 // don't log the input string as it's PII.
                 warn!(

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -382,6 +382,71 @@ pub struct LoginEntry {
     pub password: String,
 }
 
+#[cfg(feature = "perform_additional_origin_fixups")]
+fn looks_like_bare_ipv4(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    parts.len() == 4 && parts.iter().all(|p| p.parse::<u8>().is_ok())
+}
+
+// Returns true if `s` looks like a bare domain name (e.g. `example.com`):
+// at least two dot-separated labels, each label only ASCII alphanumeric or hyphens.
+#[cfg(feature = "perform_additional_origin_fixups")]
+fn looks_like_bare_domain(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    parts.len() >= 2
+        && parts.iter().all(|p| {
+            !p.is_empty() && p.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        })
+}
+
+// Returns true if `s` looks like a single hostname label (no dots),
+// e.g. addon-generated origins like "example".
+#[cfg(feature = "perform_additional_origin_fixups")]
+fn looks_like_bare_label(s: &str) -> bool {
+    !s.is_empty() && !s.contains('.') && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+// Attempts to repair origins that fail URL parsing:
+// - bare https: / https:/ / https:// → https://moz.pwmngr.fixed
+// - http://ftp.<IPv4>[:port] → ftp://<IPv4>[:port]  (FireFTP quirk)
+// - ftp.<IPv4>[:port] without a scheme → ftp://<IPv4>[:port]
+// - ftp.<domain> without a scheme → ftp://ftp.<domain>
+// - bare IPv4 address or bare domain → moz-pwmngr-fixed://<host>
+// - bare label (e.g. example) → moz-pwmngr-fixed://<label>
+#[cfg(feature = "perform_additional_origin_fixups")]
+fn perform_additional_origin_fixup(origin: &str) -> Option<String> {
+    // Bare https: with missing or incomplete authority.
+    if matches!(origin, "https:" | "https:/" | "https://") {
+        return Some("https://moz.pwmngr.fixed".to_string());
+    }
+
+    // http://ftp.<IP>[:port] → ftp://<IP>[:port]
+    if let Some(rest) = origin.strip_prefix("http://ftp.") {
+        let host = rest.split(':').next().unwrap_or(rest);
+        if looks_like_bare_ipv4(host) {
+            return Some(format!("ftp://{rest}"));
+        }
+    }
+
+    // ftp.<IPv4 or bare domain> without a scheme
+    if let Some(rest) = origin.strip_prefix("ftp.") {
+        if looks_like_bare_ipv4(rest) {
+            // ftp.<IP> → ftp://<IP> (strips ftp. prefix; ftp://ftp.<IP> would fail URL parsing)
+            return Some(format!("ftp://{rest}"));
+        } else if looks_like_bare_domain(rest) {
+            // ftp.<domain> → ftp://ftp.<domain>
+            return Some(format!("ftp://{origin}"));
+        }
+    }
+
+    // bare domain, IPv4 address, or single-label hostname → moz-pwmngr-fixed://
+    if looks_like_bare_domain(origin) || looks_like_bare_label(origin) {
+        return Some(format!("moz-pwmngr-fixed://{origin}"));
+    }
+
+    None
+}
+
 impl LoginEntry {
     pub fn new(fields: LoginFields, sec_fields: SecureLoginFields) -> Self {
         Self {
@@ -441,7 +506,12 @@ impl LoginEntry {
                     "Error parsing login origin: {e:?} ({})",
                     error_support::redact_url(origin)
                 );
-                // We can't fixup completely invalid records, so always throw.
+                #[cfg(feature = "perform_additional_origin_fixups")]
+                if let Some(fixed) = perform_additional_origin_fixup(origin) {
+                    if Url::parse(&fixed).is_ok() {
+                        return Ok(Some(fixed));
+                    }
+                }
                 Err(InvalidLogin::IllegalOrigin {
                     reason: e.to_string(),
                 }
@@ -887,9 +957,105 @@ mod tests {
         }
 
         // Finally, look at some invalid logins
-        for input in &[".", "example", "example.com"] {
+        for input in &["."] {
             assert!(LoginEntry::validate_and_fixup_origin(input).is_err());
         }
+        // With perform_additional_origin_fixups, bare domains/labels get a moz-pwmngr-fixed:// scheme
+        #[cfg(not(feature = "perform_additional_origin_fixups"))]
+        for input in &["example.com", "example"] {
+            assert!(LoginEntry::validate_and_fixup_origin(input).is_err());
+        }
+        #[cfg(feature = "perform_additional_origin_fixups")]
+        {
+            assert_eq!(
+                LoginEntry::validate_and_fixup_origin("example.com")?,
+                Some("moz-pwmngr-fixed://example.com".into())
+            );
+            assert_eq!(
+                LoginEntry::validate_and_fixup_origin("example")?,
+                Some("moz-pwmngr-fixed://example".into())
+            );
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "perform_additional_origin_fixups")]
+    #[test]
+    fn test_additional_origin_fixups() -> Result<()> {
+        // Origins that are already valid should not be changed
+        for input in &[
+            "https://example.com",
+            "http://example.com:8080",
+            "ftp://ftp.example.com",
+            "moz-pwmngr-fixed://example.com",
+            "moz-pwmngr-fixed://foo.bar",
+        ] {
+            assert_eq!(
+                LoginEntry::validate_and_fixup_origin(input)?,
+                None,
+                "expected no change for: {input}"
+            );
+        }
+
+        // bare https: with incomplete authority (e.g. corrupted or addon-generated entry)
+        for input in &["https:", "https:/", "https://"] {
+            assert_eq!(
+                LoginEntry::validate_and_fixup_origin(input)?,
+                Some("https://moz.pwmngr.fixed".into()),
+                "input: {input}"
+            );
+        }
+
+        // http://ftp.<IP>[:port] — FireFTP stored origins like this instead of ftp://
+        assert_eq!(
+            LoginEntry::validate_and_fixup_origin("http://ftp.1.2.3.4")?,
+            Some("ftp://1.2.3.4".into())
+        );
+        assert_eq!(
+            LoginEntry::validate_and_fixup_origin("http://ftp.1.2.3.4:21")?,
+            Some("ftp://1.2.3.4:21".into())
+        );
+
+        // ftp.<IPv4> without a scheme — FireFTP IP variant (ftp. prefix stripped;
+        // ftp://ftp.<IP> would fail URL parsing due to the url crate's IPv4 detection)
+        assert_eq!(
+            LoginEntry::validate_and_fixup_origin("ftp.1.2.3.4")?,
+            Some("ftp://1.2.3.4".into())
+        );
+        // ftp.<domain> without a scheme — FireFTP domain variant
+        assert_eq!(
+            LoginEntry::validate_and_fixup_origin("ftp.example.com")?,
+            Some("ftp://ftp.example.com".into())
+        );
+
+        // bare IPv4 address — addon-generated or manually entered
+        assert_eq!(
+            LoginEntry::validate_and_fixup_origin("1.2.3.4")?,
+            Some("moz-pwmngr-fixed://1.2.3.4".into())
+        );
+
+        // bare domain without a scheme — addon-generated origins (e.g. PassHash, gManager)
+        for (input, output) in &[
+            ("example.com", "moz-pwmngr-fixed://example.com"),
+            ("sub.example.com", "moz-pwmngr-fixed://sub.example.com"),
+            ("foo.bar", "moz-pwmngr-fixed://foo.bar"),
+        ] {
+            assert_eq!(
+                LoginEntry::validate_and_fixup_origin(input)?,
+                Some((*output).into()),
+                "input: {input}"
+            );
+        }
+
+        // bare single-label hostname — addon-generated origins
+        assert_eq!(
+            LoginEntry::validate_and_fixup_origin("example")?,
+            Some("moz-pwmngr-fixed://example".into())
+        );
+
+        // things that cannot be fixed even with the feature on
+        assert!(LoginEntry::validate_and_fixup_origin(".").is_err());
 
         Ok(())
     }

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -383,68 +383,69 @@ pub struct LoginEntry {
 }
 
 #[cfg(feature = "perform_additional_origin_fixups")]
-fn looks_like_bare_ipv4(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    parts.len() == 4 && parts.iter().all(|p| p.parse::<u8>().is_ok())
-}
-
-// Returns true if `s` looks like a bare domain name (e.g. `example.com`):
-// at least two dot-separated labels, each label only ASCII alphanumeric or hyphens.
-#[cfg(feature = "perform_additional_origin_fixups")]
-fn looks_like_bare_domain(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    parts.len() >= 2
-        && parts.iter().all(|p| {
-            !p.is_empty() && p.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
-        })
-}
-
-// Returns true if `s` looks like a single hostname label (no dots),
-// e.g. addon-generated origins like "example".
-#[cfg(feature = "perform_additional_origin_fixups")]
-fn looks_like_bare_label(s: &str) -> bool {
-    !s.is_empty() && !s.contains('.') && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
-}
-
-// Attempts to repair origins that fail URL parsing:
-// - bare https: / https:/ / https:// → https://moz.pwmngr.fixed
-// - http://ftp.<IPv4>[:port] → ftp://<IPv4>[:port]  (FireFTP quirk)
-// - ftp.<IPv4>[:port] without a scheme → ftp://<IPv4>[:port]
-// - ftp.<domain> without a scheme → ftp://ftp.<domain>
-// - bare IPv4 address or bare domain → moz-pwmngr-fixed://<host>
-// - bare label (e.g. example) → moz-pwmngr-fixed://<label>
-#[cfg(feature = "perform_additional_origin_fixups")]
-fn perform_additional_origin_fixup(origin: &str) -> Option<String> {
-    // Bare https: with missing or incomplete authority.
-    if matches!(origin, "https:" | "https:/" | "https://") {
-        return Some("https://moz.pwmngr.fixed".to_string());
+mod origin_fixup {
+    fn looks_like_bare_ipv4(s: &str) -> bool {
+        let parts: Vec<&str> = s.split('.').collect();
+        parts.len() == 4 && parts.iter().all(|p| p.parse::<u8>().is_ok())
     }
 
-    // http://ftp.<IP>[:port] → ftp://<IP>[:port]
-    if let Some(rest) = origin.strip_prefix("http://ftp.") {
-        let host = rest.split(':').next().unwrap_or(rest);
-        if looks_like_bare_ipv4(host) {
-            return Some(format!("ftp://{rest}"));
+    // Returns true if `s` looks like a bare domain name (e.g. `example.com`):
+    // at least two dot-separated labels, each label only ASCII alphanumeric or hyphens.
+    fn looks_like_bare_domain(s: &str) -> bool {
+        let parts: Vec<&str> = s.split('.').collect();
+        parts.len() >= 2
+            && parts
+                .iter()
+                .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'))
+    }
+
+    // Returns true if `s` looks like a single hostname label (no dots),
+    // e.g. addon-generated origins like "example".
+    fn looks_like_bare_label(s: &str) -> bool {
+        !s.is_empty()
+            && !s.contains('.')
+            && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+    }
+
+    // Attempts to repair origins that fail URL parsing:
+    // - bare https: / https:/ / https:// → https://moz.pwmngr.fixed
+    // - http://ftp.<IPv4>[:port] → ftp://<IPv4>[:port]  (FireFTP quirk)
+    // - ftp.<IPv4>[:port] without a scheme → ftp://<IPv4>[:port]
+    // - ftp.<domain> without a scheme → ftp://ftp.<domain>
+    // - bare IPv4 address or bare domain → moz-pwmngr-fixed://<host>
+    // - bare label (e.g. example) → moz-pwmngr-fixed://<label>
+    pub fn perform_additional_origin_fixup(origin: &str) -> Option<String> {
+        // Bare https: with missing or incomplete authority.
+        if matches!(origin, "https:" | "https:/" | "https://") {
+            return Some("https://moz.pwmngr.fixed".to_string());
         }
-    }
 
-    // ftp.<IPv4 or bare domain> without a scheme
-    if let Some(rest) = origin.strip_prefix("ftp.") {
-        if looks_like_bare_ipv4(rest) {
-            // ftp.<IP> → ftp://<IP> (strips ftp. prefix; ftp://ftp.<IP> would fail URL parsing)
-            return Some(format!("ftp://{rest}"));
-        } else if looks_like_bare_domain(rest) {
-            // ftp.<domain> → ftp://ftp.<domain>
-            return Some(format!("ftp://{origin}"));
+        // http://ftp.<IP>[:port] → ftp://<IP>[:port]
+        if let Some(rest) = origin.strip_prefix("http://ftp.") {
+            let host = rest.split(':').next().unwrap_or(rest);
+            if looks_like_bare_ipv4(host) {
+                return Some(format!("ftp://{rest}"));
+            }
         }
-    }
 
-    // bare domain, IPv4 address, or single-label hostname → moz-pwmngr-fixed://
-    if looks_like_bare_domain(origin) || looks_like_bare_label(origin) {
-        return Some(format!("moz-pwmngr-fixed://{origin}"));
-    }
+        // ftp.<IPv4 or bare domain> without a scheme
+        if let Some(rest) = origin.strip_prefix("ftp.") {
+            if looks_like_bare_ipv4(rest) {
+                // ftp.<IP> → ftp://<IP> (strips ftp. prefix; ftp://ftp.<IP> would fail URL parsing)
+                return Some(format!("ftp://{rest}"));
+            } else if looks_like_bare_domain(rest) {
+                // ftp.<domain> → ftp://ftp.<domain>
+                return Some(format!("ftp://{origin}"));
+            }
+        }
 
-    None
+        // bare domain, IPv4 address, or single-label hostname → moz-pwmngr-fixed://
+        if looks_like_bare_domain(origin) || looks_like_bare_label(origin) {
+            return Some(format!("moz-pwmngr-fixed://{origin}"));
+        }
+
+        None
+    }
 }
 
 impl LoginEntry {
@@ -461,9 +462,11 @@ impl LoginEntry {
         }
     }
 
-    /// Helper for validation and fixups of an "origin" provided as a string.
-    pub fn validate_and_fixup_origin(origin: &str) -> Result<Option<String>> {
-        // Check we can parse the origin, then use the normalized version of it.
+    /// Shared core logic for origin-like fields: parses `origin` as a URL and
+    /// normalizes it to origin-only form. Returns `Ok(None)` if the input is
+    /// already a valid, normalized origin, `Ok(Some(fixed))` if it needed
+    /// normalization, or `Err` if the input cannot be parsed as a URL.
+    fn parse_and_normalize_origin(origin: &str) -> Result<Option<String>> {
         match Url::parse(origin) {
             Ok(mut u) => {
                 // Presumably this is a faster path than always setting?
@@ -506,17 +509,50 @@ impl LoginEntry {
                     "Error parsing login origin: {e:?} ({})",
                     error_support::redact_url(origin)
                 );
-                #[cfg(feature = "perform_additional_origin_fixups")]
-                if let Some(fixed) = perform_additional_origin_fixup(origin) {
-                    if Url::parse(&fixed).is_ok() {
-                        return Ok(Some(fixed));
-                    }
-                }
                 Err(InvalidLogin::IllegalOrigin {
                     reason: e.to_string(),
                 }
                 .into())
             }
+        }
+    }
+
+    /// Validation and fixups for a login `origin`.
+    ///
+    /// When the `perform_additional_origin_fixups` feature is enabled, some
+    /// origins that fail URL parsing (bare domains, FireFTP quirks, etc.)
+    /// are repaired into parseable URLs.
+    pub fn validate_and_fixup_origin(origin: &str) -> Result<Option<String>> {
+        match Self::parse_and_normalize_origin(origin) {
+            Ok(result) => Ok(result),
+            Err(e) => {
+                #[cfg(feature = "perform_additional_origin_fixups")]
+                if let Some(fixed) = origin_fixup::perform_additional_origin_fixup(origin) {
+                    if Url::parse(&fixed).is_ok() {
+                        return Ok(Some(fixed));
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Validation and normalizations for a login `form_action_origin`.
+    ///
+    /// When the `ignore_form_action_origin_validation_errors` feature is
+    /// enabled, unparseable values are accepted as-is (returning `Ok(None)`
+    /// so callers keep the original string), allowing non-URL values such
+    /// as "email" or "UserCode" that exist in some Desktop databases to be
+    /// saved regardless.
+    pub fn validate_and_normalize_form_action_origin(
+        form_action_origin: &str,
+    ) -> Result<Option<String>> {
+        match Self::parse_and_normalize_origin(form_action_origin) {
+            Ok(result) => Ok(result),
+            #[cfg(feature = "ignore_form_action_origin_validation_errors")]
+            Err(_) => Ok(None),
+            #[cfg(not(feature = "ignore_form_action_origin_validation_errors"))]
+            Err(e) => Err(e),
         }
     }
 }
@@ -830,7 +866,7 @@ impl ValidateAndFixup for LoginEntry {
                             .form_action_origin = Some("".into());
                     }
                 } else if !href.is_empty() && href != "javascript:" {
-                    match Self::validate_and_fixup_origin(href) {
+                    match Self::validate_and_normalize_form_action_origin(href) {
                         Ok(Some(fixed)) => {
                             get_fixed_or_throw!(InvalidLogin::IllegalFieldValue {
                                 field_info: "form_action_origin is not normalized".into()
@@ -838,9 +874,6 @@ impl ValidateAndFixup for LoginEntry {
                             .form_action_origin = Some(fixed);
                         }
                         Ok(None) => {}
-                        #[cfg(feature = "ignore_form_action_origin_validation_errors")]
-                        Err(_) => {}
-                        #[cfg(not(feature = "ignore_form_action_origin_validation_errors"))]
                         Err(e) => return Err(e),
                     }
                 }
@@ -957,7 +990,8 @@ mod tests {
         }
 
         // Finally, look at some invalid logins
-        for input in &["."] {
+        {
+            let input = &".";
             assert!(LoginEntry::validate_and_fixup_origin(input).is_err());
         }
         // With perform_additional_origin_fixups, bare domains/labels get a moz-pwmngr-fixed:// scheme
@@ -1058,6 +1092,62 @@ mod tests {
         assert!(LoginEntry::validate_and_fixup_origin(".").is_err());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_form_action_origin_normalizes_valid_urls() -> Result<()> {
+        // Already-normalized origins pass through.
+        assert_eq!(
+            LoginEntry::validate_and_normalize_form_action_origin("https://example.com")?,
+            None
+        );
+        // Full URLs get normalized to origin-only form, same as for `origin`.
+        assert_eq!(
+            LoginEntry::validate_and_normalize_form_action_origin("https://example.com/foo?x=1")?,
+            Some("https://example.com".into())
+        );
+        Ok(())
+    }
+
+    // The `perform_additional_origin_fixups` feature is intentionally scoped
+    // to the `origin` field. Inputs that it would repair for `origin` must
+    // NOT be repaired here.
+    #[cfg(feature = "perform_additional_origin_fixups")]
+    #[test]
+    fn test_form_action_origin_skips_additional_fixups() {
+        for input in &[
+            "example.com",
+            "example",
+            "1.2.3.4",
+            "https:",
+            "ftp.example.com",
+        ] {
+            let result = LoginEntry::validate_and_normalize_form_action_origin(input);
+            // The result depends on the other feature flag, but in no case
+            // should it be the moz-pwmngr-fixed:// / repaired form returned
+            // by `validate_and_fixup_origin`.
+            #[cfg(feature = "ignore_form_action_origin_validation_errors")]
+            assert_eq!(result.unwrap(), None, "input: {input}");
+            #[cfg(not(feature = "ignore_form_action_origin_validation_errors"))]
+            assert!(result.is_err(), "input: {input}");
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "ignore_form_action_origin_validation_errors"))]
+    fn test_form_action_origin_rejects_invalid() {
+        assert!(LoginEntry::validate_and_normalize_form_action_origin("email").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "ignore_form_action_origin_validation_errors")]
+    fn test_form_action_origin_accepts_invalid_with_feature() {
+        // With the feature on, unparseable values return Ok(None) — meaning
+        // "no fixup needed", so callers keep the original string as-is.
+        assert_eq!(
+            LoginEntry::validate_and_normalize_form_action_origin("email").unwrap(),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add `perform_additional_origin_fixups` feature flag that repairs `origin` values which fail URL parsing (bare domains, FireFTP quirks, bare `https:` / `https://`, etc.) into parseable URLs instead of rejecting them. Scoped to the `origin` field only; `form_action_origin` keeps the stricter behavior, but can be disabled via `ignore_form_action_origin_validation_errors`.

Intended to be enabled on desktop during migration to salvage legacy/addon-generated entries.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
