### PR TITLE
Refactor `CliFxa` to better manage the account state for cli apps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ logins.jwk
 *.db-wal
 *~
 .vscode/
-credentials.json
+credentials.json # no longer written to - new name below - so kinda deprecated.
+.fxa-cli-credentials.json
 .venv
 
 # Android stuff.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,6 @@ dependencies = [
  "fxa-client",
  "log",
  "nss",
- "sync15",
  "url",
  "viaduct",
  "viaduct-hyper",

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -12,7 +12,7 @@ use autofill::db::{
 use autofill::encryption::{create_autofill_key, EncryptorDecryptor};
 use autofill::error::Error;
 use clap::{Parser, Subcommand};
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
+use cli_support::fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE};
 use cli_support::prompt::{prompt_string, prompt_usize};
 use interrupt_support::NeverInterrupts; // XXX need a real interruptee!
 use std::sync::Arc;
@@ -341,10 +341,12 @@ fn run_sync(
     wait: u64,
 ) -> Result<()> {
     // XXX - need to add interrupts
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
+    let mut cli = CliFxa::new(get_default_fxa_config(), Some(&cred_file))?;
+    cli.ensure_logged_in(&[SYNC_SCOPE])?;
+    let sync = cli.sync_info()?.expect("logged in with SYNC_SCOPE");
 
     if wipe_all {
-        Sync15StorageClient::new(cli_fxa.client_init.clone())?.wipe_all_remote()?;
+        Sync15StorageClient::new(sync.client_init.clone())?.wipe_all_remote()?;
     }
     let mut mem_cached_state = MemoryCachedState::default();
     let mut global_state: Option<String> = None;
@@ -375,8 +377,8 @@ fn run_sync(
             &engines_to_sync,
             &mut global_state,
             &mut mem_cached_state,
-            &cli_fxa.client_init.clone(),
-            &cli_fxa.as_key_bundle()?,
+            &sync.client_init,
+            &sync.key_bundle,
             &NeverInterrupts,
             None,
         );

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -3,164 +3,267 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /// Utilities for command-line utilities which want to use fxa credentials.
-use std::{
-    collections::HashMap,
-    fs,
-    io::{Read, Write},
-};
+use std::{collections::HashMap, fs, io::Write};
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use url::Url;
 
-// This crate awkardly uses some internal implementation details of the fxa-client crate,
-// because we haven't worked on exposing those test-only features via UniFFI.
-use fxa_client::{AccessTokenInfo, FirefoxAccount, FxaConfig, FxaError};
-use sync15::client::Sync15StorageClientInit;
-use sync15::KeyBundle;
+use fxa_client::{DeviceConfig, DeviceType, FirefoxAccount, FxaConfig, FxaEvent, FxaState};
+use sync15::{client::Sync15StorageClientInit, KeyBundle};
 
-use crate::prompt::prompt_string;
+use crate::{prompt::prompt_string, workspace_root_dir};
 
-// Defaults - not clear they are the best option, but they are a currently
-// working option.
+// Defaults for the release FxA server
 const CLIENT_ID: &str = "3c49430b43dfba77";
 const REDIRECT_URI: &str = "https://accounts.firefox.com/oauth/success/3c49430b43dfba77";
+
+pub const CREDENTIALS_FILENAME: &str = ".fxa-cli-credentials.json";
+pub const PROFILE_SCOPE: &str = "profile";
 pub const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
 pub const SESSION_SCOPE: &str = "https://identity.mozilla.com/tokens/session";
+pub const RELAY_SCOPE: &str = "https://identity.mozilla.com/apps/relay";
+pub const VPN_SCOPE: &str = "https://identity.mozilla.com/apps/vpn";
+pub const MONITOR_SCOPE: &str = "https://identity.mozilla.com/apps/monitor";
+pub const SUBSCRIPTIONS_SCOPE: &str = "https://identity.mozilla.com/account/subscriptions";
 
-fn load_fxa_creds(path: &str) -> Result<FirefoxAccount> {
-    let mut file = fs::File::open(path)?;
-    let mut s = String::new();
-    file.read_to_string(&mut s)?;
-    Ok(FirefoxAccount::from_json(&s)?)
-}
+pub const WELL_KNOWN_SCOPES: [&str; 7] = [
+    PROFILE_SCOPE,
+    SYNC_SCOPE,
+    SESSION_SCOPE,
+    RELAY_SCOPE,
+    VPN_SCOPE,
+    MONITOR_SCOPE,
+    SUBSCRIPTIONS_SCOPE,
+];
 
-fn load_or_create_fxa_creds(path: &str, cfg: FxaConfig, scopes: &[&str]) -> Result<FirefoxAccount> {
-    match load_fxa_creds(path) {
-        Ok(account) => {
-            if !account.matches_server(&cfg.server)? {
-                bail!("Stored credentials don't match configured server.\nDelete {path} to start over or specify a different server arg")
-            }
-            Ok(account)
-        }
-        Err(e) => {
-            log::info!(
-                "Failed to load existing FxA credentials from {:?} (error: {}), launching OAuth flow",
-                path,
-                e
-            );
-            create_fxa_creds(path, cfg, scopes)
-        }
-    }
-}
+const DEVICE_NAME: &str = "app-services example cli client";
+const OAUTH_ENTRYPOINT: &str = "fxa_creds";
 
-fn create_fxa_creds(path: &str, cfg: FxaConfig, scopes: &[&str]) -> Result<FirefoxAccount> {
-    let acct = FirefoxAccount::new(cfg);
-    handle_oauth_flow(path, &acct, scopes)?;
-    Ok(acct)
-}
-
-fn handle_oauth_flow(path: &str, acct: &FirefoxAccount, scopes: &[&str]) -> Result<()> {
-    let oauth_uri = acct.begin_oauth_flow(scopes, "fxa_creds")?;
-
-    if open::that(&oauth_uri).is_err() {
-        log::warn!("Failed to open a web browser D:");
-        println!("Please visit this URL, sign in, and then copy-paste the final URL below.");
-        println!("\n    {}\n", oauth_uri);
-    } else {
-        println!("Please paste the final URL below:\n");
-    }
-
-    let final_url = url::Url::parse(&prompt_string("Final URL").unwrap_or_default())?;
-    let query_params = final_url
-        .query_pairs()
-        .into_owned()
-        .collect::<HashMap<String, String>>();
-
-    acct.complete_oauth_flow(&query_params["code"], &query_params["state"])?;
-    // Device registration.
-    acct.initialize_device("CLI Device", sync15::DeviceType::Desktop, vec![])?;
-    let mut file = fs::File::create(path)?;
-    write!(file, "{}", acct.to_json()?)?;
-    file.flush()?;
-    Ok(())
-}
-
-// Our public functions. It would be awesome if we could somehow integrate
-// better with clap, so we could automagically support various args (such as
-// the config to use or filenames to read), but this will do for now.
 pub fn get_default_fxa_config() -> FxaConfig {
     FxaConfig::release(CLIENT_ID, REDIRECT_URI)
 }
 
-pub fn get_account_and_token(
-    config: FxaConfig,
-    cred_file: &str,
-    scopes: &[&str],
-) -> Result<(FirefoxAccount, AccessTokenInfo)> {
-    // TODO: we should probably set a persist callback on acct?
-    let acct = load_or_create_fxa_creds(cred_file, config.clone(), scopes)?;
-    // `scope` could be a param, but I can't see it changing.
-    match acct.get_access_token(SYNC_SCOPE, true) {
-        Ok(t) => Ok((acct, t)),
-        Err(e) => {
-            match e {
-                // We can retry an auth error.
-                FxaError::Authentication => {
-                    println!("Saw an auth error using stored credentials - attempting to re-authenticate");
-                    println!("If fails, consider deleting {cred_file} to start from scratch");
-                    handle_oauth_flow(cred_file, &acct, scopes)?;
-                    let token = acct.get_access_token(SYNC_SCOPE, true)?;
-                    Ok((acct, token))
-                }
-                _ => Err(e.into()),
-            }
-        }
-    }
-}
-
-pub fn get_cli_fxa(config: FxaConfig, cred_file: &str, scopes: &[&str]) -> Result<CliFxa> {
-    let (account, token_info) = match get_account_and_token(config, cred_file, scopes) {
-        Ok(v) => v,
-        Err(e) => anyhow::bail!("Failed to use saved credentials. {}", e),
-    };
-    let tokenserver_url = Url::parse(&account.get_token_server_endpoint_url()?)?;
-
-    let client_init = Sync15StorageClientInit {
-        key_id: token_info.key.as_ref().unwrap().kid.clone(),
-        access_token: token_info.token.clone(),
-        tokenserver_url: tokenserver_url.clone(),
-    };
-
-    Ok(CliFxa {
-        account,
-        client_init,
-        tokenserver_url,
-        token_info,
-    })
-}
-
-pub struct CliFxa {
-    pub account: FirefoxAccount,
+/// Everything a sync consumer needs, built on demand by [`CliFxa::sync_info`].
+pub struct CliSyncInfo {
     pub client_init: Sync15StorageClientInit,
+    pub key_bundle: KeyBundle,
+    pub auth_info: sync_manager::SyncAuthInfo,
     pub tokenserver_url: Url,
-    pub token_info: AccessTokenInfo,
+}
+
+/// Manages FxA credentials for CLI examples and tests.
+///
+/// Typical usage:
+/// ```no_run
+/// let mut cli = CliFxa::new(get_default_fxa_config(), None)?;
+/// cli.ensure_logged_in(&[SYNC_SCOPE])?;
+/// let sync = cli.sync_info()?.expect("logged in with SYNC_SCOPE");
+/// ```
+pub struct CliFxa {
+    config: FxaConfig,
+    cred_path: String,
+    account: Option<FirefoxAccount>,
 }
 
 impl CliFxa {
-    // A helper for consumers who use this with the sync manager.
-    pub fn as_auth_info(&self) -> sync_manager::SyncAuthInfo {
-        let scoped_key = self.token_info.key.as_ref().unwrap();
-        sync_manager::SyncAuthInfo {
-            kid: scoped_key.kid.clone(),
-            sync_key: scoped_key.k.clone(),
-            fxa_access_token: self.token_info.token.clone(),
-            tokenserver_url: self.tokenserver_url.to_string(),
-        }
+    /// Create a `CliFxa`, loading saved credentials if they exist.
+    ///
+    /// `cred_path` defaults to `CREDENTIALS_FILENAME` in the workspace root.
+    pub fn new(config: FxaConfig, cred_path: Option<&str>) -> Result<Self> {
+        let cred_path = cred_path.map(|s| s.to_owned()).unwrap_or_else(|| {
+            workspace_root_dir()
+                .join(CREDENTIALS_FILENAME)
+                .to_string_lossy()
+                .to_string()
+        });
+
+        let account = match load_account(&cred_path, &config) {
+            Ok(acct) => {
+                log::info!("Loaded saved FxA credentials from {cred_path}");
+                match acct.check_authorization_status() {
+                    Ok(info) if info.active => {
+                        log::info!("fxa stored credentials are active");
+                        Some(acct)
+                    }
+                    Ok(_) => {
+                        log::warn!("fxa stored credentials are no longer active; re-login will be required");
+                        None
+                    }
+                    Err(e) => {
+                        log::warn!("FxA: could not verify authorization status ({e}); will attempt to use stored credentials");
+                        Some(acct)
+                    }
+                }
+            }
+            Err(e) => {
+                log::info!("No saved FxA credentials at {cred_path} ({e}); login required");
+                None
+            }
+        };
+
+        Ok(Self {
+            config,
+            cred_path,
+            account,
+        })
     }
 
-    // A helper for consumers who use this directly with sync15
-    pub fn as_key_bundle(&self) -> Result<KeyBundle> {
-        let scoped_key = self.token_info.key.as_ref().unwrap();
-        Ok(KeyBundle::from_ksync_bytes(&scoped_key.key_bytes()?)?)
+    /// Ensure the user is logged in, running interactive OAuth if needed.
+    ///
+    /// Uses the state machine: `Initialize` → `BeginOAuthFlow` if needed → `CompleteOAuthFlow`.
+    /// Persists credentials after a successful login.
+    pub fn ensure_logged_in(&mut self, scopes: &[&str]) -> Result<&FirefoxAccount> {
+        if self.account.is_none() {
+            log::info!("Creating new FxA account object");
+            self.account = Some(FirefoxAccount::new(self.config.clone()));
+        }
+
+        let device_config = DeviceConfig {
+            name: DEVICE_NAME.to_owned(),
+            device_type: DeviceType::Desktop,
+            capabilities: vec![],
+        };
+
+        let state = self
+            .account
+            .as_mut()
+            .unwrap()
+            .process_event(FxaEvent::Initialize { device_config })?;
+
+        match state {
+            FxaState::Connected => {
+                log::info!("FxA: already connected");
+                self.persist()?;
+            }
+            FxaState::Disconnected | FxaState::AuthIssues => {
+                log::info!("FxA: need to authenticate (state was {state:?})");
+                self.handle_oauth_flow(scopes)?;
+            }
+            other => {
+                anyhow::bail!("Unexpected FxA state after Initialize: {other:?}");
+            }
+        }
+
+        Ok(self.account.as_ref().unwrap())
     }
+
+    /// Get the account reference if logged in.
+    pub fn account(&self) -> Option<&FirefoxAccount> {
+        self.account.as_ref()
+    }
+
+    /// Get everything needed to sync, built fresh from the current access token.
+    ///
+    /// Returns `Ok(None)` if the sync scope key is not available (e.g., not logged in with
+    /// `SYNC_SCOPE`). Returns `Err` for real errors.
+    pub fn sync_info(&self) -> Result<Option<CliSyncInfo>> {
+        let account = self
+            .account
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("not logged in; call ensure_logged_in first"))?;
+
+        let token = account.get_access_token(SYNC_SCOPE, false)?;
+        let key = match token.key {
+            Some(k) => k,
+            None => {
+                log::info!("No sync key in token — not logged in with SYNC_SCOPE");
+                return Ok(None);
+            }
+        };
+
+        let tokenserver_url = Url::parse(&account.get_token_server_endpoint_url()?)?;
+        let client_init = Sync15StorageClientInit {
+            key_id: key.kid.clone(),
+            access_token: token.token.clone(),
+            tokenserver_url: tokenserver_url.clone(),
+        };
+        let key_bundle = KeyBundle::from_ksync_bytes(&key.key_bytes()?)?;
+        let auth_info = sync_manager::SyncAuthInfo {
+            kid: key.kid.clone(),
+            sync_key: key.k.clone(),
+            fxa_access_token: token.token.clone(),
+            tokenserver_url: tokenserver_url.to_string(),
+        };
+
+        Ok(Some(CliSyncInfo {
+            client_init,
+            key_bundle,
+            auth_info,
+            tokenserver_url,
+        }))
+    }
+
+    /// Persist account state to disk.
+    ///
+    /// Called automatically after login. Call this explicitly after any direct
+    /// account operation (e.g. `set_device_name`, `poll_device_commands`) that
+    /// may update local state.
+    pub fn persist(&self) -> Result<()> {
+        if let Some(account) = &self.account {
+            let json = account.to_json()?;
+            let mut file = fs::File::create(&self.cred_path)?;
+            write!(file, "{json}")?;
+            file.flush()?;
+            log::info!("Saved FxA credentials to {}", self.cred_path);
+        }
+        Ok(())
+    }
+
+    /// Run the interactive browser OAuth flow and complete the login.
+    fn handle_oauth_flow(&mut self, scopes: &[&str]) -> Result<()> {
+        let scopes: Vec<String> = scopes.iter().map(|s| s.to_string()).collect();
+
+        let state = self
+            .account
+            .as_mut()
+            .unwrap()
+            .process_event(FxaEvent::BeginOAuthFlow {
+                scopes,
+                entrypoint: OAUTH_ENTRYPOINT.to_owned(),
+            })?;
+
+        let oauth_url = match state {
+            FxaState::Authenticating { oauth_url } => oauth_url,
+            other => anyhow::bail!("Unexpected FxA state after BeginOAuthFlow: {other:?}"),
+        };
+
+        println!("Trying to open the auth URL — if your browser doesn't open, please open this URL manually:");
+        println!("    {oauth_url}\n");
+        match open::that(&oauth_url) {
+            Ok(()) => println!("Opened in your browser."),
+            Err(e) => log::warn!("Could not open a browser: {e}"),
+        }
+
+        let final_url = Url::parse(&prompt_string("Final URL").unwrap_or_default())?;
+        let query_params: HashMap<String, String> = final_url.query_pairs().into_owned().collect();
+
+        let state = self
+            .account
+            .as_mut()
+            .unwrap()
+            .process_event(FxaEvent::CompleteOAuthFlow {
+                code: query_params["code"].clone(),
+                state: query_params["state"].clone(),
+            })?;
+
+        match state {
+            FxaState::Connected => {
+                log::info!("FxA: OAuth flow complete, now connected");
+                self.persist()
+            }
+            other => anyhow::bail!("Unexpected FxA state after CompleteOAuthFlow: {other:?}"),
+        }
+    }
+}
+
+fn load_account(path: &str, config: &FxaConfig) -> Result<FirefoxAccount> {
+    let s = fs::read_to_string(path)?;
+    let account = FirefoxAccount::from_json(&s)?;
+    if !account.matches_server(&config.server)? {
+        anyhow::bail!(
+            "Stored credentials don't match configured server.\n\
+             Delete {path} to start over or use a different server arg"
+        )
+    }
+    Ok(account)
 }

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -5,8 +5,13 @@ authors = ["sync-team@mozilla.com"]
 license = "MPL-2.0"
 edition = "2021"
 publish = false
+autobins = false
 
-[dependencies]
+[[example]]
+name = "fxa-client"
+path = "src/main.rs"
+
+[dev-dependencies]
 nss = { path = "../../components/support/rc_crypto/nss" }
 viaduct = { path = "../../components/viaduct"}
 viaduct-hyper = { path = "../../components/support/viaduct-hyper" }
@@ -16,4 +21,3 @@ cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }
 anyhow = "1.0"
 url = "2.2"
-sync15 = { path = "../../components/sync15" }

--- a/examples/fxa-client/src/devices.rs
+++ b/examples/fxa-client/src/devices.rs
@@ -5,7 +5,7 @@
 use clap::{Args, Subcommand};
 use fxa_client::FirefoxAccount;
 
-use crate::{persist_fxa_state, Result};
+use anyhow::Result;
 
 #[derive(Args)]
 pub struct DeviceArgs {
@@ -36,6 +36,5 @@ fn list(account: &FirefoxAccount) -> Result<()> {
 fn set_name(account: &FirefoxAccount, name: String) -> Result<()> {
     account.set_device_name(&name)?;
     println!("Display name set to {name}");
-    persist_fxa_state(account)?;
     Ok(())
 }

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -5,19 +5,16 @@
 mod devices;
 mod send_tab;
 
-use std::fs;
-
 use clap::{Parser, Subcommand, ValueEnum};
-use cli_support::{fxa_creds, init_logging_with};
-use fxa_client::{FirefoxAccount, FxaConfig, FxaServer};
+use cli_support::fxa_creds::{self, CliFxa, WELL_KNOWN_SCOPES};
+use fxa_client::{FxaConfig, FxaServer};
 
-static CREDENTIALS_FILENAME: &str = "credentials.json";
 static CLIENT_ID: &str = "a2270f727f45f648";
 
 use anyhow::{bail, Result};
 
 #[derive(Parser)]
-#[command(about, long_about = None)]
+#[command(about, long_about = None, after_help=format!("Some well known scopes:\n{WELL_KNOWN_SCOPES:#?}"))]
 struct Cli {
     /// The FxA server to use
     #[clap(long)]
@@ -27,28 +24,8 @@ struct Cli {
     #[clap(long)]
     custom_url: Option<String>,
 
-    /// Request a session scope
-    #[clap(long, short, action)]
-    session_scope: bool,
-
-    /// Print out log to the console.  The default level is WARN
-    #[clap(long, short, action)]
-    log: bool,
-
-    /// Set the logging level to INFO
-    #[clap(long, short, action)]
-    info: bool,
-
-    /// Set the logging level to DEBUG
-    #[clap(long, short, action)]
-    debug: bool,
-
-    /// Set the logging level to TRACE
-    #[clap(long, short, action)]
-    trace: bool,
-
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -76,15 +53,22 @@ enum Command {
     /// This can be used to test the token exchange API for relay
     /// (https://bugzilla.mozilla.org/show_bug.cgi?id=2012143).
     ///
-    /// * Start with a fresh account by using the `cargo fxa disconnect`
-    /// * Run `cargo fxa --log --trace get-access-token https://identity.mozilla.com/apps/relay`.
+    /// * Start with a fresh account by using `cargo run --example fxa-client disconnect`
+    /// * Log in to the account with `cargo run --example fxa-client login`
+    /// * Run `RUST_LOG=trace cargo run --example fxa-client fxa get-access-token https://identity.mozilla.com/apps/relay`.
     ///   * You should see a token exchange request in the trace logs.
-    /// * Run `cargo fxa --log --trace get-access-token https://identity.mozilla.com/apps/relay`
+    /// * Run `RUST_LOG=trace cargo run --example fxa-client https://identity.mozilla.com/apps/relay`
     ///   again.
     ///   * This time there shouldn't be a token exchange request, since the refresh token now has
     ///     the relay scope.
     GetAccessToken {
         scope: String,
+    },
+    /// Log in to FxA with the given scopes
+    Login {
+        /// OAuth scopes to request (repeatable), if not supplied, sync, session and profile scopes are requested.
+        #[clap(long = "scope", required = true)]
+        scopes: Vec<String>,
     },
     Disconnect,
 }
@@ -93,42 +77,49 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     nss::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
-    if cli.log {
-        if cli.trace {
-            init_logging_with("fxa_client=trace");
-        } else if cli.debug {
-            init_logging_with("fxa_client=debug");
-        } else if cli.info {
-            init_logging_with("fxa_client=info");
-        } else {
-            init_logging_with("fxa_client=warn");
-        }
-    }
-
-    let scopes: &[&str] = if cli.session_scope {
-        &[fxa_creds::SYNC_SCOPE, fxa_creds::SESSION_SCOPE]
-    } else {
-        &[fxa_creds::SYNC_SCOPE]
-    };
+    cli_support::init_logging_with("info");
 
     println!();
-    let account = load_account(&cli, scopes)?;
+    let mut fxa = make_cli_fxa(&cli)?;
+
     match cli.command {
-        Command::Devices(args) => devices::run(&account, args),
-        Command::SendTab(args) => send_tab::run(&account, args),
-        Command::GetAccessToken { scope } => {
-            println!("Requesting access token with scope: {scope}");
-            account.get_access_token(&scope, false)?;
-            println!("Saving account with updated token");
-            persist_fxa_state(&account)?;
-            println!("Success");
-            Ok(())
+        None => {
+            println!("A utility to help manage a Firefox account in a CLI environment");
+            println!("The account state managed by this utility can be used by many app-services demos and examples.");
+            println!("Run with `help` or `--help` for more");
+            print_status(&fxa);
+            return Ok(());
         }
-        Command::Disconnect => {
-            account.disconnect();
-            Ok(())
+        Some(Command::Login { scopes }) => {
+            let scope_refs: Vec<&str> = if scopes.is_empty() {
+                vec![fxa_creds::SYNC_SCOPE, fxa_creds::SESSION_SCOPE]
+            } else {
+                scopes.iter().map(|s| s.as_str()).collect()
+            };
+            fxa.ensure_logged_in(&scope_refs)?;
+            print_status(&fxa);
         }
-    }?;
+        Some(command) => {
+            let Some(account) = fxa.account() else {
+                println!("not logged in");
+                return Ok(());
+            };
+            match command {
+                Command::Devices(args) => devices::run(account, args)?,
+                Command::SendTab(args) => send_tab::run(account, args)?,
+                Command::GetAccessToken { scope } => {
+                    println!("Requesting access token with scope: {scope}");
+                    account.get_access_token(&scope, false)?;
+                    println!("Success");
+                }
+                Command::Disconnect => {
+                    account.disconnect();
+                }
+                Command::Login { .. } => unreachable!(),
+            }
+        }
+    }
+    fxa.persist()?;
 
     Ok(())
 }
@@ -152,7 +143,20 @@ impl Cli {
     }
 }
 
-fn load_account(cli: &Cli, scopes: &[&str]) -> Result<FirefoxAccount> {
+fn print_status(fxa: &CliFxa) {
+    match fxa.account() {
+        None => println!("Not logged in"),
+        Some(account) => match account.check_authorization_status() {
+            Ok(status) if status.active => {
+                println!("Account is logged in and authorized by the server")
+            }
+            Ok(_) => println!("Account is logged in but not authorized by the server"),
+            Err(e) => println!("Account logged in but account status failed: {e}"),
+        },
+    }
+}
+
+fn make_cli_fxa(cli: &Cli) -> Result<CliFxa> {
     let server = cli.server()?;
     let redirect_uri = format!("{}/oauth/success/a2270f727f45f648", server.content_url());
     let config = FxaConfig {
@@ -161,14 +165,5 @@ fn load_account(cli: &Cli, scopes: &[&str]) -> Result<FirefoxAccount> {
         client_id: CLIENT_ID.into(),
         token_server_url_override: None,
     };
-    fxa_creds::get_cli_fxa(config, &credentials_path(), scopes).map(|cli| cli.account)
-}
-
-pub fn persist_fxa_state(acct: &FirefoxAccount) -> Result<()> {
-    let json = acct.to_json().unwrap();
-    Ok(fs::write(credentials_path(), json)?)
-}
-
-fn credentials_path() -> String {
-    cli_support::cli_data_path(CREDENTIALS_FILENAME)
+    CliFxa::new(config, Some(fxa_creds::CREDENTIALS_FILENAME))
 }

--- a/examples/fxa-client/src/send_tab.rs
+++ b/examples/fxa-client/src/send_tab.rs
@@ -5,7 +5,7 @@
 use clap::{Args, Subcommand};
 use fxa_client::{FirefoxAccount, IncomingDeviceCommand};
 
-use crate::{persist_fxa_state, Result};
+use anyhow::Result;
 
 #[derive(Args)]
 pub struct SendTabArgs {
@@ -47,7 +47,6 @@ fn poll(account: &FirefoxAccount) -> Result<()> {
     println!("Polling for send-tab events.  Ctrl-C to cancel");
     loop {
         let events = account.poll_device_commands().unwrap_or_default(); // Ignore 404 errors for now.
-        persist_fxa_state(account)?;
         if !events.is_empty() {
             for e in events {
                 match e {

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -5,7 +5,7 @@
 #![warn(rust_2018_idioms)]
 
 use clap::{Parser, Subcommand};
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
+use cli_support::fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE};
 use interrupt_support::Interruptee;
 use places::storage::bookmarks::{
     json_tree::{
@@ -236,10 +236,12 @@ fn sync(
 ) -> Result<()> {
     viaduct_hyper::viaduct_init_backend_hyper()?;
 
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
+    let mut cli = CliFxa::new(get_default_fxa_config(), Some(&cred_file))?;
+    cli.ensure_logged_in(&[SYNC_SCOPE])?;
+    let sync = cli.sync_info()?.expect("logged in with SYNC_SCOPE");
 
     if wipe_all {
-        Sync15StorageClient::new(cli_fxa.client_init.clone())?.wipe_all_remote()?;
+        Sync15StorageClient::new(sync.client_init.clone())?.wipe_all_remote()?;
     }
     // phew - working with traits is making markh's brain melt!
     // Note also that PlacesApi::sync() exists and ultimately we should
@@ -287,8 +289,8 @@ fn sync(
             &engines_to_sync,
             &mut global_state,
             &mut mem_cached_state,
-            &cli_fxa.client_init.clone(),
-            &cli_fxa.as_key_bundle()?,
+            &sync.client_init,
+            &sync.key_bundle,
             &interrupt_support::ShutdownInterruptee,
             None,
         );

--- a/examples/relevancy-cli/src/main.rs
+++ b/examples/relevancy-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use cli_support::{
-    fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE},
+    fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE},
     remote_settings_service,
 };
 use env_logger::Builder;
@@ -17,8 +17,6 @@ use sync15::client::{sync_multiple, MemoryCachedState};
 use sync15::engine::SyncEngineId;
 
 use anyhow::{bail, Result};
-
-static CREDENTIALS_PATH: &str = ".cli-data/credentials.json";
 
 #[derive(Parser)]
 #[command(about, long_about = None)]
@@ -38,9 +36,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     nss::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
-    if let Some(dir) = std::path::PathBuf::from(CREDENTIALS_PATH).parent() {
-        std::fs::create_dir_all(dir)?;
-    }
+    cli_support::ensure_cli_data_dir_exists();
     let mut builder = Builder::new();
     builder.filter_level(log::LevelFilter::Info);
     if cli.verbose {
@@ -78,7 +74,9 @@ fn main() -> Result<()> {
 
 fn sync_places(places_api: &Arc<PlacesApi>) -> Result<()> {
     Arc::clone(places_api).register_with_sync_manager();
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), CREDENTIALS_PATH, &[SYNC_SCOPE])?;
+    let mut cli = CliFxa::new(get_default_fxa_config(), None)?;
+    cli.ensure_logged_in(&[SYNC_SCOPE])?;
+    let sync = cli.sync_info()?.expect("logged in with SYNC_SCOPE");
     let mut mem_cached_state = MemoryCachedState::default();
     let mut global_state: Option<String> = None;
     let engine = places::get_registered_sync_engine(&SyncEngineId::History)
@@ -87,8 +85,8 @@ fn sync_places(places_api: &Arc<PlacesApi>) -> Result<()> {
         &[&*engine],
         &mut global_state,
         &mut mem_cached_state,
-        &cli_fxa.client_init.clone(),
-        &cli_fxa.as_key_bundle()?,
+        &sync.client_init,
+        &sync.key_bundle,
         &NeverInterrupts,
         None,
     );

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -5,10 +5,7 @@
 #![recursion_limit = "4096"]
 #![warn(rust_2018_idioms)]
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use cli_support::fxa_creds::{
-    get_account_and_token, get_cli_fxa, get_default_fxa_config, SYNC_SCOPE,
-};
+use cli_support::fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE};
 use cli_support::prompt::{prompt_char, prompt_password, prompt_string, prompt_usize};
 use logins::encryption::{ManagedEncryptorDecryptor, NSSKeyManager, PrimaryPasswordAuthenticator};
 use logins::{Login, LoginEntry, LoginStore, LoginsApiError, LoginsSyncEngine, ValidateAndFixup};
@@ -326,7 +323,7 @@ fn do_sync(
     store: Arc<LoginStore>,
     key_id: String,
     access_token: String,
-    sync_key: String,
+    root_sync_key: &sync15::KeyBundle,
     tokenserver_url: url::Url,
 ) -> Result<String> {
     let engine = LoginsSyncEngine::new(Arc::clone(&store))?;
@@ -336,7 +333,6 @@ fn do_sync(
         access_token,
         tokenserver_url,
     };
-    let root_sync_key = &sync15::KeyBundle::from_ksync_base64(sync_key.as_str())?;
 
     // We don't track any state at all - this means every sync acts like a first sync.
     // We should consider supporting this - choices would be to re-open the database ourself and abuse the
@@ -496,18 +492,16 @@ fn main() -> Result<()> {
             }
             'S' | 's' => {
                 log::info!("Syncing!");
-                let (_, token_info) = get_account_and_token(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
-                let sync_key = URL_SAFE_NO_PAD.encode(
-                    token_info.key.unwrap().key_bytes()?,
-                );
                 // TODO: allow users to use stage/etc.
-                let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
+                let mut cli = CliFxa::new(get_default_fxa_config(), Some(&cred_file))?;
+                cli.ensure_logged_in(&[SYNC_SCOPE])?;
+                let sync = cli.sync_info()?.expect("logged in with SYNC_SCOPE");
                 match do_sync(
                     Arc::clone(&store),
-                    cli_fxa.client_init.key_id.clone(),
-                    cli_fxa.client_init.access_token.clone(),
-                    sync_key,
-                    cli_fxa.client_init.tokenserver_url.clone(),
+                    sync.client_init.key_id.clone(),
+                    sync.client_init.access_token.clone(),
+                    &sync.key_bundle,
+                    sync.client_init.tokenserver_url.clone(),
                 ) {
                     Err(e) => {
                         log::warn!("Sync failed! {}", e);

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -4,11 +4,8 @@
 
 #![warn(rust_2018_idioms)]
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::Parser;
-use cli_support::fxa_creds::{
-    get_account_and_token, get_cli_fxa, get_default_fxa_config, SYNC_SCOPE,
-};
+use cli_support::fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE};
 use cli_support::prompt::{prompt_char, prompt_string};
 use interrupt_support::NeverInterrupts;
 use std::path::Path;
@@ -57,7 +54,7 @@ fn do_sync(
     store: Arc<TabsStore>,
     key_id: String,
     access_token: String,
-    sync_key: String,
+    root_sync_key: &KeyBundle,
     tokenserver_url: url::Url,
     local_id: String,
 ) -> Result<String> {
@@ -74,9 +71,8 @@ fn do_sync(
     let storage_init = &Sync15StorageClientInit {
         key_id,
         access_token,
-        tokenserver_url: url::Url::parse(tokenserver_url.as_str())?,
+        tokenserver_url,
     };
-    let root_sync_key = &KeyBundle::from_ksync_base64(sync_key.as_str())?;
 
     let mut result = sync_multiple(
         &[&engine],
@@ -103,12 +99,10 @@ fn main() -> Result<()> {
     cli_support::init_logging();
     let opts = Opts::parse();
 
-    let (_, token_info) =
-        get_account_and_token(get_default_fxa_config(), &opts.creds_file, &[SYNC_SCOPE])?;
-    let sync_key = URL_SAFE_NO_PAD.encode(token_info.key.unwrap().key_bytes()?);
-
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &opts.creds_file, &[SYNC_SCOPE])?;
-    let device_id = cli_fxa.account.get_current_device_id()?;
+    let mut cli = CliFxa::new(get_default_fxa_config(), Some(&opts.creds_file))?;
+    cli.ensure_logged_in(&[SYNC_SCOPE])?;
+    let sync = cli.sync_info()?.expect("logged in with SYNC_SCOPE");
+    let device_id = cli.account().unwrap().get_current_device_id()?;
 
     let store = Arc::new(TabsStore::new(Path::new(&opts.db_path)));
 
@@ -180,10 +174,10 @@ fn main() -> Result<()> {
                 log::info!("Syncing!");
                 match do_sync(
                     Arc::clone(&store),
-                    cli_fxa.client_init.clone().key_id,
-                    cli_fxa.client_init.clone().access_token,
-                    sync_key.clone(),
-                    cli_fxa.client_init.tokenserver_url.clone(),
+                    sync.client_init.key_id.clone(),
+                    sync.client_init.access_token.clone(),
+                    &sync.key_bundle,
+                    sync.client_init.tokenserver_url.clone(),
                     device_id.clone(),
                 ) {
                     Err(e) => {

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -44,17 +44,16 @@ impl TestClient {
     pub fn new(cli: Arc<CliFxa>, device_name: &str) -> Result<Self> {
         // XXX - not clear if/how this device gets cleaned up - we never disconnect from the account!
         // And this is messy - I think it reflects that the public device api should be improved?
-        let device = match cli
-            .account
+        let account = cli.account().expect("CliFxa must be logged in");
+        let device = match account
             .get_devices(false)?
             .into_iter()
             .find(|d| d.is_current_device)
         {
             Some(d) => d,
             None => {
-                cli.account
-                    .initialize_device(device_name, DeviceType::Desktop, vec![])?;
-                cli.account
+                account.initialize_device(device_name, DeviceType::Desktop, vec![])?;
+                account
                     .get_devices(true)?
                     .into_iter()
                     .find(|d| d.is_current_device)
@@ -94,6 +93,7 @@ impl TestClient {
         self.autofill_store.clone().register_with_sync_manager();
         self.tabs_store.clone().register_with_sync_manager();
         self.logins_store.clone().register_with_sync_manager();
+        let sync_info = self.cli.sync_info()?.expect("CliFxa must have SYNC_SCOPE");
         let params = SyncParams {
             reason: SyncReason::User,
             engines: SyncEngineSelection::Some {
@@ -101,7 +101,7 @@ impl TestClient {
             },
             enabled_changes: HashMap::new(),
             local_encryption_keys,
-            auth_info: self.cli.as_auth_info(),
+            auth_info: sync_info.auth_info,
             persisted_state: self.persisted_state.take(),
             device_settings: DeviceSettings {
                 fxa_device_id: self.device.id.clone(),
@@ -135,6 +135,7 @@ impl TestClient {
         self.autofill_store.clone().register_with_sync_manager();
         self.tabs_store.clone().register_with_sync_manager();
         self.logins_store.clone().register_with_sync_manager();
+        let sync_info = self.cli.sync_info()?.expect("CliFxa must have SYNC_SCOPE");
         let params = SyncParams {
             reason: SyncReason::User,
             engines: SyncEngineSelection::Some {
@@ -142,7 +143,7 @@ impl TestClient {
             },
             enabled_changes: HashMap::new(),
             local_encryption_keys,
-            auth_info: self.cli.as_auth_info(),
+            auth_info: sync_info.auth_info,
             persisted_state: self.persisted_state.take(),
             device_settings: DeviceSettings {
                 fxa_device_id: self.device.id.clone(),
@@ -163,7 +164,8 @@ impl TestClient {
     }
 
     pub fn fully_wipe_server(&mut self) -> Result<()> {
-        Sync15StorageClient::new(self.cli.client_init.clone())?.wipe_all_remote()?;
+        let sync_info = self.cli.sync_info()?.expect("CliFxa must have SYNC_SCOPE");
+        Sync15StorageClient::new(sync_info.client_init)?.wipe_all_remote()?;
         Ok(())
     }
 

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -5,7 +5,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 #![warn(rust_2018_idioms)]
 
 use clap::Parser;
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
+use cli_support::fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE};
 use nss::ensure_initialized;
 use std::sync::Arc;
 use std::{collections::HashSet, process};
@@ -80,9 +80,9 @@ pub fn run_test_group(opts: &Opts, group: TestGroup) {
     }
 
     let cfg = get_default_fxa_config();
-    let cli_fxa =
-        get_cli_fxa(cfg, &opts.credential_file, &[SYNC_SCOPE]).expect("can't initialize cli");
-    let acct = Arc::new(cli_fxa);
+    let mut cli = CliFxa::new(cfg, opts.credential_file.as_deref()).expect("can't create CliFxa");
+    cli.ensure_logged_in(&[SYNC_SCOPE]).expect("can't log in");
+    let acct = Arc::new(cli);
 
     let mut user = TestUser::new(acct, 2).expect("Failed to get test user.");
     let (c0, c1) = {
@@ -123,8 +123,8 @@ pub struct Opts {
     /// Either 'release', 'stage', 'stable-dev', or a URL.
     pub fxa_stack: FxaConfigUrl,
 
-    #[arg(long = "credentials", default_value = "./credentials.json")]
-    credential_file: String,
+    #[arg(long = "credentials")]
+    credential_file: Option<String>,
 
     #[arg(long = "helper-debug")]
     /// Run the helper browser as non-headless, and enable extra logging

--- a/testing/sync-test/src/sync15.rs
+++ b/testing/sync-test/src/sync15.rs
@@ -147,12 +147,17 @@ fn sync_client(c: &mut TestClient, desc: &str, engine: &dyn SyncEngine) {
     let mut persisted_global_state = None;
     let mut mem_cached_state = MemoryCachedState::default();
 
+    let sync_info = c
+        .cli
+        .sync_info()
+        .unwrap()
+        .expect("CliFxa must have SYNC_SCOPE");
     let result = sync_multiple(
         &[engine],
         &mut persisted_global_state,
         &mut mem_cached_state,
-        &c.cli.client_init,
-        &c.cli.as_key_bundle().unwrap(),
+        &sync_info.client_init,
+        &sync_info.key_bundle,
         &NeverInterrupts,
         None,
     );


### PR DESCRIPTION
This adds methods etc to `CliFxa` for account state operations - this will make it much easier to, eg, add new scopes to an existing login while already logged in. It doesn't insist the first login must be with sync scopes etc, and simplifies how the credentials file is managed etc.

It changes relevancy to use this new model - it previously specified a different location for credentials.json, but I don't see a great reason for that - all examples etc are probably better served with a "global" account state, as they are cheap to create etc.

Also removed the ability to set log levels from the command line as they weren't that useful - the logs of interest tend to be in fxa-client, or in the other crates using this. This just means `RUST_LOG` must be used, which seems fine.

It changes the name of the credentials file to be a name that's both clearer and with a leading period. Don't care too much about this one but it seems an improvement to me.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
