### PR TITLE
Bug 2030949 - default timeout for viaduct is now 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 * Add uptake telemetry support ([#7288](https://github.com/mozilla/application-services/pull/7288))
 * Add v2 routes ([#7339](https://github.com/mozilla/application-services/pull/7339))
 
+## ✨ What's Changed ✨
+
+- Viaduct has a default timeout of 60 seconds on all platforms (was previously 10 seconds on Android, 7 seconds on iOS)
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v151.0...v152.0)
 
 # v151.0 (_2026-04-20_)

--- a/components/viaduct/src/client.rs
+++ b/components/viaduct/src/client.rs
@@ -106,10 +106,7 @@ impl ClientSettings {
 impl Default for ClientSettings {
     fn default() -> Self {
         Self {
-            #[cfg(target_os = "ios")]
-            timeout: 7000,
-            #[cfg(not(target_os = "ios"))]
-            timeout: 10000,
+            timeout: 60000,
             redirect_limit: 10,
             user_agent: None,
             #[cfg(feature = "ohttp")]


### PR DESCRIPTION
Discussed this a little in #application-services-eng and there was general agreement, but asking for explicit review for people who own components which may be impacted.