### PR TITLE
Remote-Settings: Adding support for v2 routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Remote Settings
 * Add uptake telemetry support ([#7288](https://github.com/mozilla/application-services/pull/7288))
+* Add v2 routes ([#7339](https://github.com/mozilla/application-services/pull/7339))
 
 # v151.0 (_2026-04-20_)
 

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -31,8 +31,11 @@ pub struct RemoteSettingsConfig {
 #[derive(Debug, Clone, uniffi::Enum)]
 pub enum RemoteSettingsServer {
     Prod,
+    ProdV2,
     Stage,
+    StageV2,
     Dev,
+    DevV2,
     Custom { url: String },
 }
 
@@ -74,9 +77,17 @@ impl RemoteSettingsServer {
 
     fn raw_url(&self) -> &str {
         match self {
+            // v1 routes, current default
             Self::Prod => "https://firefox.settings.services.mozilla.com/v1",
             Self::Stage => "https://firefox.settings.services.allizom.org/v1",
             Self::Dev => "https://remote-settings-dev.allizom.org/v1",
+
+            // v2 routes, optional for now but will be default later
+            Self::ProdV2 => "https://firefox.settings.services.mozilla.com/v2",
+            Self::StageV2 => "https://firefox.settings.services.allizom.org/v2",
+            Self::DevV2 => "https://remote-settings-dev.allizom.org/v2",
+
+            // custom, not currently implemented in android or iOS
             Self::Custom { url } => url,
         }
     }
@@ -90,6 +101,9 @@ impl RemoteSettingsServer {
             Self::Prod => Url::parse("https://firefox.settings.services.mozilla.com/v1")?,
             Self::Stage => Url::parse("https://firefox.settings.services.allizom.org/v1")?,
             Self::Dev => Url::parse("https://remote-settings-dev.allizom.org/v1")?,
+            Self::ProdV2 => Url::parse("https://firefox.settings.services.mozilla.com/v2")?,
+            Self::StageV2 => Url::parse("https://firefox.settings.services.allizom.org/v2")?,
+            Self::DevV2 => Url::parse("https://remote-settings-dev.allizom.org/v2")?,
             Self::Custom { url } => {
                 let mut url = Url::parse(url)?;
                 // Custom URLs are weird and require a couple tricks for backwards compatibility.


### PR DESCRIPTION
## Description
This adds 3 new remote-settings endpoints for the v2 service routes.

Mobile works a little differently than desktop currently, so this seems like the best path forward. Once v1 support is dropped in the future, we'll shrink this list back down to 3 options.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR has no breaking changes
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR does not change any business logic, no tests needed
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - No dependency changes


Testing locally with android and it looks like this works.
<img width="674" height="275" alt="image" src="https://github.com/user-attachments/assets/457505a4-12aa-41db-a2f3-35b59306a606" />
