### PR TITLE
Bug 2032774 - rename internal 'nss' crate to 'nss-as'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
  "jwcrypto",
  "lazy_static",
  "libsqlite3-sys",
- "nss",
+ "nss-as",
  "rusqlite",
  "serde",
  "serde_derive",
@@ -1214,7 +1214,7 @@ dependencies = [
  "fxa-client",
  "interrupt-support",
  "log",
- "nss",
+ "nss-as",
  "rusqlite",
  "serde_json",
  "sql-support",
@@ -1271,7 +1271,7 @@ dependencies = [
  "fxa-client",
  "interrupt-support",
  "log",
- "nss",
+ "nss-as",
  "places",
  "serde",
  "serde_derive",
@@ -1334,7 +1334,7 @@ dependencies = [
  "cli-support",
  "interrupt-support",
  "log",
- "nss",
+ "nss-as",
  "serde_json",
  "sync15",
  "tabs",
@@ -1364,7 +1364,7 @@ dependencies = [
  "cli-support",
  "fxa-client",
  "log",
- "nss",
+ "nss-as",
  "url",
  "viaduct",
  "viaduct-hyper",
@@ -1407,7 +1407,7 @@ dependencies = [
  "env_logger",
  "interrupt-support",
  "log",
- "nss",
+ "nss-as",
  "places",
  "relevancy",
  "sync15",
@@ -1425,7 +1425,7 @@ dependencies = [
  "futures",
  "indicatif",
  "log",
- "nss",
+ "nss-as",
  "remote_settings",
  "serde",
  "serde_json",
@@ -1446,7 +1446,7 @@ dependencies = [
  "clap",
  "cli-support",
  "log",
- "nss",
+ "nss-as",
  "remote_settings",
  "suggest",
  "viaduct",
@@ -1715,7 +1715,7 @@ dependencies = [
  "log",
  "mockall",
  "mockito",
- "nss",
+ "nss-as",
  "parking_lot",
  "payload-support",
  "rate-limiter",
@@ -2243,7 +2243,7 @@ dependencies = [
 name = "init_rust_components"
 version = "0.1.0"
 dependencies = [
- "nss",
+ "nss-as",
  "uniffi",
  "viaduct",
 ]
@@ -2396,7 +2396,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
  "error-support",
- "nss",
+ "nss-as",
  "rc_crypto",
  "serde",
  "serde_derive",
@@ -2547,7 +2547,7 @@ dependencies = [
  "interrupt-support",
  "jwcrypto",
  "lazy_static",
- "nss",
+ "nss-as",
  "parking_lot",
  "rusqlite",
  "serde",
@@ -2996,7 +2996,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "nss"
+name = "nss-as"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
@@ -3500,7 +3500,7 @@ dependencies = [
  "lazy_static",
  "mockall",
  "mockito",
- "nss",
+ "nss-as",
  "rc_crypto",
  "rusqlite",
  "serde",
@@ -3610,7 +3610,7 @@ dependencies = [
  "error-support",
  "hawk",
  "hex",
- "nss",
+ "nss-as",
  "thiserror 2.0.3",
 ]
 
@@ -3741,7 +3741,7 @@ dependencies = [
  "jexl-eval",
  "mockall",
  "mockito",
- "nss",
+ "nss-as",
  "parking_lot",
  "rc_crypto",
  "regex",
@@ -4378,7 +4378,7 @@ dependencies = [
  "lazy_static",
  "log",
  "logins",
- "nss",
+ "nss-as",
  "rand",
  "restmail-client",
  "serde",
@@ -4403,7 +4403,7 @@ dependencies = [
  "error-support",
  "interrupt-support",
  "lazy_static",
- "nss",
+ "nss-as",
  "payload-support",
  "rc_crypto",
  "serde",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -28,7 +28,7 @@ url = { version = "2.2", features = ["serde"] }
 
 [dev-dependencies]
 libsqlite3-sys = { version = "0.35.0" }
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }
 error-support = { path = "../support/error", features=["testing"] }
 
 [build-dependencies]

--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -291,7 +291,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::db::test::new_mem_db;
     use crate::encryption::EncryptorDecryptor;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use sync15::bso::IncomingBso;
 
     pub fn get_all(

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -254,7 +254,7 @@ mod tests {
     use super::*;
     use crate::db::test::new_mem_db;
     use crate::encryption::EncryptorDecryptor;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn test_autofill_meta() -> Result<()> {

--- a/components/autofill/src/encryption.rs
+++ b/components/autofill/src/encryption.rs
@@ -56,7 +56,7 @@ pub fn create_autofill_key() -> ApiResult<String> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn test_encrypt() {

--- a/components/autofill/src/sync/credit_card/incoming.rs
+++ b/components/autofill/src/sync/credit_card/incoming.rs
@@ -268,7 +268,7 @@ mod tests {
 
     use error_support::{info, trace};
     use interrupt_support::NeverInterrupts;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use serde_json::{json, Map, Value};
     use sql_support::ConnExt;
 

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -255,7 +255,7 @@ fn test_last_4() {
 
 #[test]
 fn test_to_from_payload() {
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     let key = crate::encryption::create_autofill_key().unwrap();
     let cc_number = "1234567812345678";
     let cc_number_enc =

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -255,7 +255,7 @@ mod tests {
     use crate::db::schema::create_empty_sync_temp_tables;
     use crate::encryption::EncryptorDecryptor;
     use crate::sync::{IncomingBso, UnknownFields};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use sql_support::ConnExt;
 
     impl InternalCreditCard {

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
 uniffi = { version = "0.31" }
 payload-support = { path = "../support/payload" }
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }
 
 [build-dependencies]
 uniffi = { version = "0.31", features = ["build"] }

--- a/components/fxa-client/src/internal/close_tabs.rs
+++ b/components/fxa-client/src/internal/close_tabs.rs
@@ -164,7 +164,7 @@ mod tests {
     use std::{collections::HashSet, sync::Arc};
 
     use mockall::predicate::{always, eq};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use serde_json::json;
 
     use crate::{

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -440,7 +440,7 @@ mod tests {
     use crate::ScopedKey;
     use mockall::predicate::always;
     use mockall::predicate::eq;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::collections::HashSet;
     use std::sync::Arc;
 

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -625,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_oauth_flow_url() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::new_with_mock_well_known_fxa_client_configuration(
             "https://mock-fxa.example.com",
             "12345678",
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_force_auth_url() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
         let email = "test@example.com";
@@ -716,7 +716,7 @@ mod tests {
 
     #[test]
     fn test_webchannel_context_url() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
         let config = Config::new_with_mock_well_known_fxa_client_configuration(
             "https://mock-fxa.example.com",
@@ -736,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_webchannel_pairing_context_url() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
         const PAIRING_URL: &str = "https://accounts.firefox.com/pair#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
 
@@ -763,7 +763,7 @@ mod tests {
 
     #[test]
     fn test_pairing_flow_url() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
         const PAIRING_URL: &str = "https://accounts.firefox.com/pair#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
         const EXPECTED_URL: &str = "https://accounts.firefox.com/pair/supp?client_id=12345678&redirect_uri=https%3A%2F%2Ffoo.bar&scope=https%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync&state=SmbAA_9EA5v1R2bgIPeWWw&code_challenge_method=S256&code_challenge=ZgHLPPJ8XYbXpo7VIb7wFw0yXlTa6MUOVfGiADt0JSM&access_type=offline&keys_jwk=eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6Ing5LUltQjJveDM0LTV6c1VmbW5sNEp0Ti14elV2eFZlZXJHTFRXRV9BT0kiLCJ5IjoiNXBKbTB3WGQ4YXdHcm0zREl4T1pWMl9qdl9tZEx1TWlMb1RkZ1RucWJDZyJ9#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
@@ -838,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_pairing_flow_origin_mismatch() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         static PAIRING_URL: &str = "https://bad.origin.com/pair#channel_id=foo&channel_key=bar";
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
@@ -864,7 +864,7 @@ mod tests {
 
     #[test]
     fn test_check_authorization_status() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
 
@@ -888,7 +888,7 @@ mod tests {
 
     #[test]
     fn test_check_authorization_status_circuit_breaker() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
 
@@ -937,7 +937,7 @@ mod tests {
 
     #[test]
     fn test_auth_code_pair_valid_not_allowed_scope() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
         fxa.set_session_token("session");
@@ -991,7 +991,7 @@ mod tests {
 
     #[test]
     fn test_auth_code_pair_invalid_scope_not_allowed() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
         fxa.set_session_token("session");
@@ -1042,7 +1042,7 @@ mod tests {
 
     #[test]
     fn test_auth_code_pair_scope_not_in_state() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
         fxa.set_session_token("session");
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[test]
     fn test_handle_web_channel_login_sets_session_token() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
         fxa.handle_web_channel_login(
@@ -1102,7 +1102,7 @@ mod tests {
 
     #[test]
     fn test_oauth_request_sent_with_session_when_available() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::new_with_mock_well_known_fxa_client_configuration(
             "mock-fxa.example.com",
             "12345678",
@@ -1182,7 +1182,7 @@ mod tests {
     // different scopes, the new token is merged with the old scopes and the device is restored.
     #[test]
     fn test_complete_oauth_flow_merges_scopes_and_restores_device() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::new_with_mock_well_known_fxa_client_configuration(
             "mock-fxa.example.com",
             "12345678",
@@ -1293,7 +1293,7 @@ mod tests {
     // the device is restored.
     #[test]
     fn test_complete_oauth_flow_no_merge_when_scopes_match() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let config = Config::new_with_mock_well_known_fxa_client_configuration(
             "mock-fxa.example.com",
             "12345678",

--- a/components/fxa-client/src/internal/oauth/access_token.rs
+++ b/components/fxa-client/src/internal/oauth/access_token.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_gat_empty_scope_errors() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         assert!(matches!(
             fxa.get_access_token("", true),
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_gat_no_tokens_errors() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         assert!(matches!(
             fxa.get_access_token("profile", false),
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn test_gat_cache_hit() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         fxa.add_cached_token("profile", token_info("profile"));
         let client = MockFxAClient::new(); // no expectations — asserts zero calls
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_gat_cache_hit_order_insensitive() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         fxa.add_cached_token("a b", token_info("a b")); // cached under normalized key
         let client = MockFxAClient::new();
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn test_gat_single_scope_from_refresh_token() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &["profile"]);
         let mut client = MockFxAClient::new();
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_gat_single_scope_exchange() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &["profile"]);
         let mut client = MockFxAClient::new();
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_gat_old_sync_key_populated() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &[scopes::OLD_SYNC]);
         fxa.state
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_gat_old_sync_missing_key_errors() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &[scopes::OLD_SYNC]);
         let mut client = MockFxAClient::new();
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_gat_multi_scope_from_refresh_token() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &["profile", "sync"]);
         let mut client = MockFxAClient::new();
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_gat_multi_scope_exchange_missing() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &["profile"]);
         let mut client = MockFxAClient::new();
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_gat_multi_scope_session_token() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         fxa.set_session_token("st");
         let mut client = MockFxAClient::new();
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_gat_multi_scope_old_sync_key_is_none() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         let combined = format!("{} profile", scopes::OLD_SYNC);
         seed_refresh_token(&mut fxa, "rt", &[scopes::OLD_SYNC, "profile"]);
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn test_gat_duplicate_scopes_deduped() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let mut fxa = make_fxa();
         seed_refresh_token(&mut fxa, "rt", &["profile"]);
         let mut client = MockFxAClient::new();

--- a/components/fxa-client/src/internal/scoped_keys.rs
+++ b/components/fxa-client/src/internal/scoped_keys.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn test_flow() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let x = URL_SAFE_NO_PAD
             .decode("ARvGIPJ5eIFdp6YTM-INVDqwfun2R9FfCUvXbH7QCIU")
             .unwrap();

--- a/components/init_rust_components/Cargo.toml
+++ b/components/init_rust_components/Cargo.toml
@@ -8,10 +8,10 @@ exclude = ["/android"]
 
 [features]
 default = []
-keydb = ["nss/keydb"]
+keydb = ["nss-as/keydb"]
 ohttp = ["dep:viaduct", "viaduct/ohttp"]
 
 [dependencies]
 uniffi = { version = "0.31" }
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }
 viaduct = { path = "../viaduct", optional = true }

--- a/components/init_rust_components/src/lib.rs
+++ b/components/init_rust_components/src/lib.rs
@@ -4,9 +4,9 @@
  */
 
 #[cfg(not(feature = "keydb"))]
-use nss::ensure_initialized as ensure_nss_initialized;
+use nss_as::ensure_initialized as ensure_nss_initialized;
 #[cfg(feature = "keydb")]
-use nss::ensure_initialized_with_profile_dir as ensure_nss_initialized_with_profile_dir;
+use nss_as::ensure_initialized_with_profile_dir as ensure_nss_initialized_with_profile_dir;
 #[cfg(feature = "ohttp")]
 use viaduct::ohttp::configure_default_ohttp_channels;
 uniffi::setup_scaffolding!();

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 # `key4.db` (wrapped with a key derived from the primary password, if set).
 # Used on Desktop to integrate with the existing NSS key store and primary
 # password flow.
-keydb = ["nss/keydb", "dep:async-trait", "dep:futures"]
+keydb = ["nss-as/keydb", "dep:async-trait", "dep:futures"]
 # Allows logins with empty passwords to be imported. Used on Desktop during
 # migration to accept existing logins that have empty passwords.
 allow_empty_passwords = []
@@ -37,7 +37,7 @@ lazy_static = "1.4"
 url = "2.2"
 sql-support = { path = "../support/sql" }
 jwcrypto = { path = "../support/jwcrypto" }
-nss = { path = "../support/rc_crypto/nss", default-features = false }
+nss-as = { path = "../support/rc_crypto/nss", default-features = false }
 interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 rusqlite = { version = "0.37.0", features = ["limits", "unlock_notify"] }
@@ -54,4 +54,4 @@ uniffi = { version = "0.31", features = ["build"] }
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }
 tempfile = "3.2.0"
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1324,7 +1324,7 @@ mod tests {
     use crate::db::test_utils::{get_local_guids, get_mirror_guids};
     use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::sync::merge::LocalLogin;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::{thread, time};
 
     #[test]

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -58,9 +58,9 @@ use futures::executor::block_on;
 use async_trait::async_trait;
 
 #[cfg(feature = "keydb")]
-use nss::assert_initialized as assert_nss_initialized;
+use nss_as::assert_initialized as assert_nss_initialized;
 #[cfg(feature = "keydb")]
-use nss::pk11::sym_key::{
+use nss_as::pk11::sym_key::{
     authenticate_with_primary_password, authentication_with_primary_password_is_needed,
     get_or_create_aes256_key,
 };
@@ -262,7 +262,7 @@ static KEY_NAME: &str = "as-logins-key";
 // wrapp `authentication_with_primary_password_is_needed` into an ApiResult
 #[cfg(feature = "keydb")]
 fn api_authentication_with_primary_password_is_needed() -> ApiResult<bool> {
-    authentication_with_primary_password_is_needed().map_err(|e: nss::Error| {
+    authentication_with_primary_password_is_needed().map_err(|e: nss_as::Error| {
         LoginsApiError::NSSAuthenticationError {
             reason: e.to_string(),
         }
@@ -272,7 +272,7 @@ fn api_authentication_with_primary_password_is_needed() -> ApiResult<bool> {
 // wrapp `authenticate_with_primary_password` into an ApiResult
 #[cfg(feature = "keydb")]
 fn api_authenticate_with_primary_password(primary_password: &str) -> ApiResult<bool> {
-    authenticate_with_primary_password(primary_password).map_err(|e: nss::Error| {
+    authenticate_with_primary_password(primary_password).map_err(|e: nss_as::Error| {
         LoginsApiError::NSSAuthenticationError {
             reason: e.to_string(),
         }
@@ -362,7 +362,7 @@ pub mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn test_static_key_manager() {
@@ -456,7 +456,7 @@ mod tests {
 #[cfg(test)]
 mod tests_keydb {
     use super::*;
-    use nss::ensure_initialized_with_profile_dir;
+    use nss_as::ensure_initialized_with_profile_dir;
     use std::path::PathBuf;
 
     struct MockPrimaryPasswordAuthenticator {

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -298,7 +298,7 @@ mod tests {
     use super::*;
     use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::LoginDb;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use rusqlite::Connection;
 
     // Snapshot of the schema in version 1.  We use this to test that we can migrate from there to the

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -370,7 +370,7 @@ mod tests {
     use super::*;
     use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::util;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::cmp::Reverse;
     use std::time::SystemTime;
 
@@ -589,7 +589,7 @@ mod tests_keydb {
     use super::*;
     use crate::{ManagedEncryptorDecryptor, NSSKeyManager, PrimaryPasswordAuthenticator};
     use async_trait::async_trait;
-    use nss::ensure_initialized_with_profile_dir;
+    use nss_as::ensure_initialized_with_profile_dir;
     use std::path::PathBuf;
 
     struct MockPrimaryPasswordAuthenticator {

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -486,7 +486,7 @@ mod tests {
     use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::login::test_utils::enc_login;
     use crate::{LoginEntry, LoginFields, LoginMeta, SecureLoginFields};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::collections::HashMap;
     use std::sync::Arc;
 

--- a/components/logins/src/sync/merge.rs
+++ b/components/logins/src/sync/merge.rs
@@ -381,7 +381,7 @@ impl EncryptedLogin {
 mod tests {
     use super::*;
     use crate::encryption::test_utils::TEST_ENCDEC;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn test_invalid_payload_timestamps() {

--- a/components/logins/src/sync/update_plan.rs
+++ b/components/logins/src/sync/update_plan.rs
@@ -316,7 +316,7 @@ impl UpdatePlan {
 #[cfg(not(feature = "keydb"))]
 #[cfg(test)]
 mod tests {
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::time::Duration;
 
     use super::*;

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -32,4 +32,4 @@ hex = "0.4"
 tempfile = "3.1.0"
 mockall = "0.12"
 viaduct-dev = { path = "../support/viaduct-dev" }
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }

--- a/components/push/src/internal/crypto.rs
+++ b/components/push/src/internal/crypto.rs
@@ -263,7 +263,7 @@ impl<'a> TryFrom<&'a HashMap<String, String>> for PushPayload<'a> {
 #[cfg(test)]
 mod crypto_tests {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     // generate unit test key
     fn test_key(priv_key: &str, pub_key: &str, auth: &str) -> Key {

--- a/components/push/src/internal/push_manager.rs
+++ b/components/push/src/internal/push_manager.rs
@@ -387,7 +387,7 @@ mod test {
     use lazy_static::lazy_static;
     use std::sync::{Mutex, MutexGuard};
 
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     use crate::Store;
 

--- a/components/push/src/internal/storage/db.rs
+++ b/components/push/src/internal/storage/db.rs
@@ -254,7 +254,7 @@ mod test {
     use super::PushDb;
     use crate::internal::crypto::get_random_bytes;
     use crate::internal::storage::{db::Storage, record::PushRecord};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     const DUMMY_UAID: &str = "abad1dea00000000aabbccdd00000000";
 

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -47,5 +47,5 @@ mockito = { version = "0.31", default-features = false}
 # We add the perserve_order feature to guarantee ordering of the keys in our
 # JSON objects as they get serialized/deserialized.
 serde_json = { version = "1", features = ["preserve_order"] }
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }
 tempfile = "3"

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -1205,7 +1205,7 @@ mod test_signatures {
     use crate::RemoteSettingsContext;
 
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     const VALID_CERTIFICATE: &str = "\
 -----BEGIN CERTIFICATE-----

--- a/components/support/jwcrypto/Cargo.toml
+++ b/components/support/jwcrypto/Cargo.toml
@@ -18,4 +18,4 @@ serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]
-nss = { path = "../rc_crypto/nss" }
+nss-as = { path = "../rc_crypto/nss" }

--- a/components/support/jwcrypto/src/direct.rs
+++ b/components/support/jwcrypto/src/direct.rs
@@ -80,7 +80,7 @@ pub(crate) fn decrypt_jwe(jwe: &CompactJwe, jwk: Jwk) -> Result<String> {
 fn test_simple_roundtrip() {
     // We should be able to round-trip data.
     use super::{decrypt_jwe, encrypt_to_jwe, DecryptionParameters, EncryptionParameters};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
 
@@ -102,7 +102,7 @@ fn test_simple_roundtrip() {
 fn test_modified_ciphertext() {
     // Modifying the ciphertext will fail.
     use super::{decrypt_jwe, encrypt_to_jwe, DecryptionParameters, EncryptionParameters};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::str::FromStr;
 
     ensure_initialized();
@@ -163,7 +163,7 @@ fn test_iv() {
     // Encrypting the same thing twice should give different payloads due to
     // different IV.
     use super::{encrypt_to_jwe, EncryptionParameters};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
 
@@ -212,7 +212,7 @@ fn test_jose() {
     // `Nonce::try_assume_unique_for_key()` to allow a longer key, but we don't
     // want to do that until we have evidence it's actually spec compliant.)
     use super::{decrypt_jwe, DecryptionParameters};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
 
@@ -226,7 +226,7 @@ fn test_jose() {
 fn test_bad_key() {
     use super::{decrypt_jwe, DecryptionParameters};
     use crate::error::JwCryptoError;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
 
@@ -242,7 +242,7 @@ fn test_bad_key() {
 fn test_bad_key_type() {
     use super::{encrypt_to_jwe, EncryptionParameters};
     use crate::error::JwCryptoError;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
 
@@ -263,7 +263,7 @@ fn test_bad_key_type() {
 #[test]
 fn test_bad_key_type_direct() {
     use super::{EncryptionAlgorithm, EphemeralKeyPair};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use rc_crypto::agreement;
 
     use crate::error::JwCryptoError;

--- a/components/support/jwcrypto/src/ec.rs
+++ b/components/support/jwcrypto/src/ec.rs
@@ -177,7 +177,7 @@ pub fn extract_pub_key_jwk(key_pair: &EphemeralKeyPair) -> Result<Jwk> {
 #[test]
 fn test_encrypt_decrypt_jwe_ecdh_es() {
     use super::{decrypt_jwe, encrypt_to_jwe, DecryptionParameters, EncryptionParameters};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use rc_crypto::agreement;
 
     ensure_initialized();
@@ -207,7 +207,7 @@ fn test_encrypt_decrypt_jwe_ecdh_es() {
 fn test_bad_key_type() {
     use super::{encrypt_to_jwe, EncryptionParameters};
     use crate::error::JwCryptoError;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
 

--- a/components/support/jwcrypto/src/lib.rs
+++ b/components/support/jwcrypto/src/lib.rs
@@ -237,7 +237,7 @@ pub fn decrypt_jwe(jwe: &str, decryption_params: DecryptionParameters) -> Result
 
 #[test]
 fn test_jwk_ec_deser_with_kid() {
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
     let jwk = Jwk {
@@ -260,7 +260,7 @@ fn test_jwk_ec_deser_with_kid() {
 
 #[test]
 fn test_jwk_deser_no_kid() {
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
     let jwk = Jwk {
@@ -280,7 +280,7 @@ fn test_jwk_deser_no_kid() {
 
 #[test]
 fn test_jwk_direct_deser_with_kid() {
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
     let jwk = Jwk::new_direct_from_bytes(Some("key-id".to_string()), &[0, 1, 2, 3]);
@@ -293,7 +293,7 @@ fn test_jwk_direct_deser_with_kid() {
 
 #[test]
 fn test_compact_jwe_roundtrip() {
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     ensure_initialized();
     let mut iv = [0u8; 16];

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -13,7 +13,7 @@ base64 = "0.21"
 hex = "0.4"
 thiserror = "2"
 error-support = { path = "../error" }
-nss = { path = "nss" }
+nss-as = { path = "nss" }
 hawk = { version = "5", default-features = false, optional = true }
 ece = { version = "2.3", default-features = false, features = ["serializable-keys"], optional = true }
 

--- a/components/support/rc_crypto/nss/Cargo.toml
+++ b/components/support/rc_crypto/nss/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "nss"
+name = "nss-as"
 version = "0.1.0"
 authors = ["Sync Team <sync-team@mozilla.com>"]
 edition = "2021"

--- a/components/support/rc_crypto/src/aead.rs
+++ b/components/support/rc_crypto/src/aead.rs
@@ -25,7 +25,7 @@ mod aes_gcm;
 use crate::error::*;
 pub use aes_cbc::LEGACY_SYNC_AES_256_CBC_HMAC_SHA256;
 pub use aes_gcm::{AES_128_GCM, AES_256_GCM};
-use nss::aes;
+use nss_as::aes;
 
 pub fn open(
     key: &OpeningKey,
@@ -191,7 +191,7 @@ impl Direction {
 #[cfg(test)]
 mod test {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     static ALL_ALGORITHMS: &[&Algorithm] = &[
         &LEGACY_SYNC_AES_256_CBC_HMAC_SHA256,

--- a/components/support/rc_crypto/src/aead/aes_cbc.rs
+++ b/components/support/rc_crypto/src/aead/aes_cbc.rs
@@ -21,7 +21,7 @@
 
 use crate::{aead, digest, error::*, hmac};
 use base64::{engine::general_purpose::STANDARD, Engine};
-use nss::aes;
+use nss_as::aes;
 
 /// AES-256 in CBC mode with HMAC-SHA256 tags and 128 bit nonces.
 /// This is a Sync 1.5 specific encryption scheme, do not use for new
@@ -105,7 +105,7 @@ fn aes_cbc(
 #[cfg(test)]
 mod test {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     // These are the test vectors used by the sync15 crate, but concatenated
     // together rather than split into individual pieces.

--- a/components/support/rc_crypto/src/aead/aes_gcm.rs
+++ b/components/support/rc_crypto/src/aead/aes_gcm.rs
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{aead, error::*};
-use nss::aes;
+use nss_as::aes;
 
 /// AES-128 in GCM mode with 128-bit tags and 96 bit nonces.
 pub static AES_128_GCM: aead::Algorithm = aead::Algorithm {
@@ -83,7 +83,7 @@ fn aes_gcm(
 #[cfg(test)]
 mod test {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     // Test vector from the AES-GCM spec.
     const NONCE_HEX: &str = "cafebabefacedbaddecaf888";

--- a/components/support/rc_crypto/src/agreement.rs
+++ b/components/support/rc_crypto/src/agreement.rs
@@ -23,7 +23,7 @@ use crate::error::*;
 use core::marker::PhantomData;
 
 pub use ec::{Curve, EcKey};
-use nss::{ec, ecdh};
+use nss_as::{ec, ecdh};
 
 pub type EphemeralKeyPair = KeyPair<Ephemeral>;
 
@@ -254,7 +254,7 @@ impl InputKeyMaterial {
 mod tests {
     use super::*;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     // Test vectors copied from:
     // https://chromium.googlesource.com/chromium/src/+/56f1232/components/test/data/webcrypto/ecdh.json#5

--- a/components/support/rc_crypto/src/constant_time.rs
+++ b/components/support/rc_crypto/src/constant_time.rs
@@ -26,7 +26,7 @@ use crate::error::*;
 /// contents of each, but NOT in constant time with respect to the lengths of
 /// `a` and `b`.
 pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<()> {
-    if nss::secport::secure_memcmp(a, b)? {
+    if nss_as::secport::secure_memcmp(a, b)? {
         Ok(())
     } else {
         Err(ErrorKind::InternalError.into())
@@ -36,7 +36,7 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn does_compare() {

--- a/components/support/rc_crypto/src/contentsignature.rs
+++ b/components/support/rc_crypto/src/contentsignature.rs
@@ -100,22 +100,22 @@ pub fn verify(
 
     let root_hash_bytes = decode_root_hash(root_sha256_hash)?;
 
-    nss::pkixc::verify_code_signing_certificate_chain(
+    nss_as::pkixc::verify_code_signing_certificate_chain(
         certificates_slices,
         seconds_since_epoch,
         &root_hash_bytes,
         hostname,
     )
     .map_err(|err| match err.kind() {
-        nss::ErrorKind::CertificateIssuerError => ErrorKind::CertificateIssuerError,
-        nss::ErrorKind::CertificateValidityError => ErrorKind::CertificateValidityError,
-        nss::ErrorKind::CertificateSubjectError => ErrorKind::CertificateSubjectError,
+        nss_as::ErrorKind::CertificateIssuerError => ErrorKind::CertificateIssuerError,
+        nss_as::ErrorKind::CertificateValidityError => ErrorKind::CertificateValidityError,
+        nss_as::ErrorKind::CertificateSubjectError => ErrorKind::CertificateSubjectError,
         _ => ErrorKind::CertificateChainError(err.to_string()),
     })?;
 
     let leaf_cert = certificates.first().unwrap(); // PEM parse fails if len == 0.
 
-    let public_key_bytes = match nss::cert::extract_ec_public_key(leaf_cert) {
+    let public_key_bytes = match nss_as::cert::extract_ec_public_key(leaf_cert) {
         Ok(bytes) => bytes,
         Err(err) => return Err(ErrorKind::CertificateContentError(err.to_string()).into()),
     };
@@ -283,7 +283,7 @@ IKdcFKAt3fFrpyMhlfIKkLfmm0iDjmfmIXbDGBJw9SE=
 
     #[test]
     fn test_decode_root_hash() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(decode_root_hash("meh!").is_err());
         assert!(decode_root_hash("3C:rr:44").is_err());
 
@@ -330,7 +330,7 @@ BAUG
 
     #[test]
     fn test_verify_fails_if_invalid() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(verify(
             b"msg",
             b"sig",
@@ -346,7 +346,7 @@ fdfeff
 
     #[test]
     fn test_verify_fails_if_cert_has_expired() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(verify(
             VALID_INPUT,
             VALID_SIGNATURE,
@@ -360,7 +360,7 @@ fdfeff
 
     #[test]
     fn test_verify_fails_if_bad_certificate_chain() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(verify(
             VALID_INPUT,
             VALID_SIGNATURE,
@@ -374,7 +374,7 @@ fdfeff
 
     #[test]
     fn test_verify_fails_if_mismatch() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(verify(
             b"msg",
             VALID_SIGNATURE,
@@ -388,7 +388,7 @@ fdfeff
 
     #[test]
     fn test_verify_fails_if_bad_hostname() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(verify(
             VALID_INPUT,
             VALID_SIGNATURE,
@@ -402,7 +402,7 @@ fdfeff
 
     #[test]
     fn test_verify_fails_if_bad_root_hash() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert!(verify(
             VALID_INPUT,
             VALID_SIGNATURE,
@@ -416,7 +416,7 @@ fdfeff
 
     #[test]
     fn test_verify_succeeds_if_valid() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         verify(
             VALID_INPUT,
             VALID_SIGNATURE,

--- a/components/support/rc_crypto/src/digest.rs
+++ b/components/support/rc_crypto/src/digest.rs
@@ -21,7 +21,7 @@
 
 use crate::error::*;
 
-pub use nss::pk11::context::HashAlgorithm::{self as Algorithm, *};
+pub use nss_as::pk11::context::HashAlgorithm::{self as Algorithm, *};
 
 /// A calculated digest value.
 #[derive(Clone)]
@@ -44,7 +44,7 @@ impl AsRef<[u8]> for Digest {
 
 /// Returns the digest of data using the given digest algorithm.
 pub fn digest(algorithm: &Algorithm, data: &[u8]) -> Result<Digest> {
-    let value = nss::pk11::context::hash_buf(algorithm, data)?;
+    let value = nss_as::pk11::context::hash_buf(algorithm, data)?;
     Ok(Digest {
         value,
         algorithm: *algorithm,
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn sha256_digest() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         assert_eq!(hex::encode(digest(&SHA256, MESSAGE).unwrap()), DIGEST_HEX);
         assert_ne!(
             hex::encode(digest(&SHA256, b"notbobo").unwrap()),
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn digest_cleanly_rejects_gigantic_messages() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let message = vec![0; (i32::MAX as usize) + 1];
         assert!(digest(&SHA256, &message).is_err());
     }

--- a/components/support/rc_crypto/src/ece_crypto.rs
+++ b/components/support/rc_crypto/src/ece_crypto.rs
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_cryptographer_backend() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         crate::ensure_initialized();
         ece::crypto::test_cryptographer(RcCryptoCryptographer);
     }

--- a/components/support/rc_crypto/src/error.rs
+++ b/components/support/rc_crypto/src/error.rs
@@ -5,7 +5,7 @@
 #[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
     #[error("NSS error: {0}")]
-    NSSError(#[from] nss::Error),
+    NSSError(#[from] nss_as::Error),
     #[error("Internal crypto error")]
     InternalError,
     #[error("Conversion error: {0}")]
@@ -33,6 +33,6 @@ pub enum ErrorKind {
 error_support::define_error! {
     ErrorKind {
         (ConversionError, std::num::TryFromIntError),
-        (NSSError, nss::Error),
+        (NSSError, nss_as::Error),
     }
 }

--- a/components/support/rc_crypto/src/hawk_crypto.rs
+++ b/components/support/rc_crypto/src/hawk_crypto.rs
@@ -93,7 +93,7 @@ mod test {
     // Based on rust-hawk's hash_consistency. This fails if we've messed up the hashing.
     #[test]
     fn test_hawk_hashing() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         crate::ensure_initialized();
 
         let mut hasher1 = hawk::PayloadHasher::new("text/plain", hawk::SHA256).unwrap();
@@ -125,7 +125,7 @@ mod test {
     // Based on rust-hawk's test_make_mac. This fails if we've messed up the signing.
     #[test]
     fn test_hawk_signing() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         crate::ensure_initialized();
 
         let key = hawk::Key::new(

--- a/components/support/rc_crypto/src/hkdf.rs
+++ b/components/support/rc_crypto/src/hkdf.rs
@@ -39,7 +39,7 @@ pub fn extract(salt: &hmac::SigningKey, secret: &[u8]) -> Result<hmac::SigningKe
 
 pub fn expand(prk: &hmac::SigningKey, info: &[u8], out: &mut [u8]) -> Result<()> {
     let mut derived =
-        nss::pk11::sym_key::hkdf_expand(prk.digest_alg, &prk.key_value, info, out.len())?;
+        nss_as::pk11::sym_key::hkdf_expand(prk.digest_alg, &prk.key_value, info, out.len())?;
     out.swap_with_slice(&mut derived[0..out.len()]);
     Ok(())
 }
@@ -48,7 +48,7 @@ pub fn expand(prk: &hmac::SigningKey, info: &[u8], out: &mut [u8]) -> Result<()>
 mod tests {
     use super::*;
     use crate::digest;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn hkdf_produces_correct_result() {

--- a/components/support/rc_crypto/src/hmac.rs
+++ b/components/support/rc_crypto/src/hmac.rs
@@ -84,7 +84,7 @@ pub fn verify_with_own_key(key: &SigningKey, data: &[u8], signature: &[u8]) -> R
 
 /// Calculate the HMAC of `data` using `key`.
 pub fn sign(key: &SigningKey, data: &[u8]) -> Result<Signature> {
-    let value = nss::pk11::context::hmac_sign(key.digest_alg, &key.key_value, data)?;
+    let value = nss_as::pk11::context::hmac_sign(key.digest_alg, &key.key_value, data)?;
     Ok(Signature(digest::Digest {
         value,
         algorithm: *key.digest_alg,
@@ -94,7 +94,7 @@ pub fn sign(key: &SigningKey, data: &[u8]) -> Result<Signature> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     const KEY: &[u8] = b"key";
     const MESSAGE: &[u8] = b"The quick brown fox jumps over the lazy dog";

--- a/components/support/rc_crypto/src/lib.rs
+++ b/components/support/rc_crypto/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::error::{Error, ErrorKind, Result};
 /// Only required to be called if you intend to use this library in conjunction
 /// with the `hawk` or the `ece` crate.
 pub fn ensure_initialized() {
-    nss::assert_initialized();
+    nss_as::assert_initialized();
 
     #[cfg(any(feature = "hawk", feature = "ece"))]
     {

--- a/components/support/rc_crypto/src/pbkdf2.rs
+++ b/components/support/rc_crypto/src/pbkdf2.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::*;
-use nss::pbkdf2::pbkdf2_key_derive;
-pub use nss::pbkdf2::HashAlgorithm;
+use nss_as::pbkdf2::pbkdf2_key_derive;
+pub use nss_as::pbkdf2::HashAlgorithm;
 /// Extend passwords using pbkdf2, based on the following [rfc](https://www.ietf.org/rfc/rfc2898.txt) it runs the NSS implementation
 /// # Arguments
 ///
@@ -18,7 +18,7 @@ pub use nss::pbkdf2::HashAlgorithm;
 ///
 /// ```
 /// use rc_crypto::pbkdf2;
-/// use nss::ensure_initialized;
+/// use nss_as::ensure_initialized;
 /// ensure_initialized();
 /// let password = b"password";
 /// let salt = b"salt";
@@ -46,7 +46,7 @@ pub fn derive(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn test_generate_correct_out() {

--- a/components/support/rc_crypto/src/rand.rs
+++ b/components/support/rc_crypto/src/rand.rs
@@ -23,13 +23,13 @@ use crate::error::*;
 
 /// Fill a buffer with cryptographically secure pseudo-random data.
 pub fn fill(dest: &mut [u8]) -> Result<()> {
-    Ok(nss::pk11::slot::generate_random(dest)?)
+    Ok(nss_as::pk11::slot::generate_random(dest)?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn random_fill() {

--- a/components/support/rc_crypto/src/signature.rs
+++ b/components/support/rc_crypto/src/signature.rs
@@ -20,7 +20,7 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::Result;
-use nss::{ec::Curve, ec::PublicKey, pbkdf2::HashAlgorithm};
+use nss_as::{ec::Curve, ec::PublicKey, pbkdf2::HashAlgorithm};
 
 /// A signature verification algorithm.
 pub struct VerificationAlgorithm {
@@ -70,7 +70,7 @@ impl<'a> UnparsedPublicKey<'a> {
 mod tests {
     use super::*;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
 
     #[test]
     fn test_ecdsa_p384_sha384_verify() {

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -48,4 +48,4 @@ viaduct = { path = "../viaduct", optional = true }
 
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }
-nss = { path = "../support/rc_crypto/nss" }
+nss-as = { path = "../support/rc_crypto/nss" }

--- a/components/sync15/src/client/coll_state.rs
+++ b/components/sync15/src/client/coll_state.rs
@@ -174,7 +174,7 @@ mod tests {
     use crate::record_types::{MetaGlobalEngine, MetaGlobalRecord};
     use crate::{CollectionName, telemetry};
     use anyhow::Result;
-    use nss::ensure_initialized;
+    use nss_as::ensure_initialized;
     use std::cell::{Cell, RefCell};
     use std::collections::HashMap;
     use sync_guid::Guid;

--- a/components/sync15/src/client/state.rs
+++ b/components/sync15/src/client/state.rs
@@ -759,7 +759,7 @@ mod tests {
 
     #[test]
     fn test_state_machine_ready_from_empty() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         error_support::init_for_tests();
         let root_key = KeyBundle::new_random().unwrap();
         let keys = CollectionKeys {
@@ -817,7 +817,7 @@ mod tests {
 
     #[test]
     fn test_from_previous_state_declined() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         error_support::init_for_tests();
         // The state-machine sequence where we didn't use the previous state
         // (ie, where the state machine restarted)

--- a/components/sync15/src/client/token.rs
+++ b/components/sync15/src/client/token.rs
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_endpoint() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         // Use a cell to avoid the closure having a mutable ref to this scope.
         let counter: Cell<u32> = Cell::new(0);
         let fetch = || {
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_backoff() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let counter: Cell<u32> = Cell::new(0);
         let fetch = || {
             counter.set(counter.get() + 1);
@@ -530,7 +530,7 @@ mod tests {
 
     #[test]
     fn test_validity() {
-        nss::ensure_initialized();
+        nss_as::ensure_initialized();
         let counter: Cell<u32> = Cell::new(0);
         let fetch = || {
             counter.set(counter.get() + 1);

--- a/examples/autofill-utils/Cargo.toml
+++ b/examples/autofill-utils/Cargo.toml
@@ -18,7 +18,7 @@ cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }
 error-support = { path = "../../components/support/error" }
 interrupt-support = { path = "../../components/support/interrupt" } # XXX - should be removed once we do interrupts correctly!
-nss = { path = "../../components/support/rc_crypto/nss" }
+nss-as = { path = "../../components/support/rc_crypto/nss" }
 log = "0.4"
 rusqlite = { version = "0.37.0", features = ["functions", "bundled", "serde_json", "unlock_notify"]}
 serde_json = "1"

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -476,7 +476,7 @@ fn get_encryption_key(store: &Store, db_path: &str, opts: &Opts) -> Result<Strin
 }
 
 fn main() -> Result<()> {
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
 
     let opts = Opts::parse();

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -12,7 +12,7 @@ name = "fxa-client"
 path = "src/main.rs"
 
 [dev-dependencies]
-nss = { path = "../../components/support/rc_crypto/nss" }
+nss-as = { path = "../../components/support/rc_crypto/nss" }
 viaduct = { path = "../../components/viaduct"}
 viaduct-hyper = { path = "../../components/support/viaduct-hyper" }
 log = "0.4"

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -77,7 +77,7 @@ enum Command {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
     cli_support::init_logging_with("info");
 

--- a/examples/places-utils/Cargo.toml
+++ b/examples/places-utils/Cargo.toml
@@ -16,7 +16,7 @@ sync-guid = { path = "../../components/support/guid" }
 types = { path = "../../components/support/types" }
 error-support = { path = "../../components/support/error" }
 interrupt-support = { path = "../../components/support/interrupt" }
-nss = { path = "../../components/support/rc_crypto/nss" }
+nss-as = { path = "../../components/support/rc_crypto/nss" }
 sql-support = { path = "../../components/support/sql", features = ["debug-tools"] }
 sync15 = { path = "../../components/sync15" }
 viaduct = { path = "../../components/viaduct"}

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -445,7 +445,7 @@ enum Command {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     if !opts.no_logging {
         cli_support::init_trace_logging();
     }

--- a/examples/relevancy-cli/Cargo.toml
+++ b/examples/relevancy-cli/Cargo.toml
@@ -17,4 +17,4 @@ places = { path = "../../components/places" }
 relevancy = { path = "../../components/relevancy" }
 anyhow = "1.0"
 sync15 = { path = "../../components/sync15" }
-nss = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }
+nss-as = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }

--- a/examples/relevancy-cli/src/main.rs
+++ b/examples/relevancy-cli/src/main.rs
@@ -34,7 +34,7 @@ struct Cli {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
     cli_support::ensure_cli_data_dir_exists();
     let mut builder = Builder::new();

--- a/examples/remote-settings-cli/Cargo.toml
+++ b/examples/remote-settings-cli/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/dump/lib.rs"
 [dependencies]
 cli-support = { path = "../cli-support" }
 remote_settings = { features = ["signatures"], path = "../../components/remote_settings" }
-nss = { path = "../../components/support/rc_crypto/nss" }
+nss-as = { path = "../../components/support/rc_crypto/nss" }
 viaduct = { path = "../../components/viaduct"}
 viaduct-hyper = { path = "../../components/support/viaduct-hyper" }
 log = "0.4"

--- a/examples/remote-settings-cli/src/main.rs
+++ b/examples/remote-settings-cli/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<()> {
     } else {
         DEFAULT_LOG_FILTER
     });
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
     let service = build_service(&cli)?;
     match cli.command {

--- a/examples/suggest-cli/Cargo.toml
+++ b/examples/suggest-cli/Cargo.toml
@@ -14,4 +14,4 @@ log = "0.4"
 clap = {version = "4.2", default-features = false, features = ["std", "derive"]}
 suggest = { path = "../../components/suggest" }
 anyhow = "1.0"
-nss = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }
+nss-as = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }

--- a/examples/suggest-cli/src/main.rs
+++ b/examples/suggest-cli/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
     } else {
         DEFAULT_LOG_FILTER
     });
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
     let store = build_store(&cli)?;
     match cli.command {

--- a/examples/tabs-sync/Cargo.toml
+++ b/examples/tabs-sync/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.2", default-features = false, features = ["std", "derive"]
 cli-support = { path = "../cli-support" }
 url = "2.2"
 interrupt-support = { path = "../../components/support/interrupt" }
-nss = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }
+nss-as = { version = "0.1.0", path = "../../components/support/rc_crypto/nss" }
 sync15 = { path = "../../components/sync15", features = ["sync-engine"] }
 viaduct = { path = "../../components/viaduct"}
 viaduct-hyper = { path = "../../components/support/viaduct-hyper"}

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -94,7 +94,7 @@ fn do_sync(
 }
 
 fn main() -> Result<()> {
-    nss::ensure_initialized();
+    nss_as::ensure_initialized();
     viaduct_hyper::viaduct_init_backend_hyper()?;
     cli_support::init_logging();
     let opts = Opts::parse();

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -29,4 +29,4 @@ serde_derive = "1.0"
 serde_json = "1.0"
 base64 = "0.21"
 cli-support = { path = "../../examples/cli-support" }
-nss = { path = "../../components/support/rc_crypto/nss" }
+nss-as = { path = "../../components/support/rc_crypto/nss" }

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -6,7 +6,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 
 use clap::Parser;
 use cli_support::fxa_creds::{get_default_fxa_config, CliFxa, SYNC_SCOPE};
-use nss::ensure_initialized;
+use nss_as::ensure_initialized;
 use std::sync::Arc;
 use std::{collections::HashSet, process};
 


### PR DESCRIPTION
Intent is to make space for an "official" nss crate.

Seems like this is tedious but should be safe.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
