### PR TITLE
Bug 2034610 - Reduce allocations in unenroll_for_gecko_pref

### DIFF
--- a/components/nimbus/src/stateful/enrollment.rs
+++ b/components/nimbus/src/stateful/enrollment.rs
@@ -167,18 +167,16 @@ pub fn unenroll_for_pref(
     unenroll_reason: PrefUnenrollReason,
     triggering_pref_name: &str,
     gecko_pref_store: Option<&GeckoPrefStore>,
-) -> Result<Vec<EnrollmentChangeEvent>> {
-    let mut events = vec![];
+    events: &mut Vec<EnrollmentChangeEvent>,
+) -> Result<()> {
     let enr_store = db.get_store(StoreId::Enrollments);
     if let Ok(Some(existing_enrollment)) =
         enr_store.get::<ExperimentEnrollment, Writer>(writer, experiment_slug)
     {
-        #[cfg(feature = "stateful")]
         existing_enrollment
             .maybe_revert_unchanged_gecko_pref_states(triggering_pref_name, gecko_pref_store);
 
-        let updated_enrollment =
-            &existing_enrollment.on_pref_unenroll(unenroll_reason, &mut events);
+        let updated_enrollment = &existing_enrollment.on_pref_unenroll(unenroll_reason, events);
         enr_store.put(writer, experiment_slug, updated_enrollment)?;
     } else {
         events.push(EnrollmentChangeEvent {
@@ -189,7 +187,7 @@ pub fn unenroll_for_pref(
         });
     }
 
-    Ok(events)
+    Ok(())
 }
 
 pub fn get_experiment_participation<'r>(

--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -790,6 +790,7 @@ impl NimbusClient {
         pref_state: GeckoPrefState,
         pref_unenroll_reason: PrefUnenrollReason,
     ) -> Result<Vec<EnrollmentChangeEvent>> {
+        let mut events = Vec::new();
         if let Some(prefs) = self.gecko_prefs.clone() {
             {
                 let mut pref_store_state = prefs.get_mutable_pref_state();
@@ -802,18 +803,17 @@ impl NimbusClient {
             let db = self.db()?;
             let mut writer = db.write()?;
 
-            let mut results = Vec::new();
             if let Some(enrollments) = enrollments {
                 for experiment_slug in enrollments {
-                    let result = unenroll_for_pref(
+                    unenroll_for_pref(
                         db,
                         &mut writer,
                         &experiment_slug,
                         pref_unenroll_reason,
                         &pref_state.gecko_pref.pref,
                         self.gecko_prefs.as_deref(),
+                        &mut events,
                     )?;
-                    results.push(result);
                 }
             } else {
                 warn!(
@@ -823,9 +823,8 @@ impl NimbusClient {
 
             let mut state = self.mutable_state.lock().unwrap();
             self.end_initialize(db, writer, &mut state)?;
-            return Ok(results.concat());
         }
-        Ok(Vec::new())
+        Ok(events)
     }
 
     pub fn register_previous_gecko_pref_states(


### PR DESCRIPTION
We end up allocating a Vec<Vec<T>> and calling concat() instead of allocating a Vec<T> and passing a &mut Vec<T> in these functions.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
