### PR TITLE
[DISCO-4151] Merino: add client for wcs

### DIFF
--- a/components/merino/src/lib.rs
+++ b/components/merino/src/lib.rs
@@ -20,4 +20,5 @@
 
 pub mod curated_recommendations;
 pub mod suggest;
+pub mod worldcup;
 uniffi::setup_scaffolding!("merino");

--- a/components/merino/src/worldcup/error.rs
+++ b/components/merino/src/worldcup/error.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub use error_support::error;
+use error_support::{ErrorHandling, GetErrorHandling};
+
+pub type Result<T> = std::result::Result<T, Error>;
+pub type ApiResult<T> = std::result::Result<T, MerinoWorldCupApiError>;
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum MerinoWorldCupApiError {
+    /// A network-level failure.
+    #[error("WorldCup network error: {reason}")]
+    Network { reason: String },
+
+    /// Any other error, e.g. HTTP errors, validation errors.
+    #[error("WorldCup error: code {code:?}, reason: {reason}")]
+    Other { code: Option<u16>, reason: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failed to parse a URL.
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    /// Failed to send the HTTP request.
+    #[error("Error sending request: {0}")]
+    Request(#[from] viaduct::ViaductError),
+
+    /// The server rejected the request due to malformed syntax (HTTP 400).
+    #[error("Bad request ({code}): {message}")]
+    BadRequest { code: u16, message: String },
+
+    /// The server rejected the request due to invalid input (HTTP 422).
+    #[error("Validation error ({code}): {message}")]
+    Validation { code: u16, message: String },
+
+    /// The server encountered an internal error (HTTP 5xx).
+    #[error("Server error ({code}): {message}")]
+    Server { code: u16, message: String },
+
+    /// An unexpected HTTP status code was received.
+    #[error("Unexpected error ({code}): {message}")]
+    Unexpected { code: u16, message: String },
+}
+
+impl GetErrorHandling for Error {
+    type ExternalError = MerinoWorldCupApiError;
+
+    fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError> {
+        match self {
+            Self::Request { .. } => ErrorHandling::convert(MerinoWorldCupApiError::Network {
+                reason: self.to_string(),
+            })
+            .log_warning(),
+
+            Self::Validation { code, .. }
+            | Self::Server { code, .. }
+            | Self::Unexpected { code, .. }
+            | Self::BadRequest { code, .. } => {
+                ErrorHandling::convert(MerinoWorldCupApiError::Other {
+                    code: Some(*code),
+                    reason: self.to_string(),
+                })
+                .report_error("merino-http-error")
+            }
+
+            Self::UrlParse(_) => ErrorHandling::convert(MerinoWorldCupApiError::Other {
+                code: None,
+                reason: self.to_string(),
+            })
+            .report_error("merino-unexpected"),
+        }
+    }
+}

--- a/components/merino/src/worldcup/fixtures/live.json
+++ b/components/merino/src/worldcup/fixtures/live.json
@@ -1,0 +1,60 @@
+{
+  "current": [
+    {
+      "date": "2026-04-30T14:00:00+00:00",
+      "global_event_id": 1002,
+      "home_team": {
+        "key": "ENG",
+        "global_team_id": 90000005,
+        "name": "England",
+        "region": "ENG",
+        "colors": [
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_gb-eng.png",
+        "group": "Group C",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "USA",
+        "global_team_id": 90000006,
+        "name": "United States",
+        "region": "USA",
+        "colors": [
+          "Navy",
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_us.png",
+        "group": "Group C",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "2",
+      "home_score": 1,
+      "away_score": 0,
+      "home_extra": null,
+      "away_extra": null,
+      "home_penalty": null,
+      "away_penalty": null,
+      "clock": "67",
+      "updated": 1777554000,
+      "status": "In Progress",
+      "status_type": "live",
+      "query": null,
+      "sport": "soccer"
+    }
+  ]
+}

--- a/components/merino/src/worldcup/fixtures/matches.json
+++ b/components/merino/src/worldcup/fixtures/matches.json
@@ -1,0 +1,346 @@
+{
+  "previous": [
+    {
+      "date": "2026-04-29T14:00:00+00:00",
+      "global_event_id": 1000,
+      "home_team": {
+        "key": "BRA",
+        "global_team_id": 90000001,
+        "name": "Brazil",
+        "region": "BRA",
+        "colors": [
+          "Yellow",
+          "Green",
+          "Blue"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_br.png",
+        "group": "Group A",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "ARG",
+        "global_team_id": 90000002,
+        "name": "Argentina",
+        "region": "ARG",
+        "colors": [
+          "Sky Blue",
+          "White"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_ar.png",
+        "group": "Group A",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "FT",
+      "home_score": 2,
+      "away_score": 1,
+      "home_extra": null,
+      "away_extra": null,
+      "home_penalty": null,
+      "away_penalty": null,
+      "clock": "90",
+      "updated": 1777467600,
+      "status": "Final",
+      "status_type": "past",
+      "query": null,
+      "sport": "soccer"
+    },
+    {
+      "date": "2026-04-29T18:00:00+00:00",
+      "global_event_id": 1001,
+      "home_team": {
+        "key": "GER",
+        "global_team_id": 90000003,
+        "name": "Germany",
+        "region": "GER",
+        "colors": [
+          "Black",
+          "Red",
+          "Yellow"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_de.png",
+        "group": "Group B",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "FRA",
+        "global_team_id": 90000004,
+        "name": "France",
+        "region": "FRA",
+        "colors": [
+          "Blue",
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_fr.png",
+        "group": "Group B",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "FT(P)",
+      "home_score": 1,
+      "away_score": 1,
+      "home_extra": 1,
+      "away_extra": 1,
+      "home_penalty": 5,
+      "away_penalty": 4,
+      "clock": "120",
+      "updated": 1777482000,
+      "status": "Final",
+      "status_type": "past",
+      "query": null,
+      "sport": "soccer"
+    }
+  ],
+  "current": [
+    {
+      "date": "2026-04-30T14:00:00+00:00",
+      "global_event_id": 1002,
+      "home_team": {
+        "key": "ENG",
+        "global_team_id": 90000005,
+        "name": "England",
+        "region": "ENG",
+        "colors": [
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_gb-eng.png",
+        "group": "Group C",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "USA",
+        "global_team_id": 90000006,
+        "name": "United States",
+        "region": "USA",
+        "colors": [
+          "Navy",
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_us.png",
+        "group": "Group C",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "2",
+      "home_score": 1,
+      "away_score": 0,
+      "home_extra": null,
+      "away_extra": null,
+      "home_penalty": null,
+      "away_penalty": null,
+      "clock": "67",
+      "updated": 1777554000,
+      "status": "In Progress",
+      "status_type": "live",
+      "query": null,
+      "sport": "soccer"
+    },
+    {
+      "date": "2026-04-30T17:00:00+00:00",
+      "global_event_id": 1003,
+      "home_team": {
+        "key": "BRA",
+        "global_team_id": 90000001,
+        "name": "Brazil",
+        "region": "BRA",
+        "colors": [
+          "Yellow",
+          "Green",
+          "Blue"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_br.png",
+        "group": "Group A",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "GER",
+        "global_team_id": 90000003,
+        "name": "Germany",
+        "region": "GER",
+        "colors": [
+          "Black",
+          "Red",
+          "Yellow"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_de.png",
+        "group": "Group B",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "ET",
+      "home_score": 2,
+      "away_score": 2,
+      "home_extra": null,
+      "away_extra": null,
+      "home_penalty": null,
+      "away_penalty": null,
+      "clock": "90+15",
+      "updated": 1777564800,
+      "status": "In Progress",
+      "status_type": "live",
+      "query": null,
+      "sport": "soccer"
+    }
+  ],
+  "next": [
+    {
+      "date": "2026-05-01T15:00:00+00:00",
+      "global_event_id": 1004,
+      "home_team": {
+        "key": "ARG",
+        "global_team_id": 90000002,
+        "name": "Argentina",
+        "region": "ARG",
+        "colors": [
+          "Sky Blue",
+          "White"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_ar.png",
+        "group": "Group A",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "ENG",
+        "global_team_id": 90000005,
+        "name": "England",
+        "region": "ENG",
+        "colors": [
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_gb-eng.png",
+        "group": "Group C",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "1",
+      "home_score": null,
+      "away_score": null,
+      "home_extra": null,
+      "away_extra": null,
+      "home_penalty": null,
+      "away_penalty": null,
+      "clock": "0",
+      "updated": 1777644000,
+      "status": "Scheduled",
+      "status_type": "scheduled",
+      "query": null,
+      "sport": "soccer"
+    },
+    {
+      "date": "2026-05-01T19:00:00+00:00",
+      "global_event_id": 1005,
+      "home_team": {
+        "key": "FRA",
+        "global_team_id": 90000004,
+        "name": "France",
+        "region": "FRA",
+        "colors": [
+          "Blue",
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_fr.png",
+        "group": "Group B",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "away_team": {
+        "key": "USA",
+        "global_team_id": 90000006,
+        "name": "United States",
+        "region": "USA",
+        "colors": [
+          "Navy",
+          "White",
+          "Red"
+        ],
+        "icon_url": "https://storage.googleapis.com/merino-images-prod/logos/nations/nations_us.png",
+        "group": "Group C",
+        "eliminated": false,
+        "standing": {
+          "wins": 0,
+          "losses": 0,
+          "draws": 0,
+          "points": 0
+        }
+      },
+      "period": "1",
+      "home_score": null,
+      "away_score": null,
+      "home_extra": null,
+      "away_extra": null,
+      "home_penalty": null,
+      "away_penalty": null,
+      "clock": "0",
+      "updated": 1777658400,
+      "status": "Scheduled",
+      "status_type": "scheduled",
+      "query": null,
+      "sport": "soccer"
+    }
+  ]
+}

--- a/components/merino/src/worldcup/fixtures/teams.json
+++ b/components/merino/src/worldcup/fixtures/teams.json
@@ -1,0 +1,23 @@
+{
+  "teams": [
+    {
+      "key": "ENG",
+      "global_team_id": 1001,
+      "name": "England",
+      "region": "ENG",
+      "colors": ["White", "Red", "Navy Blue"],
+      "icon": "https://example.com/logos/england.png",
+      "group": "Group A",
+      "eliminated": false
+    },
+    {
+      "key": "BRA",
+      "global_team_id": 1002,
+      "name": "Brazil",
+      "region": "BRA",
+      "colors": ["Yellow", "Green", "Blue"],
+      "icon": "https://example.com/logos/brazil.png",
+      "group": "Group A",
+      "eliminated": false
+    }]
+}

--- a/components/merino/src/worldcup/http.rs
+++ b/components/merino/src/worldcup/http.rs
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use url::Url;
+use viaduct::{Request, Response};
+
+use super::error::{Error, Result};
+
+pub struct HttpClient;
+
+#[derive(Default)]
+pub struct WorldCupQueryParams {
+    pub limit: Option<u32>,
+    pub teams: Option<String>,
+}
+
+pub trait HttpClientTrait {
+    fn make_request(&self, url: Url, params: WorldCupQueryParams) -> Result<Option<Response>>;
+}
+
+impl HttpClientTrait for HttpClient {
+    fn make_request(&self, url: Url, params: WorldCupQueryParams) -> Result<Option<Response>> {
+        send_get(build_url(url, &params))
+    }
+}
+
+pub fn build_url(endpoint_url: Url, params: &WorldCupQueryParams) -> Url {
+    if params.limit.is_none() && params.teams.is_none() {
+        return endpoint_url;
+    }
+    let mut url = endpoint_url;
+    {
+        let mut pairs = url.query_pairs_mut();
+        if let Some(v) = params.limit {
+            pairs.append_pair("limit", &v.to_string());
+        }
+        if let Some(v) = &params.teams {
+            pairs.append_pair("teams", v);
+        }
+    }
+    url
+}
+
+fn send_get(url: Url) -> Result<Option<Response>> {
+    let response = Request::get(url)
+        .header("accept", "application/json")?
+        .send()?;
+    let status = response.status;
+    match status {
+        200 => Ok(Some(response)),
+        204 => Ok(None),
+        400 => Err(Error::BadRequest {
+            code: status,
+            message: response.text().to_string(),
+        }),
+        422 => Err(Error::Validation {
+            code: status,
+            message: response.text().to_string(),
+        }),
+        500..=599 => Err(Error::Server {
+            code: status,
+            message: response.text().to_string(),
+        }),
+        _ => Err(Error::Unexpected {
+            code: status,
+            message: response.text().to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE_URL: &str = "https://merino.services.mozilla.com/api/v1/wcs/teams";
+
+    fn base_url() -> Url {
+        Url::parse(BASE_URL).unwrap()
+    }
+
+    fn has_param(url: &Url, key: &str, value: &str) -> bool {
+        url.query_pairs().any(|(k, v)| k == key && v == value)
+    }
+
+    #[test]
+    fn test_build_url_with_params() {
+        let options = WorldCupQueryParams {
+            limit: Some(10),
+            ..WorldCupQueryParams::default()
+        };
+        let url = build_url(base_url(), &options);
+        assert!(has_param(&url, "limit", "10"));
+    }
+
+    #[test]
+    fn test_build_url_with_teams() {
+        let options = WorldCupQueryParams {
+            teams: Some("FRA,ENG".to_string()),
+            ..WorldCupQueryParams::default()
+        };
+        let url = build_url(base_url(), &options);
+        assert!(has_param(&url, "teams", "FRA,ENG"));
+    }
+
+    #[test]
+    fn test_build_url_with_all_options() {
+        let options = WorldCupQueryParams {
+            limit: Some(5),
+            teams: Some("FRA,ENG".to_string()),
+        };
+        let url = build_url(base_url(), &options);
+        assert!(has_param(&url, "limit", "5"));
+        assert!(has_param(&url, "teams", "FRA,ENG"));
+    }
+
+    #[test]
+    fn test_build_url_omits_none_options() {
+        let url = build_url(base_url(), &WorldCupQueryParams::default());
+        let keys: Vec<_> = url.query_pairs().map(|(k, _)| k.into_owned()).collect();
+        assert_eq!(keys.len(), 0);
+    }
+
+    #[test]
+    fn test_build_url_full_string() {
+        let options = WorldCupQueryParams {
+            limit: Some(3),
+            teams: Some("FRA".to_string()),
+        };
+        let url = build_url(base_url(), &options);
+        assert_eq!(
+            url.to_string(),
+            "https://merino.services.mozilla.com/api/v1/wcs/teams\
+            ?limit=3\
+            &teams=FRA"
+        );
+    }
+}

--- a/components/merino/src/worldcup/http.rs
+++ b/components/merino/src/worldcup/http.rs
@@ -13,6 +13,7 @@ pub struct HttpClient;
 pub struct WorldCupQueryParams {
     pub limit: Option<u32>,
     pub teams: Option<String>,
+    pub accept_language: Option<String>,
 }
 
 pub trait HttpClientTrait {
@@ -21,7 +22,7 @@ pub trait HttpClientTrait {
 
 impl HttpClientTrait for HttpClient {
     fn make_request(&self, url: Url, params: WorldCupQueryParams) -> Result<Option<Response>> {
-        send_get(build_url(url, &params))
+        send_get(build_url(url, &params), params.accept_language)
     }
 }
 
@@ -42,10 +43,12 @@ pub fn build_url(endpoint_url: Url, params: &WorldCupQueryParams) -> Url {
     url
 }
 
-fn send_get(url: Url) -> Result<Option<Response>> {
-    let response = Request::get(url)
-        .header("accept", "application/json")?
-        .send()?;
+fn send_get(url: Url, accept_language: Option<String>) -> Result<Option<Response>> {
+    let mut request = Request::get(url).header("accept", "application/json")?;
+    if let Some(lang) = accept_language {
+        request = request.header("accept-language", lang)?;
+    }
+    let response = request.send()?;
     let status = response.status;
     match status {
         200 => Ok(Some(response)),
@@ -108,6 +111,7 @@ mod tests {
         let options = WorldCupQueryParams {
             limit: Some(5),
             teams: Some("FRA,ENG".to_string()),
+            accept_language: Some("en-GB".to_string()),
         };
         let url = build_url(base_url(), &options);
         assert!(has_param(&url, "limit", "5"));
@@ -126,6 +130,7 @@ mod tests {
         let options = WorldCupQueryParams {
             limit: Some(3),
             teams: Some("FRA".to_string()),
+            accept_language: Some("en-US".to_string()),
         };
         let url = build_url(base_url(), &options);
         assert_eq!(

--- a/components/merino/src/worldcup/mod.rs
+++ b/components/merino/src/worldcup/mod.rs
@@ -116,6 +116,7 @@ impl<T: http::HttpClientTrait> WorldCupClientInner<T> {
         http::WorldCupQueryParams {
             limit: options.limit,
             teams,
+            accept_language: options.accept_language,
         }
     }
 

--- a/components/merino/src/worldcup/mod.rs
+++ b/components/merino/src/worldcup/mod.rs
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod error;
+mod http;
+mod schema;
+#[cfg(test)]
+mod tests;
+
+use error_support::handle_error;
+use url::Url;
+
+pub use error::{ApiResult, Error, MerinoWorldCupApiError, Result};
+pub use schema::{WorldCupConfig, WorldCupOptions};
+
+pub(crate) const DEFAULT_BASE_URL: &str = "https://merino.services.mozilla.com/api/v1/wcs/";
+
+/// A client for the merino wcs endpoint.
+///
+/// Use [`WorldCupClient::new`] to create an instance, then call
+/// [`WordCupClient::get_*`] to fetch wcs content.
+#[derive(uniffi::Object)]
+pub struct WorldCupClient {
+    inner: WorldCupClientInner<http::HttpClient>,
+    base_url: Url,
+}
+
+struct WorldCupClientInner<T: http::HttpClientTrait> {
+    http_client: T,
+}
+
+#[derive(Default)]
+struct WorldCupClientBuilder {
+    base_host: Option<String>,
+}
+
+impl WorldCupClientBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn base_host(mut self, base_host: String) -> Self {
+        self.base_host = Some(base_host);
+        self
+    }
+
+    pub fn build(self) -> Result<WorldCupClient> {
+        let base_url = match self.base_host {
+            Some(host) => Url::parse(&format!("{}/api/v1/wcs/", host))?,
+            None => Url::parse(DEFAULT_BASE_URL)?,
+        };
+
+        Ok(WorldCupClient {
+            inner: WorldCupClientInner::new()?,
+            base_url,
+        })
+    }
+}
+
+#[uniffi::export]
+impl WorldCupClient {
+    /// Creates a new `WorldCupClient` from the given configuration.
+    #[uniffi::constructor]
+    #[handle_error(Error)]
+    pub fn new(config: WorldCupConfig) -> ApiResult<Self> {
+        let mut builder = WorldCupClientBuilder::new();
+
+        if let Some(host) = config.base_host {
+            builder = builder.base_host(host);
+        }
+
+        builder.build()
+    }
+
+    #[handle_error(Error)]
+    /// Fetches teams from the merino wcs endpoint
+    pub fn get_teams(&self, options: WorldCupOptions) -> ApiResult<Option<String>> {
+        let url = self.base_url.join("teams")?;
+        let response = self.inner.make_request(url, options)?;
+        Ok(response.map(|r| r.text().to_string()))
+    }
+
+    #[handle_error(Error)]
+    /// Fetches matches from merino wcs endpoint
+    pub fn get_matches(&self, options: WorldCupOptions) -> ApiResult<Option<String>> {
+        let url = self.base_url.join("matches")?;
+        let response = self.inner.make_request(url, options)?;
+        Ok(response.map(|r| r.text().to_string()))
+    }
+
+    #[handle_error(Error)]
+    /// Fetches live info from merino wcs endpoint
+    pub fn get_live(&self, options: WorldCupOptions) -> ApiResult<Option<String>> {
+        let url = self.base_url.join("live")?;
+        let response = self.inner.make_request(url, options)?;
+        Ok(response.map(|r| r.text().to_string()))
+    }
+}
+
+impl WorldCupClientInner<http::HttpClient> {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            http_client: http::HttpClient,
+        })
+    }
+}
+
+impl<T: http::HttpClientTrait> WorldCupClientInner<T> {
+    fn params(options: WorldCupOptions) -> http::WorldCupQueryParams {
+        let teams = options
+            .teams
+            .as_ref()
+            .filter(|v| !v.is_empty())
+            .map(|v| v.join(","));
+        http::WorldCupQueryParams {
+            limit: options.limit,
+            teams,
+        }
+    }
+
+    pub fn make_request(
+        &self,
+        url: Url,
+        options: WorldCupOptions,
+    ) -> Result<Option<viaduct::Response>> {
+        self.http_client.make_request(url, Self::params(options))
+    }
+}
+
+#[cfg(test)]
+impl<T: http::HttpClientTrait> WorldCupClientInner<T> {
+    pub fn new_with_client(client: T) -> Self {
+        Self {
+            http_client: client,
+        }
+    }
+}

--- a/components/merino/src/worldcup/schema.rs
+++ b/components/merino/src/worldcup/schema.rs
@@ -1,0 +1,16 @@
+use uniffi::Record;
+
+#[derive(Clone, Debug, Record)]
+pub struct WorldCupConfig {
+    pub base_host: Option<String>,
+}
+
+/// Options for world cup endpoint requests.
+/// All fields are optional — omitted fields are not sent to merino.
+#[derive(Clone, Debug, Record)]
+pub struct WorldCupOptions {
+    /// Maximum number of results to return.
+    pub limit: Option<u32>,
+    /// Filter results by team(s) (e.g. `["FRA", "ENG"]`).
+    pub teams: Option<Vec<String>>,
+}

--- a/components/merino/src/worldcup/schema.rs
+++ b/components/merino/src/worldcup/schema.rs
@@ -13,4 +13,6 @@ pub struct WorldCupOptions {
     pub limit: Option<u32>,
     /// Filter results by team(s) (e.g. `["FRA", "ENG"]`).
     pub teams: Option<Vec<String>>,
+    /// Language for results (e.g. `"en-US"`). (Not supported yet)
+    pub accept_language: Option<String>,
 }

--- a/components/merino/src/worldcup/tests.rs
+++ b/components/merino/src/worldcup/tests.rs
@@ -10,12 +10,16 @@ const TEAMS_RESPONSE: &str = include_str!("fixtures/teams.json");
 const MATCH_RESPONSE: &str = include_str!("fixtures/matches.json");
 const LIVE_RESPONSE: &str = include_str!("fixtures/live.json");
 
-fn make_response(status: u16, body: &str, url: Url) -> Response {
+fn make_response(status: u16, body: &str, url: Url, accept_language: Option<String>) -> Response {
+    let mut headers = Headers::new();
+    if let Some(lang) = accept_language {
+        headers.insert("accept-language", lang).unwrap();
+    }
     Response {
         request_method: Method::Get,
         url,
         status,
-        headers: Headers::new(),
+        headers,
         body: body.as_bytes().to_vec(),
     }
 }
@@ -24,6 +28,7 @@ fn default_options() -> WorldCupOptions {
     WorldCupOptions {
         limit: None,
         teams: None,
+        accept_language: None,
     }
 }
 
@@ -31,15 +36,15 @@ fn base_url() -> Url {
     Url::parse(DEFAULT_BASE_URL).unwrap()
 }
 
-struct FakeHttpClient(fn() -> Result<Option<Response>>);
+struct FakeHttpClient(fn(http::WorldCupQueryParams) -> Result<Option<Response>>);
 
 impl http::HttpClientTrait for FakeHttpClient {
     fn make_request(
         &self,
         _url: Url,
-        _params: http::WorldCupQueryParams,
+        params: http::WorldCupQueryParams,
     ) -> Result<Option<Response>> {
-        (self.0)()
+        (self.0)(params)
     }
 }
 
@@ -54,17 +59,18 @@ impl http::HttpClientTrait for FakeCapturingClient {
         params: http::WorldCupQueryParams,
     ) -> Result<Option<Response>> {
         *self.captured_url.lock().unwrap() = Some(http::build_url(url.clone(), &params));
-        Ok(Some(make_response(200, "{}", url)))
+        Ok(Some(make_response(200, "{}", url, None)))
     }
 }
 
 #[test]
 fn test_get_teams_success() {
-    fn response() -> Result<Option<Response>> {
+    fn response(_params: http::WorldCupQueryParams) -> Result<Option<Response>> {
         Ok(Some(make_response(
             200,
             TEAMS_RESPONSE,
             Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+            None,
         )))
     }
     let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
@@ -75,11 +81,12 @@ fn test_get_teams_success() {
 
 #[test]
 fn test_get_matches_success() {
-    fn response() -> Result<Option<Response>> {
+    fn response(_params: http::WorldCupQueryParams) -> Result<Option<Response>> {
         Ok(Some(make_response(
             200,
             MATCH_RESPONSE,
             Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+            None,
         )))
     }
     let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
@@ -90,11 +97,12 @@ fn test_get_matches_success() {
 
 #[test]
 fn test_get_live_success() {
-    fn response() -> Result<Option<Response>> {
+    fn response(_params: http::WorldCupQueryParams) -> Result<Option<Response>> {
         Ok(Some(make_response(
             200,
             LIVE_RESPONSE,
             Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+            None,
         )))
     }
     let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
@@ -105,7 +113,7 @@ fn test_get_live_success() {
 
 #[test]
 fn test_no_content_returns_none() {
-    fn response() -> Result<Option<Response>> {
+    fn response(_params: http::WorldCupQueryParams) -> Result<Option<Response>> {
         Ok(None)
     }
     let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
@@ -122,7 +130,7 @@ fn test_no_content_returns_none() {
 
 #[test]
 fn test_server_error() {
-    fn response() -> Result<Option<Response>> {
+    fn response(_params: http::WorldCupQueryParams) -> Result<Option<Response>> {
         Err(Error::Server {
             code: 500,
             message: "Internal server error".to_string(),
@@ -135,6 +143,29 @@ fn test_server_error() {
         result.unwrap_err(),
         Error::Server { code: 500, .. }
     ));
+}
+
+#[test]
+fn test_accept_language_is_passed_as_header() {
+    fn response(params: http::WorldCupQueryParams) -> Result<Option<Response>> {
+        Ok(Some(make_response(
+            200,
+            "",
+            Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+            params.accept_language,
+        )))
+    }
+    let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
+    let result = client.make_request(
+        base_url().join("teams").unwrap(),
+        WorldCupOptions {
+            limit: None,
+            teams: None,
+            accept_language: Some("en-US".to_string()),
+        },
+    );
+    let response = result.unwrap().unwrap();
+    assert_eq!(response.headers.get("accept-language"), Some("en-US"));
 }
 
 #[test]
@@ -180,6 +211,7 @@ fn test_matches_endpoint_url_with_limit() {
         WorldCupOptions {
             limit: Some(2),
             teams: None,
+            accept_language: None,
         },
     );
     let captured = captured_url.lock().unwrap();

--- a/components/merino/src/worldcup/tests.rs
+++ b/components/merino/src/worldcup/tests.rs
@@ -1,0 +1,216 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+use url::Url;
+use viaduct::{Headers, Method, Response};
+
+const TEAMS_RESPONSE: &str = include_str!("fixtures/teams.json");
+const MATCH_RESPONSE: &str = include_str!("fixtures/matches.json");
+const LIVE_RESPONSE: &str = include_str!("fixtures/live.json");
+
+fn make_response(status: u16, body: &str, url: Url) -> Response {
+    Response {
+        request_method: Method::Get,
+        url,
+        status,
+        headers: Headers::new(),
+        body: body.as_bytes().to_vec(),
+    }
+}
+
+fn default_options() -> WorldCupOptions {
+    WorldCupOptions {
+        limit: None,
+        teams: None,
+    }
+}
+
+fn base_url() -> Url {
+    Url::parse(DEFAULT_BASE_URL).unwrap()
+}
+
+struct FakeHttpClient(fn() -> Result<Option<Response>>);
+
+impl http::HttpClientTrait for FakeHttpClient {
+    fn make_request(
+        &self,
+        _url: Url,
+        _params: http::WorldCupQueryParams,
+    ) -> Result<Option<Response>> {
+        (self.0)()
+    }
+}
+
+struct FakeCapturingClient {
+    captured_url: std::sync::Arc<std::sync::Mutex<Option<Url>>>,
+}
+
+impl http::HttpClientTrait for FakeCapturingClient {
+    fn make_request(
+        &self,
+        url: Url,
+        params: http::WorldCupQueryParams,
+    ) -> Result<Option<Response>> {
+        *self.captured_url.lock().unwrap() = Some(http::build_url(url.clone(), &params));
+        Ok(Some(make_response(200, "{}", url)))
+    }
+}
+
+#[test]
+fn test_get_teams_success() {
+    fn response() -> Result<Option<Response>> {
+        Ok(Some(make_response(
+            200,
+            TEAMS_RESPONSE,
+            Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+        )))
+    }
+    let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
+    let result = client.make_request(base_url().join("teams").unwrap(), default_options());
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().unwrap().text(), TEAMS_RESPONSE);
+}
+
+#[test]
+fn test_get_matches_success() {
+    fn response() -> Result<Option<Response>> {
+        Ok(Some(make_response(
+            200,
+            MATCH_RESPONSE,
+            Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+        )))
+    }
+    let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
+    let result = client.make_request(base_url().join("matches").unwrap(), default_options());
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().unwrap().text(), MATCH_RESPONSE);
+}
+
+#[test]
+fn test_get_live_success() {
+    fn response() -> Result<Option<Response>> {
+        Ok(Some(make_response(
+            200,
+            LIVE_RESPONSE,
+            Url::parse("https://merino.services.mozilla.com/api/v1/wcs/").unwrap(),
+        )))
+    }
+    let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
+    let result = client.make_request(base_url().join("live").unwrap(), default_options());
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().unwrap().text(), LIVE_RESPONSE);
+}
+
+#[test]
+fn test_no_content_returns_none() {
+    fn response() -> Result<Option<Response>> {
+        Ok(None)
+    }
+    let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
+
+    let result = client.make_request(base_url().join("teams").unwrap(), default_options());
+    assert!(result.unwrap().is_none());
+
+    let result = client.make_request(base_url().join("matches").unwrap(), default_options());
+    assert!(result.unwrap().is_none());
+
+    let result = client.make_request(base_url().join("live").unwrap(), default_options());
+    assert!(result.unwrap().is_none());
+}
+
+#[test]
+fn test_server_error() {
+    fn response() -> Result<Option<Response>> {
+        Err(Error::Server {
+            code: 500,
+            message: "Internal server error".to_string(),
+        })
+    }
+    let client = WorldCupClientInner::new_with_client(FakeHttpClient(response));
+    let result = client.make_request(base_url().join("teams").unwrap(), default_options());
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        Error::Server { code: 500, .. }
+    ));
+}
+
+#[test]
+fn test_builder_uses_default_base_host() {
+    let client = WorldCupClientBuilder::new().build().unwrap();
+    assert_eq!(client.base_url.as_str(), DEFAULT_BASE_URL);
+}
+
+#[test]
+fn test_builder_uses_custom_base_host() {
+    let client = WorldCupClientBuilder::new()
+        .base_host("https://stage.merino.services.mozilla.com".to_string())
+        .build()
+        .unwrap();
+    assert_eq!(
+        client.base_url.as_str(),
+        "https://stage.merino.services.mozilla.com/api/v1/wcs/"
+    );
+}
+
+#[test]
+fn test_teams_endpoint_url() {
+    let captured_url = std::sync::Arc::new(std::sync::Mutex::new(None::<Url>));
+    let client_inner = WorldCupClientInner::new_with_client(FakeCapturingClient {
+        captured_url: captured_url.clone(),
+    });
+    let _ = client_inner.make_request(base_url().join("teams").unwrap(), default_options());
+    let captured = captured_url.lock().unwrap();
+    assert_eq!(
+        captured.as_ref().unwrap().as_str(),
+        "https://merino.services.mozilla.com/api/v1/wcs/teams"
+    );
+}
+
+#[test]
+fn test_matches_endpoint_url_with_limit() {
+    let captured_url = std::sync::Arc::new(std::sync::Mutex::new(None::<Url>));
+    let client_inner = WorldCupClientInner::new_with_client(FakeCapturingClient {
+        captured_url: captured_url.clone(),
+    });
+    let _ = client_inner.make_request(
+        base_url().join("matches").unwrap(),
+        WorldCupOptions {
+            limit: Some(2),
+            teams: None,
+        },
+    );
+    let captured = captured_url.lock().unwrap();
+    assert_eq!(
+        captured.as_ref().unwrap().as_str(),
+        "https://merino.services.mozilla.com/api/v1/wcs/matches?limit=2"
+    );
+}
+
+#[test]
+fn test_live_endpoint_url() {
+    let captured_url = std::sync::Arc::new(std::sync::Mutex::new(None::<Url>));
+    let client_inner = WorldCupClientInner::new_with_client(FakeCapturingClient {
+        captured_url: captured_url.clone(),
+    });
+    let _ = client_inner.make_request(base_url().join("live").unwrap(), default_options());
+    let captured = captured_url.lock().unwrap();
+    assert_eq!(
+        captured.as_ref().unwrap().as_str(),
+        "https://merino.services.mozilla.com/api/v1/wcs/live"
+    );
+}
+
+#[test]
+fn test_builder_fails_with_invalid_base_host() {
+    let result = WorldCupClientBuilder::new()
+        .base_host("not a valid url".to_string())
+        .build();
+    match result {
+        Err(Error::UrlParse(_)) => {}
+        Err(other) => panic!("Expected UrlParse error, got: {:?}", other),
+        Ok(_) => panic!("Expected error for invalid base_host"),
+    }
+}

--- a/examples/merino-cli/src/main.rs
+++ b/examples/merino-cli/src/main.rs
@@ -11,6 +11,7 @@ use merino::curated_recommendations::models::request::{
 };
 use merino::curated_recommendations::CuratedRecommendationsClient;
 use merino::suggest::{SuggestClient, SuggestConfig, SuggestOptions};
+use merino::worldcup::{WorldCupClient, WorldCupConfig, WorldCupOptions};
 use viaduct::{configure_ohttp_channel, OhttpConfig};
 
 #[derive(Debug, Parser)]
@@ -85,6 +86,29 @@ enum Commands {
         #[arg(long)]
         accept_language: Option<String>,
     },
+    /// Fetch World Cup data
+    WorldCup {
+        /// Maximum number of results to return
+        #[arg(long)]
+        limit: Option<u32>,
+
+        /// Filter by team codes (e.g. --teams FRA --teams ENG)
+        #[arg(long)]
+        teams: Option<Vec<String>>,
+
+        #[command(subcommand)]
+        endpoint: WorldCupEndpoint,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum WorldCupEndpoint {
+    /// Fetch teams
+    Teams,
+    /// Fetch matches
+    Matches,
+    /// Fetch live match data
+    Live,
 }
 
 fn main() -> Result<()> {
@@ -152,6 +176,28 @@ fn main() -> Result<()> {
                     println!("{}", serde_json::to_string_pretty(&json)?);
                 }
                 None => println!("No suggestions available (204 No Content)"),
+            }
+        }
+        Commands::WorldCup {
+            limit,
+            teams,
+            endpoint,
+        } => {
+            let client = WorldCupClient::new(WorldCupConfig {
+                base_host: cli.base_host,
+            })?;
+            let options = WorldCupOptions { limit, teams };
+            let result = match endpoint {
+                WorldCupEndpoint::Teams => client.get_teams(options),
+                WorldCupEndpoint::Matches => client.get_matches(options),
+                WorldCupEndpoint::Live => client.get_live(options),
+            };
+            match result? {
+                Some(response) => {
+                    let json: serde_json::Value = serde_json::from_str(&response)?;
+                    println!("{}", serde_json::to_string_pretty(&json)?);
+                }
+                None => println!("No data available (204 No Content)"),
             }
         }
     }

--- a/examples/merino-cli/src/main.rs
+++ b/examples/merino-cli/src/main.rs
@@ -96,6 +96,10 @@ enum Commands {
         #[arg(long)]
         teams: Option<Vec<String>>,
 
+        /// Language for results (e.g. "en-US")
+        #[arg(long)]
+        accept_language: Option<String>,
+
         #[command(subcommand)]
         endpoint: WorldCupEndpoint,
     },
@@ -181,12 +185,17 @@ fn main() -> Result<()> {
         Commands::WorldCup {
             limit,
             teams,
+            accept_language,
             endpoint,
         } => {
             let client = WorldCupClient::new(WorldCupConfig {
                 base_host: cli.base_host,
             })?;
-            let options = WorldCupOptions { limit, teams };
+            let options = WorldCupOptions {
+                limit,
+                teams,
+                accept_language,
+            };
             let result = match endpoint {
                 WorldCupEndpoint::Teams => client.get_teams(options),
                 WorldCupEndpoint::Matches => client.get_matches(options),


### PR DESCRIPTION
This PR adds a new module to the merino crate that calls the Merino /api/v1/wcs endpoint
Also added a suggest subcommand to merino-cli for local testing.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
