### PR TITLE
Bug 2012185 - add validation step to nimbus-fml generate

### DIFF
--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -32,6 +32,11 @@ pub(crate) fn generate_struct(cmd: &GenerateStructCmd) -> Result<()> {
     let filename = &cmd.manifest;
     let input = files.file_path(filename)?;
 
+    validate(&ValidateCmd {
+        manifest: cmd.manifest.clone(),
+        loader: cmd.loader.clone(),
+    })?;
+
     match (&input, &cmd.output.is_dir()) {
         (FilePath::Remote(_), _) => generate_struct_single(&files, input, cmd),
         (FilePath::Local(file), _) if !file.exists() => Err(FMLError::CliError(format!(
@@ -612,6 +617,28 @@ mod test {
             "default",
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_catches_invalid_feature() -> Result<(), FMLError> {
+        let manifest = join(
+            pkg_dir(),
+            "fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml",
+        );
+        let output = NamedTempFile::new()?;
+
+        let cmd: GenerateStructCmd = GenerateStructCmd {
+            manifest,
+            output: output.path().into(),
+            language: TargetLanguage::ExperimenterYAML,
+            load_from_ir: false,
+            channel: "app-debug".to_string(),
+            loader: Default::default(),
+        };
+
+        let result = generate_struct(&cmd);
+        assert!(result.is_err());
         Ok(())
     }
 


### PR DESCRIPTION
Updates `nimbus-fml generate` to include the same validation logic as `nimbus-fml validate` allowing build scripts to rely solely on generate

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
