### PR TITLE
Fix tracing error messages

### DIFF
--- a/components/support/error/src/error_tracing.rs
+++ b/components/support/error/src/error_tracing.rs
@@ -11,7 +11,7 @@ use parking_lot::Mutex;
 
 static GLOBALS: Mutex<Globals> = Mutex::new(Globals::new());
 
-pub fn report_error_to_app(type_name: String, details: String) {
+pub fn report_error_to_app(type_name: String, message: String) {
     // First step: perform all actions that we need the lock for.
     let breadcrumbs = {
         let mut globals = GLOBALS.lock();
@@ -30,8 +30,8 @@ pub fn report_error_to_app(type_name: String, details: String) {
     // breadcrumbs will be sent in the `breadcrumbs` field as a single string, with each individual
     // breadcrumb joined by newlines.
     let breadcrumbs = breadcrumbs.join("\n");
-    let details = truncate_details(details);
-    tracing_support::error!(target: "app-services-error-reporter::error", details, type_name, breadcrumbs);
+    let message = truncate_message(message);
+    tracing_support::error!(target: "app-services-error-reporter::error", message, type_name, breadcrumbs);
 }
 
 pub fn report_breadcrumb(message: String, module: String, line: u32, column: u32) {
@@ -103,7 +103,7 @@ impl BreadcrumbRingBuffer {
     }
 }
 
-fn truncate_details(details: String) -> String {
+fn truncate_message(details: String) -> String {
     // Limit details to 255 chars so that they fit in a Glean String list
     // (https://mozilla.github.io/glean/book/reference/metrics/string.html)
     truncate_string(details, 255)


### PR DESCRIPTION
We haven't been getting error details since
c73cf2c21b10e44a14f2d344c7348e691ad87f98 because of a dumb error in that commit. We inconsistently name this data "details" or "message", however it needs to be "message" in the Rust code since that's the name we use in the `TracingEvent` struct.  The `tracing_support::error!` macro sees the variable names and uses them to generate the JSON, which is why this name change matters.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
