### PR TITLE
Bug 2034602 - Call unenrollForGeckoPref and getPreviousGeckoPrefStates on background thread only [ci full]

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -452,7 +452,21 @@ open class Nimbus(
         }
     }
 
+    @AnyThread
     override fun unenrollForGeckoPref(
+        geckoPrefState: GeckoPrefState,
+        prefUnenrollReason: PrefUnenrollReason,
+    ) {
+        dbScope.launch {
+            withCatchAll("unenrollForGeckoPref") {
+                unenrollForGeckoPrefOnThisThread(geckoPrefState, prefUnenrollReason)
+            }
+        }
+    }
+
+    @WorkerThread
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun unenrollForGeckoPrefOnThisThread(
         geckoPrefState: GeckoPrefState,
         prefUnenrollReason: PrefUnenrollReason,
     ): List<EnrollmentChangeEvent> {
@@ -469,7 +483,9 @@ open class Nimbus(
         }
     }
 
-    override fun getPreviousGeckoPrefStates(experimentSlug: String): List<PreviousGeckoPrefState>? {
+    @WorkerThread
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getPreviousGeckoPrefStatesOnThisThread(experimentSlug: String): List<PreviousGeckoPrefState>? {
         return nimbusClient.getPreviousGeckoPrefStates(experimentSlug)
     }
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -196,7 +196,7 @@ interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusE
     fun unenrollForGeckoPref(
         geckoPrefState: GeckoPrefState,
         prefUnenrollReason: PrefUnenrollReason,
-    ): List<EnrollmentChangeEvent> = listOf()
+    ) = Unit
 
     /**
      * Add a list of previous states with the original Gecko pref values on each involved enrollment.

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -934,7 +934,7 @@ class NimbusTests {
         assertEquals(1, handler.setValues?.size)
         assertEquals("42", handler.setValues?.get(0)?.enrollmentValue?.prefValue)
 
-        val events = nimbus.unenrollForGeckoPref(
+        val events = nimbus.unenrollForGeckoPrefOnThisThread(
             handler.internalMap["about_welcome"]?.get("number")!!,
             PrefUnenrollReason.FAILED_TO_SET,
         )
@@ -965,7 +965,7 @@ class NimbusTests {
         nimbus.registerPreviousGeckoPrefStates(handler.setValues!!)
         shadowOf(Looper.getMainLooper()).idle()
 
-        val previousStates = nimbus.getPreviousGeckoPrefStates("test-experiment")
+        val previousStates = nimbus.getPreviousGeckoPrefStatesOnThisThread("test-experiment")
         shadowOf(Looper.getMainLooper()).idle()
 
         assertNotNull(previousStates)


### PR DESCRIPTION
These Nimbus client functions must only be called on the background thread because they are not thread-safe. They have been refactored into `...OnThisThread` helpers (that are private but otherwise available for testing) and have been replaced by versions that call the thread-unsafe version on the correct thread.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
