### PR TITLE
Bug 2036867 - Include experimenter setPref annotations for gecko-pref variables in FML

### DIFF
--- a/components/support/nimbus-fml/ExperimentFeatureManifest.schema.json
+++ b/components/support/nimbus-fml/ExperimentFeatureManifest.schema.json
@@ -43,6 +43,18 @@
                     "description": {
                       "type": "string",
                       "description": "Explain how this value is being used"
+                    },
+                    "setPref": {
+                      "type": "object",
+                      "properties": {
+                        "branch": {
+                          "type": "string",
+                          "enum": ["user", "default"],
+                        },
+                        "pref": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "required": ["type", "description"],

--- a/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     command_line::commands::GenerateExperimenterManifestCmd,
     error::{FMLError, Result},
-    intermediate_representation::{FeatureDef, FeatureManifest, PropDef, TargetLanguage, TypeRef},
+    intermediate_representation::{
+        FeatureDef, FeatureManifest, GeckoPrefDef, PropDef, TargetLanguage, TypeRef,
+    },
 };
 
 pub(crate) type ExperimenterManifest = BTreeMap<String, ExperimenterFeature>;
@@ -36,6 +38,10 @@ pub(crate) struct ExperimenterFeatureProperty {
     #[serde(rename = "enum")]
     #[serde(skip_serializing_if = "Option::is_none")]
     variants: Option<BTreeSet<String>>,
+
+    #[serde(rename = "setPref")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    set_pref: Option<GeckoPrefDef>,
 }
 
 impl TryFrom<FeatureManifest> for ExperimenterManifest {
@@ -71,30 +77,32 @@ impl FeatureManifest {
         props.iter().try_for_each(|prop| -> Result<()> {
             let typ = ExperimentManifestPropType::from(prop.typ()).to_string();
 
-            let yaml_prop = if let TypeRef::Enum(e) = prop.typ() {
-                let enum_def = self
-                    .find_enum(&e)
-                    .ok_or(FMLError::InternalError("Found enum with no definition"))?;
+            let variants = match prop.typ() {
+                TypeRef::Enum(e) => {
+                    let enum_def = self
+                        .find_enum(&e)
+                        .ok_or(FMLError::InternalError("Found enum with no definition"))?;
 
-                let variants = enum_def
-                    .variants
-                    .iter()
-                    .map(|variant| variant.name())
-                    .collect::<BTreeSet<String>>();
-
-                ExperimenterFeatureProperty {
-                    variants: Some(variants),
-                    description: prop.doc(),
-                    property_type: typ,
+                    Some(
+                        enum_def
+                            .variants
+                            .iter()
+                            .map(|variant| variant.name())
+                            .collect::<BTreeSet<String>>(),
+                    )
                 }
-            } else {
-                ExperimenterFeatureProperty {
-                    variants: None,
-                    description: prop.doc(),
-                    property_type: typ,
-                }
+                _ => None,
             };
-            map.insert(prop.name(), yaml_prop);
+
+            map.insert(
+                prop.name(),
+                ExperimenterFeatureProperty {
+                    variants,
+                    description: prop.doc(),
+                    property_type: typ,
+                    set_pref: prop.gecko_pref.clone(),
+                },
+            );
             Ok(())
         })?;
         Ok(map)

--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -568,6 +568,54 @@ mod test {
     }
 
     #[test]
+    fn test_generate_experimenter_gecko_prefs() -> Result<()> {
+        let tmpfile = NamedTempFile::new()?;
+        let cmd = create_experimenter_manifest_cmd("fixtures/fe/gecko-pref.yaml", tmpfile.path())?;
+        generate_experimenter_manifest(&cmd)?;
+
+        let manifest: serde_yaml::Value = serde_yaml::from_reader(&tmpfile)?;
+        println!("{:?}", manifest);
+
+        let variables = manifest
+            .get("gecko-nimbus-validation")
+            .unwrap()
+            .get("variables")
+            .unwrap();
+
+        fn assert_pref_var(
+            variable: &serde_yaml::Value,
+            expected_pref: &str,
+            expected_branch: &str,
+        ) {
+            let pref_annotation = variable.get("setPref").unwrap();
+            let pref = pref_annotation.get("pref").unwrap().as_str().unwrap();
+            assert_eq!(pref, expected_pref);
+            let branch = pref_annotation.get("branch").unwrap().as_str().unwrap();
+            assert_eq!(branch, expected_branch);
+        }
+
+        assert_pref_var(
+            variables.get("test-preference-bool").unwrap(),
+            "gecko.nimbus.test.bool",
+            "default",
+        );
+
+        assert_pref_var(
+            variables.get("test-preference-int").unwrap(),
+            "gecko.nimbus.test.int",
+            "default",
+        );
+
+        assert_pref_var(
+            variables.get("test-preference-string").unwrap(),
+            "gecko.nimbus.test.string",
+            "default",
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_validate_command() -> Result<()> {
         let paths = MANIFEST_PATHS
             .iter()


### PR DESCRIPTION
Now that we have pref support on Firefox for Android 152+, we need to include the pref annotations that Experimenter expects in the generated manifests.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
