### PR TITLE
Put the new telemetry submission capability behind a feature

### DIFF
--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -11,6 +11,8 @@ exclude = ["/android", "/ios"]
 [features]
 default = []
 signatures = ["dep:canonical_json", "dep:rc_crypto"]
+# submitting glean telemetry is tricky on desktop for now.
+telemetry-submission = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -61,14 +61,6 @@ impl RemoteSettingsService {
         }
     }
 
-    /// Set the telemetry implementation used to record Glean metrics.
-    /// This should be set to a real implementation (eg. Kotlin, Swift).
-    /// If not set, all metric recording is a no-op.
-    pub fn set_telemetry(&self, telemetry: Arc<dyn RemoteSettingsTelemetry>) {
-        self.internal
-            .set_telemetry(RemoteSettingsTelemetryWrapper::new(telemetry));
-    }
-
     /// Create a new Remote Settings client
     ///
     /// This method performs no IO or network requests and is safe to run in a main thread that can't be blocked.
@@ -99,6 +91,17 @@ impl RemoteSettingsService {
 
     pub fn client_url(&self) -> String {
         self.internal.client_url().to_string()
+    }
+}
+
+#[cfg_attr(feature = "telemetry-submission", uniffi::export)]
+impl RemoteSettingsService {
+    /// Set the telemetry implementation used to record Glean metrics.
+    /// This should be set to a real implementation (eg. Kotlin, Swift).
+    /// If not set, all metric recording is a no-op.
+    pub fn set_telemetry(&self, telemetry: Arc<dyn RemoteSettingsTelemetry>) {
+        self.internal
+            .set_telemetry(RemoteSettingsTelemetryWrapper::new(telemetry));
     }
 }
 

--- a/components/remote_settings/src/telemetry.rs
+++ b/components/remote_settings/src/telemetry.rs
@@ -79,7 +79,7 @@ pub struct UptakeEventExtras {
 ///
 /// service.setTelemetry(GleanTelemetry())
 /// ```
-#[uniffi::export(with_foreign)]
+#[cfg_attr(feature = "telemetry-submission", uniffi::export(with_foreign))]
 pub trait RemoteSettingsTelemetry: Send + Sync {
     /// Report uptake event.
     fn report_uptake(&self, extras: UptakeEventExtras);

--- a/megazords/full/Cargo.toml
+++ b/megazords/full/Cargo.toml
@@ -18,7 +18,7 @@ sync_manager = { path = "../../components/sync_manager/" }
 # webext-storage = { path = "../../components/webext-storage/" }
 places = { path = "../../components/places" }
 push = { path = "../../components/push" }
-remote_settings = { path = "../../components/remote_settings" }
+remote_settings = { path = "../../components/remote_settings", features=["telemetry-submission"] }
 rust-log-forwarder = { path = "../../components/support/rust-log-forwarder" }
 viaduct = { path = "../../components/viaduct", features = ["ohttp"] }
 nimbus-sdk = { path = "../../components/nimbus" }

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -21,7 +21,7 @@ autofill = { path = "../../components/autofill" }
 push = { path = "../../components/push" }
 tabs = { path = "../../components/tabs" }
 places = { path = "../../components/places" }
-remote_settings = { path = "../../components/remote_settings" }
+remote_settings = { path = "../../components/remote_settings", features=["telemetry-submission"] }
 suggest = { path = "../../components/suggest" }
 sync15 = { path = "../../components/sync15" }
 error-support = { path = "../../components/support/error" }


### PR DESCRIPTION
This is slightly problematic on desktop. There's a good chance a callback interface would work, but that's a little problematic in other ways (as that forces you to use a `Box<dyn T>` instead of an `Arc<>`, which is particularly problematic for tests. This seems like a reasonable compromise while we work out a better option.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
