### PR TITLE
feat(ads-client): retry callback requests once on transient transport failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Ads Client
 * HTTP cache TTL is now resolved by priority — explicit per-request TTL (if any) wins, otherwise the response's `Cache-Control: max-age` is used, otherwise the configured `default_ttl`. The resolved TTL is capped at 7 days as a safety net against misconfigured server values. Previously the layer took the minimum of all three, which effectively ignored the server's `max-age` signal.
+* Callback requests (`recordImpression`, `recordClick`, `reportAd`) now retry once after a short delay on transient transport-level failures (timeouts, connection resets, DNS), to better survive flaky mobile networks. HTTP status errors are not retried.
 
 ### Remote Settings
 * Add uptake telemetry support ([#7288](https://github.com/mozilla/application-services/pull/7288))

--- a/components/ads-client/src/mars/transport.rs
+++ b/components/ads-client/src/mars/transport.rs
@@ -4,6 +4,7 @@
 */
 
 use std::hash::Hash;
+use std::time::Duration;
 
 use viaduct::{Client, ClientSettings, Request, Response};
 
@@ -15,6 +16,26 @@ use crate::{
 };
 
 const OHTTP_CHANNEL_ID: &str = "ads-client";
+
+/// Wait before the single retry attempt for fire-and-forget callback
+/// requests. Short enough to feel responsive on mobile, long enough to
+/// let a transient blip recover.
+const CALLBACK_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// Run `op` and, if it returns `Err`, sleep for `delay` and run it once
+/// more. The second result is returned as-is.
+fn retry_once<F, T, E>(delay: Duration, mut op: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    match op() {
+        Ok(v) => Ok(v),
+        Err(_) => {
+            std::thread::sleep(delay);
+            op()
+        }
+    }
+}
 
 pub struct MARSTransport<T: Telemetry> {
     http_cache: Option<HttpCache>,
@@ -38,7 +59,11 @@ impl<T: Telemetry> MARSTransport<T> {
 
     pub fn fire(&self, request: Request, ohttp: bool) -> Result<(), TransportError> {
         let client = Self::client_for(ohttp)?;
-        let response = client.send_sync(request)?;
+        // Callback requests (impression/click/report) are fire-and-forget on
+        // unreliable mobile networks. Retry once on a transient viaduct error
+        // (timeout, connection reset, DNS) before giving up. HTTP status
+        // errors are not retried — those are decided after this call returns.
+        let response = retry_once(CALLBACK_RETRY_DELAY, || client.send_sync(request.clone()))?;
         HTTPError::check(&response)?;
         Ok(())
     }
@@ -81,5 +106,48 @@ impl<T: Telemetry> MARSTransport<T> {
         } else {
             Ok(Client::new(ClientSettings::default()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn retry_once_returns_first_success_without_calling_again() {
+        let calls = Cell::new(0);
+        let result: Result<&'static str, ()> = retry_once(Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            Ok("ok")
+        });
+        assert_eq!(result, Ok("ok"));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn retry_once_retries_after_failure_and_returns_success() {
+        let calls = Cell::new(0);
+        let result: Result<&'static str, &'static str> = retry_once(Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            if calls.get() == 1 {
+                Err("transient")
+            } else {
+                Ok("ok")
+            }
+        });
+        assert_eq!(result, Ok("ok"));
+        assert_eq!(calls.get(), 2);
+    }
+
+    #[test]
+    fn retry_once_gives_up_after_second_failure() {
+        let calls = Cell::new(0);
+        let result: Result<(), &'static str> = retry_once(Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            Err("still broken")
+        });
+        assert_eq!(result, Err("still broken"));
+        assert_eq!(calls.get(), 2);
     }
 }


### PR DESCRIPTION
## Summary
`recordImpression`, `recordClick`, and `reportAd` are fire-and-forget calls — once a consumer hands them off, they have no easy way to know whether to retry. On flaky mobile networks (timeouts, brief connection resets, DNS hiccups), a single transport-level failure currently drops the callback silently.

This adds a single retry, 500ms after the first attempt, when `viaduct::ViaductError` is returned. HTTP status errors (4xx/5xx) are **not** retried — those are application decisions, not transient blips.

The retry policy is a small free function (`retry_once`) so the behaviour is unit-testable without faking a viaduct backend.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
