### PR TITLE
Bug 2038168 - fix version override for ohttp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "ohttp"
 version = "0.7.2"
-source = "git+https://github.com/martinthomson/ohttp#324f876e79394c9b815dcacda3fd4f48f105fdf2"
+source = "git+https://github.com/martinthomson/ohttp?rev=324f876e79394c9b815dcacda3fd4f48f105fdf2#324f876e79394c9b815dcacda3fd4f48f105fdf2"
 dependencies = [
  "bindgen",
  "byteorder",
@@ -3109,7 +3109,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror 2.0.3",
- "toml 0.9.6",
+ "toml 0.5.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,4 @@ uniffi_pipeline = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "59b
 mozilla-central-workspace-hack = { path = "monorepo-hacks/workspace-hack" }
 mozbuild = { path = "monorepo-hacks/mozbuild" }
 # temporary ohttp override enabling the above hacks while we wait for a new version.
-ohttp = { git = "https://github.com/martinthomson/ohttp", revision = "324f876e79394c9b815dcacda3fd4f48f105fdf2" }
+ohttp = { git = "https://github.com/martinthomson/ohttp", rev = "324f876e79394c9b815dcacda3fd4f48f105fdf2" }

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -583,6 +583,7 @@ The following text applies to code linked from these dependencies:
 [thiserror-impl](https://github.com/dtolnay/thiserror),
 [thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
+[toml](https://github.com/alexcrichton/toml-rs),
 [toml](https://github.com/toml-rs/toml),
 [toml_datetime](https://github.com/toml-rs/toml),
 [toml_parser](https://github.com/toml-rs/toml),

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -540,6 +540,7 @@ The following text applies to code linked from these dependencies:
 [thiserror-impl](https://github.com/dtolnay/thiserror),
 [thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
+[toml](https://github.com/alexcrichton/toml-rs),
 [toml](https://github.com/toml-rs/toml),
 [toml_datetime](https://github.com/toml-rs/toml),
 [toml_parser](https://github.com/toml-rs/toml),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -486,6 +486,10 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: toml</name>
+    <url>https://github.com/alexcrichton/toml-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: toml</name>
     <url>https://github.com/toml-rs/toml/blob/main/LICENSE-APACHE</url>
   </license>
   <license>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -568,6 +568,7 @@ The following text applies to code linked from these dependencies:
 [thiserror-impl](https://github.com/dtolnay/thiserror),
 [thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
+[toml](https://github.com/alexcrichton/toml-rs),
 [toml](https://github.com/toml-rs/toml),
 [toml_datetime](https://github.com/toml-rs/toml),
 [toml_parser](https://github.com/toml-rs/toml),

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -554,6 +554,7 @@ The following text applies to code linked from these dependencies:
 [thiserror-impl](https://github.com/dtolnay/thiserror),
 [thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
+[toml](https://github.com/alexcrichton/toml-rs),
 [toml](https://github.com/toml-rs/toml),
 [toml_datetime](https://github.com/toml-rs/toml),
 [toml_parser](https://github.com/toml-rs/toml),


### PR DESCRIPTION
I used 'revision' instead of 'rev' - and I'm fairly sure that kinda worked, because otherwise ohttp wouldn't have built here.

I'm a little confused by the Cargo.lock changes though, you can see the format of the ohttp entry changed, even though both formats have the same revision. It now also takes the earlier toml version even though it is marked as compatible 0.9

But it seems to work and this is obviously correct.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
