### PR TITLE
Bug 2027114 - Produce expected data format in nimbus-cli list command

### DIFF
--- a/components/support/nimbus-cli/src/sources/experiment_list.rs
+++ b/components/support/nimbus-cli/src/sources/experiment_list.rs
@@ -240,7 +240,7 @@ impl TryFrom<&ExperimentListSource> for Value {
                 let client = rs_service.make_client(collection_name);
 
                 let response = client.get_records(true);
-                serde_json::to_value(response)?
+                serde_json::json!({ "data": response} )
             }
             ExperimentListSource::FromFile { file } => {
                 let v: Value = value_utils::read_from_file(file)?;


### PR DESCRIPTION
The nimbus-cli list command expects the data from the RS server to be the raw JSON payload from the HTTP request, i.e., it should have a `data` field with the actual record contents. Until we have time to go through the entire SDK and CLI and update the parsing (see-also bug 2002310), we just wrap the returned response in an object with a data member.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
