### PR TITLE
Bug 2044397 - Add feature IDs to enrollment change events [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v153.0 (In progress)
 
+### Nimbus
+
+- Enrollment change events (visible to the UDL) now include the feature IDs of the features involved when possible. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
+- Fixed a bug where enrollment change events were not emitted for rollouts that re-enrolled after previously unenrolling. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
+
 [Full Changelog](In progress)
 
 # v152.0 (_2026-05-18_)

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -155,18 +155,21 @@ class NimbusTests {
                 branchSlug = "test-branch",
                 reason = "test-reason",
                 change = EnrollmentChangeEventType.ENROLLMENT,
+                featureIds = listOf(),
             ),
             EnrollmentChangeEvent(
                 experimentSlug = "test-experiment",
                 branchSlug = "test-branch",
                 reason = "test-reason",
                 change = EnrollmentChangeEventType.UNENROLLMENT,
+                featureIds = listOf(),
             ),
             EnrollmentChangeEvent(
                 experimentSlug = "test-experiment",
                 branchSlug = "test-branch",
                 reason = "test-reason",
                 change = EnrollmentChangeEventType.DISQUALIFICATION,
+                featureIds = listOf(),
             ),
         )
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -227,7 +227,7 @@ impl ExperimentEnrollment {
                 &enrollment.slug, &enrollment
             );
             if matches!(enrollment.status, EnrollmentStatus::Enrolled { .. }) {
-                out_enrollment_events.push(enrollment.get_change_event())
+                out_enrollment_events.push(enrollment.get_change_event(Some(experiment)))
             }
             enrollment
         })
@@ -246,6 +246,7 @@ impl ExperimentEnrollment {
                 branch_slug: branch_slug.to_string(),
                 reason: Some("does-not-exist".to_string()),
                 change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: experiment.get_feature_ids(),
             });
 
             return Err(NimbusError::NoSuchBranch(
@@ -257,7 +258,7 @@ impl ExperimentEnrollment {
             slug: experiment.slug.clone(),
             status: EnrollmentStatus::new_enrolled(EnrolledReason::OptIn, branch_slug),
         };
-        out_enrollment_events.push(enrollment.get_change_event());
+        out_enrollment_events.push(enrollment.get_change_event(Some(experiment)));
         Ok(enrollment)
     }
 
@@ -287,7 +288,8 @@ impl ExperimentEnrollment {
                         &self.slug, &self, updated_enrollment
                     );
                     if matches!(updated_enrollment.status, EnrollmentStatus::Enrolled { .. }) {
-                        out_enrollment_events.push(updated_enrollment.get_change_event());
+                        out_enrollment_events
+                            .push(updated_enrollment.get_change_event(Some(updated_experiment)));
                     }
                     updated_enrollment
                 }
@@ -303,7 +305,8 @@ impl ExperimentEnrollment {
                     self.maybe_revert_all_gecko_pref_states(gecko_pref_store);
                     let updated_enrollment =
                         self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
-                    out_enrollment_events.push(updated_enrollment.get_change_event());
+                    out_enrollment_events
+                        .push(updated_enrollment.get_change_event(Some(updated_experiment)));
                     updated_enrollment
                 } else if !updated_experiment.has_branch(branch) {
                     // The branch we were in disappeared!
@@ -311,7 +314,8 @@ impl ExperimentEnrollment {
                     self.maybe_revert_all_gecko_pref_states(gecko_pref_store);
                     let updated_enrollment =
                         self.disqualify_from_enrolled(DisqualifiedReason::Error);
-                    out_enrollment_events.push(updated_enrollment.get_change_event());
+                    out_enrollment_events
+                        .push(updated_enrollment.get_change_event(Some(updated_experiment)));
                     updated_enrollment
                 } else if matches!(reason, EnrolledReason::OptIn) {
                     // we check if we opted-in an experiment, if so
@@ -341,7 +345,9 @@ impl ExperimentEnrollment {
                         EnrollmentStatus::Error { .. } => {
                             let updated_enrollment =
                                 self.disqualify_from_enrolled(DisqualifiedReason::Error);
-                            out_enrollment_events.push(updated_enrollment.get_change_event());
+                            out_enrollment_events.push(
+                                updated_enrollment.get_change_event(Some(updated_experiment)),
+                            );
                             updated_enrollment
                         }
                         EnrollmentStatus::NotEnrolled {
@@ -359,7 +365,9 @@ impl ExperimentEnrollment {
                             );
                             let updated_enrollment =
                                 self.disqualify_from_enrolled(DisqualifiedReason::NotTargeted);
-                            out_enrollment_events.push(updated_enrollment.get_change_event());
+                            out_enrollment_events.push(
+                                updated_enrollment.get_change_event(Some(updated_experiment)),
+                            );
                             updated_enrollment
                         }
                         EnrollmentStatus::NotEnrolled {
@@ -369,7 +377,9 @@ impl ExperimentEnrollment {
                             //
                             let updated_enrollment =
                                 self.disqualify_from_enrolled(DisqualifiedReason::NotSelected);
-                            out_enrollment_events.push(updated_enrollment.get_change_event());
+                            out_enrollment_events.push(
+                                updated_enrollment.get_change_event(Some(updated_experiment)),
+                            );
                             updated_enrollment
                         }
                         EnrollmentStatus::NotEnrolled { .. }
@@ -398,13 +408,18 @@ impl ExperimentEnrollment {
                         DisqualifiedReason::NotSelected | DisqualifiedReason::NotTargeted,
                     )
                 {
-                    let evaluated_enrollment = evaluate_enrollment(
+                    let updated_enrollment = evaluate_enrollment(
                         available_randomization_units,
                         updated_experiment,
                         targeting_helper,
                     )?;
-                    match evaluated_enrollment.status {
-                        EnrollmentStatus::Enrolled { .. } => evaluated_enrollment,
+                    match updated_enrollment.status {
+                        EnrollmentStatus::Enrolled { .. } => {
+                            out_enrollment_events.push(
+                                updated_enrollment.get_change_event(Some(updated_experiment)),
+                            );
+                            updated_enrollment
+                        }
                         _ => self.clone(),
                     }
                 } else {
@@ -422,6 +437,7 @@ impl ExperimentEnrollment {
     /// from the database after `PREVIOUS_ENROLLMENTS_GC_TIME`.
     fn on_experiment_ended(
         &self,
+        experiment: &Experiment,
         #[cfg(feature = "stateful")] gecko_pref_store: Option<&GeckoPrefStore>,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> Option<Self> {
@@ -446,7 +462,7 @@ impl ExperimentEnrollment {
                 experiment_ended_at: now_secs(),
             },
         };
-        out_enrollment_events.push(enrollment.get_change_event());
+        out_enrollment_events.push(enrollment.get_change_event(Some(experiment)));
         Some(enrollment)
     }
 
@@ -455,6 +471,7 @@ impl ExperimentEnrollment {
     #[cfg_attr(not(feature = "stateful"), allow(unused))]
     pub(crate) fn on_explicit_opt_out(
         &self,
+        experiment: Option<&Experiment>,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
         #[cfg(feature = "stateful")] gecko_pref_store: Option<&GeckoPrefStore>,
     ) -> ExperimentEnrollment {
@@ -464,7 +481,7 @@ impl ExperimentEnrollment {
                 self.maybe_revert_all_gecko_pref_states(gecko_pref_store);
 
                 let enrollment = self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
-                out_enrollment_events.push(enrollment.get_change_event());
+                out_enrollment_events.push(enrollment.get_change_event(experiment));
                 enrollment
             }
             EnrollmentStatus::NotEnrolled { .. } => Self {
@@ -486,6 +503,7 @@ impl ExperimentEnrollment {
     pub(crate) fn on_pref_unenroll(
         &self,
         pref_unenroll_reason: PrefUnenrollReason,
+        experiment: Option<&Experiment>,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> ExperimentEnrollment {
         match self.status {
@@ -494,7 +512,7 @@ impl ExperimentEnrollment {
                     self.disqualify_from_enrolled(DisqualifiedReason::PrefUnenrollReason {
                         reason: pref_unenroll_reason,
                     });
-                out_enrollment_events.push(enrollment.get_change_event());
+                out_enrollment_events.push(enrollment.get_change_event(experiment));
                 enrollment
             }
             _ => self.clone(),
@@ -564,12 +582,13 @@ impl ExperimentEnrollment {
     #[cfg_attr(not(feature = "stateful"), allow(unused))]
     pub fn reset_telemetry_identifiers(
         &self,
+        experiment: Option<&Experiment>,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> Self {
         let updated = match self.status {
             EnrollmentStatus::Enrolled { .. } => {
                 let disqualified = self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
-                out_enrollment_events.push(disqualified.get_change_event());
+                out_enrollment_events.push(disqualified.get_change_event(experiment));
                 disqualified
             }
             EnrollmentStatus::NotEnrolled { .. }
@@ -602,19 +621,21 @@ impl ExperimentEnrollment {
 
     // Create a telemetry event describing the transition
     // to the current enrollment state.
-    fn get_change_event(&self) -> EnrollmentChangeEvent {
+    fn get_change_event(&self, experiment: Option<&Experiment>) -> EnrollmentChangeEvent {
         match &self.status {
             EnrollmentStatus::Enrolled { branch, .. } => EnrollmentChangeEvent::new(
                 &self.slug,
                 branch,
                 None,
                 EnrollmentChangeEventType::Enrollment,
+                experiment,
             ),
             EnrollmentStatus::WasEnrolled { branch, .. } => EnrollmentChangeEvent::new(
                 &self.slug,
                 branch,
                 None,
                 EnrollmentChangeEventType::Unenrollment,
+                experiment,
             ),
             EnrollmentStatus::Disqualified { branch, reason, .. } => EnrollmentChangeEvent::new(
                 &self.slug,
@@ -631,6 +652,7 @@ impl ExperimentEnrollment {
                     },
                 },
                 EnrollmentChangeEventType::Disqualification,
+                experiment,
             ),
             EnrollmentStatus::NotEnrolled { .. } | EnrollmentStatus::Error { .. } => {
                 unreachable!()
@@ -988,6 +1010,7 @@ impl<'a> EnrollmentsEvolver<'a> {
                         branch_slug: "N/A".to_string(),
                         reason: Some("feature-conflict".to_string()),
                         change: EnrollmentChangeEventType::EnrollFailed,
+                        feature_ids: next_experiment.get_feature_ids(),
                     })
                 }
                 // Whether it's our experiment or not that is using these features, no further enrollment can
@@ -1142,7 +1165,8 @@ impl<'a> EnrollmentsEvolver<'a> {
                 out_enrollment_events,
             )?),
             // Experiment deleted remotely.
-            (Some(_), None, Some(enrollment)) => enrollment.on_experiment_ended(
+            (Some(prev_experiment), None, Some(enrollment)) => enrollment.on_experiment_ended(
+                prev_experiment,
                 #[cfg(feature = "stateful")]
                 gecko_pref_store,
                 out_enrollment_events,
@@ -1452,11 +1476,13 @@ impl From<&EnrolledFeatureConfig> for EnrolledFeature {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct EnrollmentChangeEvent {
     pub experiment_slug: String,
     pub branch_slug: String,
     pub reason: Option<String>,
     pub change: EnrollmentChangeEventType,
+    pub feature_ids: Vec<String>,
 }
 
 impl EnrollmentChangeEvent {
@@ -1465,12 +1491,14 @@ impl EnrollmentChangeEvent {
         branch: &str,
         reason: Option<&str>,
         change: EnrollmentChangeEventType,
+        experiment: Option<&Experiment>,
     ) -> Self {
         Self {
             experiment_slug: slug.to_owned(),
             branch_slug: branch.to_owned(),
             reason: reason.map(|s| s.to_owned()),
             change,
+            feature_ids: experiment.map(|e| e.get_feature_ids()).unwrap_or_default(),
         }
     }
 }

--- a/components/nimbus/src/metrics.rs
+++ b/components/nimbus/src/metrics.rs
@@ -11,6 +11,7 @@ use crate::enrollment::PreviousGeckoPrefState;
 pub use crate::metrics::detail::*;
 
 #[derive(Serialize, Deserialize, Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub struct EnrollmentStatusExtraDef {
     pub branch: Option<String>,
     pub conflict_slug: Option<String>,

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -73,6 +73,7 @@ dictionary EnrollmentChangeEvent {
     string branch_slug;
     string? reason;
     EnrollmentChangeEventType change;
+    sequence<string> feature_ids;
 };
 
 enum EnrollmentChangeEventType {

--- a/components/nimbus/src/schema.rs
+++ b/components/nimbus/src/schema.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -75,11 +75,13 @@ impl Experiment {
             .flat_map(|b| {
                 b.get_feature_configs()
                     .iter()
-                    .map(|f| f.to_owned().feature_id)
+                    .map(|f| f.feature_id.clone())
                     .collect::<Vec<_>>()
             })
-            .collect::<HashSet<_>>();
+            .collect::<BTreeSet<_>>();
 
+        // Using a BTreeSet generates the feature IDs in a sorted order, which helps
+        // make testing easier.
         feature_ids.into_iter().collect()
     }
 

--- a/components/nimbus/src/stateful/enrollment.rs
+++ b/components/nimbus/src/stateful/enrollment.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::iter;
+
 use crate::enrollment::Participation;
 use crate::enrollment::{
     EnrollmentChangeEvent, EnrollmentChangeEventType, EnrollmentsEvolver, ExperimentEnrollment,
@@ -128,10 +130,32 @@ pub fn opt_in_with_branch(
             branch_slug: branch.to_string(),
             reason: Some("does-not-exist".to_string()),
             change: EnrollmentChangeEventType::EnrollFailed,
+            feature_ids: vec![],
         });
     }
 
     Ok(events)
+}
+
+fn get_enrollment_and_experiment(
+    db: &Database,
+    writer: &mut Writer,
+    experiment_slug: &str,
+) -> Result<(Option<ExperimentEnrollment>, Option<Experiment>)> {
+    // TODO(bug 2038055): Compute this using the database cache.
+    let maybe_enrollment: Option<ExperimentEnrollment> = db
+        .get_store(StoreId::Enrollments)
+        .get(writer, experiment_slug)?;
+    let maybe_experiment: Option<Experiment> = db
+        .get_store(StoreId::Experiments)
+        .get(writer, experiment_slug)?;
+
+    // We are technically guaranteed at this time that if an active enrollment
+    // exists in the enrollments store that the corresponding experiment must
+    // also exist in the experiment store.
+    //
+    // This is only not true during apply_pending_experiments.
+    Ok((maybe_enrollment, maybe_experiment))
 }
 
 pub fn opt_out(
@@ -141,19 +165,28 @@ pub fn opt_out(
     gecko_prefs: Option<&GeckoPrefStore>,
 ) -> Result<Vec<EnrollmentChangeEvent>> {
     let mut events = vec![];
-    let enr_store = db.get_store(StoreId::Enrollments);
-    if let Ok(Some(existing_enrollment)) =
-        enr_store.get::<ExperimentEnrollment, Writer>(writer, experiment_slug)
-    {
-        let updated_enrollment = &existing_enrollment.on_explicit_opt_out(&mut events, gecko_prefs);
-        enr_store.put(writer, experiment_slug, updated_enrollment)?;
-    } else {
-        events.push(EnrollmentChangeEvent {
-            experiment_slug: experiment_slug.to_string(),
-            branch_slug: "N/A".to_string(),
-            reason: Some("does-not-exist".to_string()),
-            change: EnrollmentChangeEventType::UnenrollFailed,
-        });
+
+    match get_enrollment_and_experiment(db, writer, experiment_slug) {
+        Ok((Some(existing_enrollment), maybe_experiment)) => {
+            let updated_enrollment = &existing_enrollment.on_explicit_opt_out(
+                maybe_experiment.as_ref(),
+                &mut events,
+                gecko_prefs,
+            );
+
+            db.get_store(StoreId::Enrollments)
+                .put(writer, experiment_slug, updated_enrollment)?;
+        }
+
+        _ => {
+            events.push(EnrollmentChangeEvent {
+                experiment_slug: experiment_slug.to_string(),
+                branch_slug: "N/A".to_string(),
+                reason: Some("does-not-exist".to_string()),
+                change: EnrollmentChangeEventType::UnenrollFailed,
+                feature_ids: vec![],
+            });
+        }
     }
 
     Ok(events)
@@ -169,22 +202,29 @@ pub fn unenroll_for_pref(
     gecko_pref_store: Option<&GeckoPrefStore>,
     events: &mut Vec<EnrollmentChangeEvent>,
 ) -> Result<()> {
-    let enr_store = db.get_store(StoreId::Enrollments);
-    if let Ok(Some(existing_enrollment)) =
-        enr_store.get::<ExperimentEnrollment, Writer>(writer, experiment_slug)
-    {
-        existing_enrollment
-            .maybe_revert_unchanged_gecko_pref_states(triggering_pref_name, gecko_pref_store);
+    match get_enrollment_and_experiment(db, writer, experiment_slug) {
+        Ok((Some(existing_enrollment), maybe_experiment)) => {
+            existing_enrollment
+                .maybe_revert_unchanged_gecko_pref_states(triggering_pref_name, gecko_pref_store);
 
-        let updated_enrollment = &existing_enrollment.on_pref_unenroll(unenroll_reason, events);
-        enr_store.put(writer, experiment_slug, updated_enrollment)?;
-    } else {
-        events.push(EnrollmentChangeEvent {
-            experiment_slug: experiment_slug.to_string(),
-            branch_slug: "N/A".to_string(),
-            reason: Some("does-not-exist".to_string()),
-            change: EnrollmentChangeEventType::UnenrollFailed,
-        });
+            let updated_enrollment = &existing_enrollment.on_pref_unenroll(
+                unenroll_reason,
+                maybe_experiment.as_ref(),
+                events,
+            );
+            db.get_store(StoreId::Enrollments)
+                .put(writer, experiment_slug, updated_enrollment)?;
+        }
+
+        _ => {
+            events.push(EnrollmentChangeEvent {
+                experiment_slug: experiment_slug.to_string(),
+                branch_slug: "N/A".to_string(),
+                reason: Some("does-not-exist".to_string()),
+                change: EnrollmentChangeEventType::UnenrollFailed,
+                feature_ids: vec![],
+            });
+        }
     }
 
     Ok(())
@@ -236,9 +276,19 @@ pub fn reset_telemetry_identifiers(
     let mut events = vec![];
     let store = db.get_store(StoreId::Enrollments);
     let enrollments: Vec<ExperimentEnrollment> = store.collect_all(writer)?;
-    let updated_enrollments = enrollments
+    // TODO(bug 2038055): Compute this using the database cache.
+    let experiments: Vec<Option<Experiment>> = enrollments
         .iter()
-        .map(|enrollment| enrollment.reset_telemetry_identifiers(&mut events));
+        .map(|enrollment| {
+            db.get_store(StoreId::Experiments)
+                .get::<Experiment, _>(writer, &enrollment.slug)
+        })
+        .collect::<Result<_>>()?;
+
+    let updated_enrollments =
+        iter::zip(enrollments, experiments).map(|(enrollment, experiment)| {
+            enrollment.reset_telemetry_identifiers(experiment.as_ref(), &mut events)
+        });
     store.clear(writer)?;
     for enrollment in updated_enrollments {
         store.put(writer, &enrollment.slug, &enrollment)?;

--- a/components/nimbus/src/tests/helpers.rs
+++ b/components/nimbus/src/tests/helpers.rs
@@ -17,7 +17,8 @@ use serde_json::Map;
 use serde_json::{Value, json};
 
 use crate::enrollment::{
-    EnrolledFeatureConfig, EnrolledReason, ExperimentEnrollment, NotEnrolledReason,
+    EnrolledFeatureConfig, EnrolledReason, EnrollmentChangeEvent, ExperimentEnrollment,
+    NotEnrolledReason,
 };
 #[cfg(feature = "stateful")]
 use crate::json::JsonObject;
@@ -506,7 +507,10 @@ pub fn get_single_feature_rollout(slug: &str, feature_id: &str, config: Value) -
 }
 
 pub fn get_bucketed_rollout(slug: &str, count: i64) -> Experiment {
-    let feature_id = "a-feature";
+    get_bucketed_rollout_with_feature(slug, count, "a-feature")
+}
+
+pub fn get_bucketed_rollout_with_feature(slug: &str, count: i64, feature_id: &str) -> Experiment {
     serde_json::from_value(json!(
         {
         "schemaVersion": "1.0.0",
@@ -618,19 +622,40 @@ where
 
 #[cfg_attr(not(feature = "stateful"), allow(unused))]
 pub fn get_targeted_experiment(slug: &str, targeting: &str) -> serde_json::Value {
+    get_targeted_experiment_with_feature(slug, targeting, "some-feature-1")
+}
+
+#[cfg_attr(not(feature = "stateful"), allow(unused))]
+pub fn get_targeted_experiment_with_feature(
+    slug: &str,
+    targeting: &str,
+    feature_id: &str,
+) -> serde_json::Value {
     json!({
         "schemaVersion": "1.0.0",
         "slug": slug,
         "endDate": null,
-        "featureIds": ["some-feature-1"],
+        "featureIds": [feature_id],
         "branches": [
             {
-            "slug": "control",
-            "ratio": 1
+                "slug": "control",
+                "ratio": 1,
+                "features": [
+                    {
+                        "featureId": feature_id,
+                        "value": {}
+                    }
+                ]
             },
             {
-            "slug": "treatment",
-            "ratio": 1
+                "slug": "treatment",
+                "ratio": 1,
+                "features": [
+                    {
+                        "featureId": feature_id,
+                        "value": {}
+                    }
+                ]
             }
         ],
         "channel": "nightly",
@@ -822,4 +847,13 @@ mod detail {
             state.nimbus_user_id = nimbus_user_id;
         }
     }
+}
+
+/// Return the given enrollments in a sorted order.
+pub fn sorted_enrollment_change_events(
+    mut events: Vec<EnrollmentChangeEvent>,
+) -> Vec<EnrollmentChangeEvent> {
+    events.sort_by(|e1, e2| e1.experiment_slug.cmp(&e2.experiment_slug));
+
+    events
 }

--- a/components/nimbus/src/tests/stateful/test_enrollment.rs
+++ b/components/nimbus/src/tests/stateful/test_enrollment.rs
@@ -5,6 +5,7 @@
 // Older tests that also use the DB.
 // XXX: make them less complicated (since the transitions are covered in crate::tests::test_enrollment), just see if we write to the DB properly.
 
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use uuid::Uuid;
@@ -43,7 +44,7 @@ fn test_enrollments() -> Result<()> {
     let db = Database::new(&tmp_dir, TestMetrics::new())?;
     let mut writer = db.write()?;
     let exp1 = get_test_experiments()[0].clone();
-    let nimbus_id = Uuid::new_v4();
+    let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
     let aru = AvailableRandomizationUnits::with_nimbus_id(&nimbus_id);
     let mut targeting_attributes = AppContext {
         app_name: "fenix".to_string(),
@@ -69,15 +70,16 @@ fn test_enrollments() -> Result<()> {
     );
     assert!(enrollment.branch_slug == "control" || enrollment.branch_slug == "treatment");
     // Ensure the event was created too.
-    assert_eq!(events.len(), 1);
-    let event = &events[0];
-    assert_eq!(event.experiment_slug, "secure-gold");
-    assert!(event.branch_slug == "control" || event.branch_slug == "treatment");
-    assert!(matches!(
-        event.change,
-        EnrollmentChangeEventType::Enrollment
-    ));
-
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()],
+        }]
+    );
     // Get the ExperimentEnrollment from the DB.
     let ee: ExperimentEnrollment = db
         .get_store(StoreId::Enrollments)
@@ -92,7 +94,7 @@ fn test_enrollments() -> Result<()> {
     ));
 
     // Now opt-out.
-    opt_out(&db, &mut writer, "secure-gold", None)?;
+    let events = opt_out(&db, &mut writer, "secure-gold", None)?;
     assert_eq!(get_enrollments(&db, &writer)?.len(), 0);
     // check we recorded the "why" correctly.
     let ee: ExperimentEnrollment = db
@@ -107,13 +109,35 @@ fn test_enrollments() -> Result<()> {
         }
     ));
 
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: Some("optout".into()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some_control".into()],
+        },]
+    );
+
     // Opt in to a specific branch.
-    opt_in_with_branch(&db, &mut writer, "secure-gold", "treatment")?;
+    let events = opt_in_with_branch(&db, &mut writer, "secure-gold", "treatment")?;
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 1);
     let enrollment = &enrollments[0];
     assert_eq!(enrollment.slug, "secure-gold");
-    assert!(enrollment.branch_slug == "treatment");
+    assert_eq!(enrollment.branch_slug, "treatment");
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()],
+        },]
+    );
 
     writer.commit()?;
     Ok(())
@@ -125,7 +149,7 @@ fn test_updates() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let db = Database::new(&tmp_dir, TestMetrics::new())?;
     let mut writer = db.write()?;
-    let nimbus_id = Uuid::new_v4();
+    let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
     let aru = AvailableRandomizationUnits::with_nimbus_id(&nimbus_id);
     let mut th = NimbusTargetingHelper::from(AppContext {
         app_name: "fenix".to_string(),
@@ -143,7 +167,26 @@ fn test_updates() -> Result<()> {
 
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 2);
-    assert_eq!(events.len(), 2);
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()]
+            }
+        ]
+    );
 
     // pretend we just updated from the server and one of the 2 is missing.
     let exps = &[exps[1].clone()];
@@ -154,13 +197,16 @@ fn test_updates() -> Result<()> {
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 1);
     // Check that the un-enrolled event was emitted.
-    assert_eq!(events.len(), 1);
-    let event = &events[0];
-    assert_eq!(event.experiment_slug, "secure-gold");
-    assert!(matches!(
-        event.change,
-        EnrollmentChangeEventType::Unenrollment
-    ));
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Unenrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
 
     writer.commit()?;
     Ok(())
@@ -172,7 +218,7 @@ fn test_global_opt_out() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let db = Database::new(&tmp_dir, TestMetrics::new())?;
     let mut writer = db.write()?;
-    let nimbus_id = Uuid::new_v4();
+    let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
     let mut th = NimbusTargetingHelper::from(AppContext {
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
@@ -193,7 +239,7 @@ fn test_global_opt_out() -> Result<()> {
 
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 0);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     // We should see the experiment non-enrollments.
     assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
     let num_not_enrolled_enrollments = get_experiment_enrollments(&db, &writer)?
@@ -218,7 +264,25 @@ fn test_global_opt_out() -> Result<()> {
 
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 2);
-    assert_eq!(events.len(), 2);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()]
+            }
+        ]
+    );
     // We should see 2 experiment enrollments.
     assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
     let num_enrolled_enrollments = get_experiment_enrollments(&db, &writer)?
@@ -236,7 +300,25 @@ fn test_global_opt_out() -> Result<()> {
 
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 0);
-    assert_eq!(events.len(), 2);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: Some("optout".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "treatment".into(),
+                reason: Some("optout".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["about_welcome".into()]
+            }
+        ]
+    );
     // We should see 2 experiment enrolments, this time they're both opt outs
     assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
 
@@ -264,7 +346,7 @@ fn test_global_opt_out() -> Result<()> {
 
     let enrollments = get_enrollments(&db, &writer)?;
     assert_eq!(enrollments.len(), 0);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
 
     assert_eq!(
         get_experiment_enrollments(&db, &writer)?
@@ -376,9 +458,11 @@ fn test_telemetry_reset() -> Result<()> {
         reason: Some(reason),
         experiment_slug,
         branch_slug,
+        feature_ids,
     } if reason == "optout"
         && *experiment_slug == mock_exp1_slug
         && *branch_slug == mock_exp1_branch
+        && feature_ids.is_empty()
     ));
 
     Ok(())
@@ -390,7 +474,7 @@ fn test_experiments_opt_out_with_rollouts_opt_in() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let db = Database::new(&tmp_dir, TestMetrics::new())?;
     let mut writer = db.write()?;
-    let nimbus_id = Uuid::new_v4();
+    let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
     let mut th = NimbusTargetingHelper::from(AppContext {
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
@@ -421,7 +505,8 @@ fn test_experiments_opt_out_with_rollouts_opt_in() -> Result<()> {
 
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
-    let _ = evolver.evolve_enrollments_in_db(&db, &mut writer, &[experiment, rollout], None)?;
+    let events =
+        evolver.evolve_enrollments_in_db(&db, &mut writer, &[experiment, rollout], None)?;
 
     let enrollments = get_experiment_enrollments(&db, &writer)?;
     println!("Total enrollments: {}", enrollments.len());
@@ -431,6 +516,17 @@ fn test_experiments_opt_out_with_rollouts_opt_in() -> Result<()> {
             enrollment.slug, enrollment.status
         );
     }
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "test-rollout".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
 
     // Should be enrolled in rollout but not experiment
     let rollout_enrollment = enrollments.iter().find(|e| e.slug == "test-rollout");
@@ -466,7 +562,7 @@ fn test_rollouts_opt_out_with_experiments_opt_in() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let db = Database::new(&tmp_dir, TestMetrics::new())?;
     let mut writer = db.write()?;
-    let nimbus_id = Uuid::new_v4();
+    let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
     let mut th = NimbusTargetingHelper::from(AppContext {
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
@@ -497,7 +593,7 @@ fn test_rollouts_opt_out_with_experiments_opt_in() -> Result<()> {
 
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
-    let _events =
+    let events =
         evolver.evolve_enrollments_in_db(&db, &mut writer, &[experiment, rollout], None)?;
 
     // Use the same helper function as the working test
@@ -509,6 +605,17 @@ fn test_rollouts_opt_out_with_experiments_opt_in() -> Result<()> {
             enrollment.slug, enrollment.status
         );
     }
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "test-experiment".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
 
     // Should be enrolled in experiment but not rollout
     let experiment_enrollment = enrollments.iter().find(|e| e.slug == "test-experiment");

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -12,12 +12,13 @@ use tempfile::TempDir;
 use uuid::Uuid;
 
 use crate::enrollment::{
-    DisqualifiedReason, EnrolledReason, EnrollmentStatus, ExperimentEnrollment,
-    PreviousGeckoPrefState,
+    DisqualifiedReason, EnrolledReason, EnrollmentChangeEvent, EnrollmentChangeEventType,
+    EnrollmentStatus, ExperimentEnrollment, PreviousGeckoPrefState,
 };
 use crate::error::{Result, info};
 use crate::json::PrefValue;
 use crate::metrics::MalformedFeatureConfigExtraDef;
+use crate::schema::{Branch, FeatureConfig};
 use crate::stateful::behavior::{
     EventStore, Interval, IntervalConfig, IntervalData, MultiIntervalCounter, SingleIntervalCounter,
 };
@@ -29,8 +30,10 @@ use crate::stateful::persistence::{Database, StoreId};
 use crate::stateful::targeting::RecordedContext;
 use crate::tests::helpers::{
     TestGeckoPrefHandler, TestMetrics, TestRecordedContext, get_bucketed_rollout,
-    get_ios_rollout_experiment, get_multi_feature_experiment, get_single_feature_experiment,
-    get_single_feature_rollout, get_targeted_experiment, to_local_experiments_string,
+    get_bucketed_rollout_with_feature, get_ios_rollout_experiment, get_multi_feature_experiment,
+    get_single_feature_experiment, get_single_feature_rollout, get_targeted_experiment,
+    get_targeted_experiment_with_feature, sorted_enrollment_change_events,
+    to_local_experiments_string,
 };
 use crate::{
     AppContext, DB_KEY_APP_VERSION, DB_KEY_UPDATE_DATE, Experiment, NimbusClient,
@@ -82,6 +85,16 @@ fn test_telemetry_reset() -> Result<()> {
         &mock_exp_slug,
         &Experiment {
             slug: mock_exp_slug.clone(),
+            branches: vec![Branch {
+                slug: "control".into(),
+                ratio: 1,
+                features: Some(vec![FeatureConfig {
+                    feature_id: "foo".into(),
+                    value: serde_json::Map::new(),
+                }]),
+                feature: None,
+            }],
+            feature_ids: vec!["foo".into()],
             ..Experiment::default()
         },
     )?;
@@ -106,6 +119,16 @@ fn test_telemetry_reset() -> Result<()> {
     assert_eq!(get_aru_nimbus_id().unwrap(), orig_nimbus_id.to_string());
 
     let events = client.reset_telemetry_identifiers()?;
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "exp-1".into(),
+            branch_slug: "branch-1".into(),
+            reason: Some("optout".into()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["foo".into()],
+        },]
+    );
 
     // We should have reset our nimbus_id.
     let new_nimbus_id = client.nimbus_id()?;
@@ -118,9 +141,6 @@ fn test_telemetry_reset() -> Result<()> {
 
     // We should have been disqualified from the enrolled experiment.
     assert_eq!(client.get_experiment_branch(mock_exp_slug)?, None);
-
-    // We should have returned a single event.
-    assert_eq!(events.len(), 1);
 
     Ok(())
 }
@@ -899,7 +919,6 @@ fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -
     Ok(())
 }
 
-#[cfg(feature = "stateful")]
 #[test]
 fn test_ios_rollout() -> Result<()> {
     let ctx = AppContext {
@@ -1063,11 +1082,11 @@ fn test_previous_enrollments_in_targeting() -> Result<()> {
     client.initialize()?;
 
     // Apply an initial experiment
-    let exp_1 = get_targeted_experiment(slug_1, "true");
-    let exp_2 = get_targeted_experiment(slug_2, "true");
-    let exp_3 = get_targeted_experiment(slug_3, "true");
-    let exp_4 = get_targeted_experiment(slug_4, "true");
-    let ro_1 = get_bucketed_rollout(slug_5, 10_000);
+    let exp_1 = get_targeted_experiment_with_feature(slug_1, "true", "feature-1");
+    let exp_2 = get_targeted_experiment_with_feature(slug_2, "true", "feature-2");
+    let exp_3 = get_targeted_experiment_with_feature(slug_3, "true", "feature-3");
+    let exp_4 = get_targeted_experiment_with_feature(slug_4, "true", "feature-4");
+    let ro_1 = get_bucketed_rollout_with_feature(slug_5, 10_000, "feature-5");
     client.set_experiments_locally(to_local_experiments_string(&[
         exp_1,
         exp_2,
@@ -1093,10 +1112,10 @@ fn test_previous_enrollments_in_targeting() -> Result<()> {
     assert!(targeting_helper.eval_jexl(format!("'{}' in enrollments", slug_5))?);
 
     // Apply empty first experiment, disqualifying second experiment, and decreased bucket rollout
-    let exp_2 = get_targeted_experiment(slug_2, "false");
-    let exp_3 = get_targeted_experiment(slug_3, "error_out");
-    let exp_4 = get_targeted_experiment(slug_4, "true");
-    let ro_1 = get_bucketed_rollout(slug_5, 0);
+    let exp_2 = get_targeted_experiment_with_feature(slug_2, "false", "feature-2");
+    let exp_3 = get_targeted_experiment_with_feature(slug_3, "error_out", "feature-3");
+    let exp_4 = get_targeted_experiment_with_feature(slug_4, "true", "feature-6");
+    let ro_1 = get_bucketed_rollout_with_feature(slug_5, 0, "feature-5");
     let experiment_json = serde_json::to_string(
         &json!({"data": [exp_2, exp_3, exp_4, serde_json::to_value(ro_1)?]}),
     )?;
@@ -1111,6 +1130,7 @@ fn test_previous_enrollments_in_targeting() -> Result<()> {
         .get_store(StoreId::Enrollments)
         .collect_all(&db.write()?)?;
     assert_eq!(enrollments.len(), 5);
+    println!("{:#?}", enrollments);
     assert!(matches!(
         enrollments.first().unwrap(),
         ExperimentEnrollment {
@@ -1204,8 +1224,8 @@ fn test_opt_out_multiple_experiments_same_feature_does_not_re_enroll() -> Result
     client.with_targeting_attributes(targeting_attributes);
     client.initialize()?;
 
-    let exp_1 = get_targeted_experiment(slug_1, "true");
-    let exp_2 = get_targeted_experiment(slug_2, "true");
+    let exp_1 = get_targeted_experiment_with_feature(slug_1, "true", "feature-1");
+    let exp_2 = get_targeted_experiment_with_feature(slug_2, "true", "feature-2");
     client.set_experiments_locally(to_local_experiments_string(&[exp_1, exp_2])?)?;
     client.apply_pending_experiments()?;
 
@@ -1233,9 +1253,9 @@ fn test_enrollment_status_metrics_recorded() -> Result<()> {
     let slug_1 = "experiment-1";
     let slug_2 = "experiment-2";
     let slug_3 = "rollout-1";
-    let exp_1 = get_targeted_experiment(slug_1, "true");
-    let exp_2 = get_targeted_experiment(slug_2, "true");
-    let ro_1 = get_bucketed_rollout(slug_3, 10_000);
+    let exp_1 = get_targeted_experiment_with_feature(slug_1, "true", "feature-1");
+    let exp_2 = get_targeted_experiment_with_feature(slug_2, "true", "feature-2");
+    let ro_1 = get_bucketed_rollout_with_feature(slug_3, 10_000, "feature-1");
 
     let metrics = TestMetrics::new();
     let client = with_metrics(metrics.clone(), "coenrolling-feature")?;
@@ -1620,12 +1640,21 @@ fn test_new_enrollment_in_targeting_mid_run() -> Result<()> {
     let slug_4 = "test-4";
 
     // Apply an initial experiment
-    let exp_1 = get_targeted_experiment(slug_1, "true");
-    let exp_2 = get_targeted_experiment(slug_2, &format!("'{}' in active_experiments", slug_1));
-    let exp_3 = get_targeted_experiment(slug_3, &format!("'{}' in enrollments", slug_1));
-    let exp_4 = get_targeted_experiment(
+    let exp_1 = get_targeted_experiment_with_feature(slug_1, "true", "feature-1");
+    let exp_2 = get_targeted_experiment_with_feature(
+        slug_2,
+        &format!("'{}' in active_experiments", slug_1),
+        "feature-2",
+    );
+    let exp_3 = get_targeted_experiment_with_feature(
+        slug_3,
+        &format!("'{}' in enrollments", slug_1),
+        "feature-3",
+    );
+    let exp_4 = get_targeted_experiment_with_feature(
         slug_4,
         &format!("enrollments_map['{}'] == 'treatment'", slug_1),
+        "feature-4",
     );
     client.set_experiments_locally(to_local_experiments_string(&[exp_1, exp_2, exp_3, exp_4])?)?;
     client.apply_pending_experiments()?;
@@ -1636,7 +1665,6 @@ fn test_new_enrollment_in_targeting_mid_run() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "stateful")]
 #[test]
 fn test_recorded_context_recorded() -> Result<()> {
     let temp_dir = tempfile::tempdir()?;
@@ -1903,9 +1931,28 @@ fn test_gecko_pref_unenrollment() -> Result<()> {
     let unenroll_events =
         client.unenroll_for_gecko_pref(pref_state, PrefUnenrollReason::FailedToSet)?;
 
+    assert_eq!(
+        &sorted_enrollment_change_events(unenroll_events),
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "exp-1".into(),
+                branch_slug: "control".into(),
+                reason: Some("pref_failed_to_set".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["test_feature".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "rollout-1".into(),
+                branch_slug: "control".into(),
+                reason: Some("pref_failed_to_set".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["test_feature".into()],
+            },
+        ]
+    );
+
     let active_experiments = client.get_active_experiments()?;
     assert_eq!(active_experiments.len(), 0);
-    assert_eq!(2, unenroll_events.len());
 
     {
         let handler = client.get_gecko_pref_store();
@@ -2035,9 +2082,28 @@ fn test_gecko_pref_unenrollment_reverts() -> Result<()> {
     let unenroll_events =
         client.unenroll_for_gecko_pref(pref_state_1, PrefUnenrollReason::Changed)?;
 
+    assert_eq!(
+        &sorted_enrollment_change_events(unenroll_events),
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "exp-1".into(),
+                branch_slug: "control".into(),
+                reason: Some("pref_changed".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["test_feature".into(), "test_feature_2".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "rollout-1".into(),
+                branch_slug: "control".into(),
+                reason: Some("pref_changed".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["test_feature".into(), "test_feature_2".into()],
+            }
+        ]
+    );
+
     let active_experiments = client.get_active_experiments()?;
     assert_eq!(active_experiments.len(), 0);
-    assert_eq!(2, unenroll_events.len());
 
     {
         let handler = client.get_gecko_pref_store();
@@ -2353,5 +2419,107 @@ fn test_add_prev_gecko_pref_states_for_experiment() -> Result<()> {
         .unwrap();
 
     assert_eq!(reader_result, original_prev_gecko_pref_states.clone());
+    Ok(())
+}
+
+#[test]
+fn test_opt_out_events() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let app_context = AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    };
+
+    let metrics = TestMetrics::new();
+    let mut client = NimbusClient::new(
+        app_context.clone(),
+        Default::default(),
+        Default::default(),
+        temp_dir.path(),
+        metrics.clone(),
+        None,
+        None,
+    )?;
+    client.with_targeting_attributes(TargetingAttributes {
+        app_context,
+        ..Default::default()
+    });
+    client.set_nimbus_id(&Uuid::from_str("00000000-0000-0000-0000-000000000004")?)?;
+    client.initialize()?;
+
+    let slug = "slug";
+    let experiment = get_targeted_experiment(slug, "true");
+    client.set_experiments_locally(to_local_experiments_string(&[experiment])?)?;
+
+    client.apply_pending_experiments()?;
+    assert_eq!(client.get_active_experiments()?.len(), 1);
+
+    let events = client.opt_out(slug.into())?;
+    assert_eq!(client.get_active_experiments()?.len(), 0);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: slug.into(),
+            branch_slug: "control".into(),
+            reason: Some("optout".into()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some-feature-1".into()],
+        },]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_opt_in_with_branch_events() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let app_context = AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    };
+
+    let metrics = TestMetrics::new();
+    let mut client = NimbusClient::new(
+        app_context.clone(),
+        Default::default(),
+        Default::default(),
+        temp_dir.path(),
+        metrics.clone(),
+        None,
+        None,
+    )?;
+    client.with_targeting_attributes(TargetingAttributes {
+        app_context,
+        ..Default::default()
+    });
+    client.set_nimbus_id(&Uuid::from_str("00000000-0000-0000-0000-000000000004")?)?;
+    client.initialize()?;
+
+    let slug = "slug";
+    let experiment = get_targeted_experiment(slug, "false");
+    client.set_experiments_locally(to_local_experiments_string(&[experiment])?)?;
+
+    client.apply_pending_experiments()?;
+    assert_eq!(client.get_active_experiments()?.len(), 0);
+
+    let events = client.opt_in_with_branch(slug.into(), "control".into())?;
+    assert_eq!(client.get_active_experiments()?.len(), 1);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: slug.into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some-feature-1".into()],
+        },]
+    );
+
     Ok(())
 }

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::defaults::Defaults;
 use crate::enrollment::*;
-use crate::error::{Result, debug};
+use crate::error::Result;
 #[cfg(feature = "stateful")]
 use crate::stateful::gecko_prefs::{
     GeckoPrefHandler, GeckoPrefState, GeckoPrefStore, OriginalGeckoPref, PrefBranch,
@@ -451,6 +451,16 @@ fn test_ios_rollout_experiment() -> Result<()> {
         enrollment.status,
         EnrollmentStatus::Enrolled { .. }
     ));
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "ios-coordinators-rollout".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["coordinators-refactor-feature".into()],
+        }],
+    );
     Ok(())
 }
 
@@ -477,9 +487,16 @@ fn test_evolver_new_experiment_enrolled() -> Result<()> {
         enrollment.status,
         EnrollmentStatus::Enrolled { .. }
     ));
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].change, EnrollmentChangeEventType::Enrollment);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()],
+        },],
+    );
     Ok(())
 }
 
@@ -509,7 +526,7 @@ fn test_evolver_new_experiment_not_enrolled() -> Result<()> {
             reason: NotEnrolledReason::NotSelected
         }
     ));
-    assert!(events.is_empty());
+    assert_eq!(&events, &[], "no change in enrollments (not bucketed)");
     Ok(())
 }
 
@@ -538,7 +555,11 @@ fn test_evolver_new_experiment_globally_opted_out() -> Result<()> {
             reason: NotEnrolledReason::OptOut
         }
     ));
-    assert!(events.is_empty());
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (no previous enrollment, opted out)"
+    );
     Ok(())
 }
 
@@ -568,7 +589,7 @@ fn test_evolver_new_experiment_enrollment_paused() -> Result<()> {
             reason: NotEnrolledReason::EnrollmentsPaused
         }
     ));
-    assert!(events.is_empty());
+    assert_eq!(&events, &[], "no change in enrollments (paused)");
     Ok(())
 }
 
@@ -598,7 +619,11 @@ fn test_evolver_experiment_update_not_enrolled_opted_out() -> Result<()> {
         )?
         .unwrap();
     assert_eq!(enrollment.status, existing_enrollment.status);
-    assert!(events.is_empty());
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (previous unenrolled (optout) enrollment, opted out)"
+    );
     Ok(())
 }
 
@@ -629,7 +654,11 @@ fn test_evolver_experiment_update_not_enrolled_enrollment_paused() -> Result<()>
         )?
         .unwrap();
     assert_eq!(enrollment.status, existing_enrollment.status);
-    assert!(events.is_empty());
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (existing enrollment, paused)"
+    );
     Ok(())
 }
 
@@ -642,6 +671,9 @@ fn test_evolver_experiment_update_not_enrolled_resuming_not_selected() -> Result
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
+
+    // TODO(bug 2044504): This test implies the existence of a enrollment paused ->
+    // enrollment unpaused workflow, which does not exist in practice.
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
         status: EnrollmentStatus::NotEnrolled {
@@ -665,7 +697,7 @@ fn test_evolver_experiment_update_not_enrolled_resuming_not_selected() -> Result
             reason: NotEnrolledReason::NotSelected
         }
     ));
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -701,9 +733,17 @@ fn test_evolver_experiment_update_not_enrolled_resuming_selected() -> Result<()>
             ..
         }
     ));
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].change, EnrollmentChangeEventType::Enrollment);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: exp.slug.clone(),
+            branch_slug: exp.branches[1].slug.clone(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()],
+        }]
+    );
+
     Ok(())
 }
 
@@ -742,13 +782,15 @@ fn test_evolver_experiment_update_enrolled_then_opted_out() -> Result<()> {
             ..
         }
     ));
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].branch_slug, "control");
-    assert_eq!(events[0].reason, Some("optout".to_owned()));
     assert_eq!(
-        events[0].change,
-        EnrollmentChangeEventType::Disqualification
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: exp.slug.clone(),
+            branch_slug: "control".into(),
+            reason: Some("optout".to_owned()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some_control".into()],
+        }]
     );
     Ok(())
 }
@@ -795,7 +837,11 @@ fn test_evolver_experiment_update_enrolled_then_experiment_paused() -> Result<()
     } else {
         panic!("Wrong variant!");
     }
-    assert!(events.is_empty());
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (existing enrollment became paused)"
+    );
     Ok(())
 }
 
@@ -839,13 +885,15 @@ fn test_evolver_experiment_update_enrolled_then_targeting_changed() -> Result<()
     } else {
         panic!("Wrong variant! \n{:#?}", enrollment.status);
     }
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].branch_slug, "control");
-    assert_eq!(events[0].reason, Some("targeting".to_owned()));
     assert_eq!(
-        events[0].change,
-        EnrollmentChangeEventType::Disqualification
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: exp.slug.clone(),
+            branch_slug: "control".into(),
+            reason: Some("targeting".to_owned()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some_control".into()],
+        }]
     );
     Ok(())
 }
@@ -888,7 +936,16 @@ fn test_evolver_experiment_update_enrolled_then_bucketing_changed() -> Result<()
             ..
         }
     ));
-    assert_eq!(1, events.len());
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: exp.slug.clone(),
+            branch_slug: "control".into(),
+            reason: Some("bucketing".to_owned()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["a-feature".into()],
+        }]
+    );
     Ok(())
 }
 
@@ -977,7 +1034,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let ro = get_bucketed_rollout(slug, 0);
     let recipes = [ro];
 
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &[],
         &recipes,
@@ -991,12 +1048,14 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::NotEnrolled { .. }));
 
+    assert_eq!(&events, &[]);
+
     // Up to 100%
     let prev_recipes = recipes;
     let ro = get_bucketed_rollout(slug, 10_000);
     let recipes = [ro];
 
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &prev_recipes,
         &recipes,
@@ -1009,12 +1068,23 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::Enrolled { .. }));
 
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "my-rollout".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["a-feature".into()],
+        }]
+    );
+
     // Back to zero again
     let prev_recipes = recipes;
     let ro = get_bucketed_rollout(slug, 0);
     let recipes = [ro];
 
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &prev_recipes,
         &recipes,
@@ -1033,12 +1103,23 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
         }
     ));
 
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "my-rollout".into(),
+            branch_slug: "control".into(),
+            reason: Some("bucketing".into()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["a-feature".into()],
+        }]
+    );
+
     // Back up to 100%
     let prev_recipes = recipes;
     let ro = get_bucketed_rollout(slug, 10_000);
     let recipes = [ro];
 
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &prev_recipes,
         &recipes,
@@ -1050,6 +1131,17 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::Enrolled { .. }));
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "my-rollout".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["a-feature".into()],
+        }]
+    );
 
     Ok(())
 }
@@ -1071,7 +1163,7 @@ fn test_experiment_does_not_reenroll_from_disqualified_not_selected_or_not_targe
         get_single_feature_experiment(slug_2, "feature_2", Value::Object(Default::default()));
     let recipes = [exp_1, exp_2];
 
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &recipes,
         &recipes,
@@ -1104,6 +1196,8 @@ fn test_experiment_does_not_reenroll_from_disqualified_not_selected_or_not_targe
     let enr = enrollments.get(1).unwrap();
     assert_eq!(&enr.slug, slug_2);
     assert!(matches!(&enr.status, EnrollmentStatus::Disqualified { .. }));
+
+    assert_eq!(&events, &[]);
 
     Ok(())
 }
@@ -1151,19 +1245,16 @@ fn test_evolver_experiment_update_enrolled_then_branches_changed() -> Result<()>
         )?
         .unwrap();
     assert_eq!(enrollment, existing_enrollment);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
 #[test]
 fn test_evolver_experiment_update_enrolled_then_branch_disappears() -> Result<()> {
     let mut exp = get_test_experiments()[0].clone();
-    exp.branches = vec![Branch {
-        slug: "bobo-branch".to_owned(),
-        ratio: 1,
-        feature: None,
-        features: None,
-    }];
+    exp.branches[0].slug = "bobo-branch".into();
+    exp.branches.remove(1);
+
     let (_, app_ctx, aru) = local_ctx();
     let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
@@ -1196,13 +1287,16 @@ fn test_evolver_experiment_update_enrolled_then_branch_disappears() -> Result<()
             ..
         }
     ));
-    assert_eq!(events.len(), 1);
     assert_eq!(
-        events[0].change,
-        EnrollmentChangeEventType::Disqualification
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "control".into(),
+            reason: Some("error".into()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some_control".into()],
+        }]
     );
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].branch_slug, "control");
     Ok(())
 }
 
@@ -1239,7 +1333,7 @@ fn test_evolver_experiment_update_disqualified_then_opted_out() -> Result<()> {
             ..
         }
     ));
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -1270,7 +1364,7 @@ fn test_evolver_experiment_update_disqualified_then_bucketing_ok() -> Result<()>
         )?
         .unwrap();
     assert_eq!(enrollment, existing_enrollment);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -1286,7 +1380,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_experiments: Vec<Experiment> = vec![];
     let existing_enrollments: Vec<ExperimentEnrollment> = vec![];
     let updated_experiments = get_feature_conflict_test_experiments();
-    let (enrollments, _events) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &existing_experiments,
         &updated_experiments,
@@ -1296,6 +1390,25 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     )?;
 
     assert_eq!(2, enrollments.len());
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["about_welcome".into()],
+            },
+        ]
+    );
 
     let enrolled: Vec<ExperimentEnrollment> = enrollments
         .clone()
@@ -1328,7 +1441,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_experiments: Vec<Experiment> = updated_experiments;
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments = get_feature_conflict_test_experiments();
-    let (enrollments, _events) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &existing_experiments,
         &updated_experiments,
@@ -1336,6 +1449,16 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
         #[cfg(feature = "stateful")]
         None,
     )?;
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-silver".into(),
+            branch_slug: "N/A".into(),
+            reason: Some("feature-conflict".into()),
+            change: EnrollmentChangeEventType::EnrollFailed,
+            feature_ids: vec!["about_welcome".into()],
+        },]
+    );
 
     assert_eq!(2, enrollments.len());
 
@@ -1357,7 +1480,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_experiments: Vec<Experiment> = updated_experiments;
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments = get_feature_conflict_test_experiments();
-    let (enrollments, _events) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &existing_experiments,
         &updated_experiments,
@@ -1365,6 +1488,17 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
         #[cfg(feature = "stateful")]
         None,
     )?;
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-silver".into(),
+            branch_slug: "N/A".into(),
+            reason: Some("feature-conflict".into()),
+            change: EnrollmentChangeEventType::EnrollFailed,
+            feature_ids: vec!["about_welcome".into()],
+        }]
+    );
 
     assert_eq!(2, enrollments.len());
 
@@ -1382,7 +1516,7 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let existing_experiments: Vec<Experiment> = updated_experiments;
     let existing_enrollments: Vec<ExperimentEnrollment> = enrollments;
     let updated_experiments: Vec<Experiment> = vec![];
-    let (enrollments, _events) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &existing_experiments,
         &updated_experiments,
@@ -1390,6 +1524,17 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
         #[cfg(feature = "stateful")]
         None,
     )?;
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Unenrollment,
+            feature_ids: vec!["about_welcome".into()],
+        }]
+    );
 
     // There should be one WasEnrolled; the NotEnrolled will have been
     // discarded.
@@ -1487,21 +1632,31 @@ fn test_evolver_experiment_not_enrolled_feature_conflict() -> Result<()> {
         "exactly two enrollments should have Enrolled status"
     );
 
-    debug!("events: {:?}", events);
-
     assert_eq!(
-        3,
-        events.len(),
-        "There should be exactly 3 enrollment_change_events (Enroll/Enroll/EnrollFailed)"
-    );
-
-    let enrolled_events = events
-        .iter()
-        .filter(|&e| matches!(e.change, EnrollmentChangeEventType::Enrollment))
-        .count();
-    assert_eq!(
-        2, enrolled_events,
-        "exactly two events should have Enrolled event types"
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "another-monkey".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["some_control".into()],
+            },
+        ]
     );
 
     Ok(())
@@ -1536,19 +1691,32 @@ fn test_multi_feature_per_branch_conflict() -> Result<()> {
     );
 
     assert_eq!(
-        3,
-        events.len(),
-        "There should be exactly 3 enrollment_change_events (Enroll/Enroll/EnrollFailed)"
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "multi-feature-experiment".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["about_welcome".into(), "newtab".into(), "onboarding".into()],
+            },
+        ]
     );
 
-    let enrolled_events = events
-        .iter()
-        .filter(|&e| matches!(e.change, EnrollmentChangeEventType::Enrollment))
-        .count();
-    assert_eq!(
-        2, enrolled_events,
-        "exactly two events should have Enrolled event types"
-    );
     Ok(())
 }
 
@@ -1561,7 +1729,7 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
     let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &[],
         &test_experiments,
@@ -1579,6 +1747,26 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
         "exactly two enrollments should have Enrolled status"
     );
 
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()],
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()],
+            }
+        ]
+    );
+
     let conflicting_experiment = get_conflicting_experiment();
     let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
@@ -1589,20 +1777,29 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
         None,
     )?;
 
-    debug!("events = {:?}", events);
-
-    assert_eq!(events.len(), 2);
-
-    // we didn't include test_experiments[1] in next_experiments above,
-    // so it should have been unenrolled...
-    assert_eq!(events[0].experiment_slug, test_experiments[0].slug);
-    assert_eq!(events[0].change, EnrollmentChangeEventType::Unenrollment);
-
-    // ...which will have gotten rid of the thing that otherwise would have
-    // conflicted with conflicting_experiment, allowing it to have now
-    // been enrolled.
-    assert_eq!(events[1].experiment_slug, conflicting_experiment.slug);
-    assert_eq!(events[1].change, EnrollmentChangeEventType::Enrollment);
+    // we didn't include test_experiments[1] in next_experiments above, so it
+    // should have been unenrolled which will have gotten rid of the thing that
+    // otherwise would have conflicted with conflicting_experiment, allowing it
+    // to have now been enrolled.
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "another-monkey".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()]
+            }
+        ]
+    );
 
     let enrolled_count = enrollments
         .iter()
@@ -1632,7 +1829,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     // 1. we have two experiments that use one feature each. There's no conflicts.
     let next_experiments = vec![aboutwelcome_experiment.clone(), newtab_experiment.clone()];
 
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &[],
         &next_experiments,
@@ -1640,6 +1837,26 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         #[cfg(feature = "stateful")]
         None,
     )?;
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "about_welcome-feature-experiment".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "newtab-feature-experiment".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["newtab".into()]
+            }
+        ]
+    );
 
     let feature_map =
         map_features_by_feature_id(&enrollments, &next_experiments, &no_coenrolling_features());
@@ -1686,9 +1903,14 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     )?;
 
     assert_eq!(
-        events.len(),
-        1,
-        "A single EnrollFailed recorded due to the feature-conflict"
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "mixed-feature-experiment".into(),
+            branch_slug: "N/A".into(),
+            reason: Some("feature-conflict".into()),
+            change: EnrollmentChangeEventType::EnrollFailed,
+            feature_ids: vec!["about_welcome".into(), "newtab".into()]
+        }]
     );
 
     let feature_map =
@@ -1756,7 +1978,7 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let prev_enrollments = enrollments;
     let prev_experiments = next_experiments;
     let next_experiments = vec![mixed_experiment.clone()];
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &prev_experiments,
         &next_experiments,
@@ -1789,12 +2011,32 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
             .collect::<HashSet<_>>()
     );
 
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "newtab-feature-experiment".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["newtab".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "mixed-feature-experiment".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into(), "newtab".into()]
+            }
+        ]
+    );
+
     // 4. Starting from an empty enrollments, enroll a multi-feature and then add the single feature ones back in again, which won't be able to enroll.
     // 4a. The multi feature experiment.
     let prev_enrollments = vec![];
     let prev_experiments = vec![];
     let next_experiments = vec![mixed_experiment.clone()];
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &prev_experiments,
         &next_experiments,
@@ -1802,6 +2044,17 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         #[cfg(feature = "stateful")]
         None,
     )?;
+
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "mixed-feature-experiment".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["about_welcome".into(), "newtab".into()]
+        }]
+    );
 
     // 4b. Add the single feature experiments.
     let prev_enrollments = enrollments;
@@ -1820,11 +2073,6 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         None,
     )?;
 
-    assert_eq!(
-        events.len(),
-        2,
-        "Exactly two EnrollFailed events should be recorded"
-    );
     let feature_map =
         map_features_by_feature_id(&enrollments, &next_experiments, &no_coenrolling_features());
     assert_eq!(feature_map.len(), 2);
@@ -1847,6 +2095,26 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
             .iter()
             .map(|s| s.to_string())
             .collect::<HashSet<_>>()
+    );
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "about_welcome-feature-experiment".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["about_welcome".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "newtab-feature-experiment".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["newtab".into()]
+            }
+        ]
     );
 
     // 5. Add in experiment with conflicting features on the **same branch**
@@ -1863,11 +2131,6 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
         None,
     )?;
 
-    assert_eq!(
-        events.len(),
-        1,
-        "Exactly one EnrollFailed event should be recorded"
-    );
     let feature_map =
         map_features_by_feature_id(&enrollments, &next_experiments, &no_coenrolling_features());
     assert_eq!(feature_map.len(), 2);
@@ -1892,11 +2155,22 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
             .collect::<HashSet<_>>()
     );
 
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "multi-feature-experiment".into(),
+            branch_slug: "N/A".into(),
+            reason: Some("feature-conflict".into()),
+            change: EnrollmentChangeEventType::EnrollFailed,
+            feature_ids: vec!["about_welcome".into(), "newtab".into(), "onboarding".into()]
+        }]
+    );
+
     // 6. Now we remove the mixed experiment, and we should get enrolled
     let prev_enrollments = enrollments;
     let prev_experiments = next_experiments;
     let next_experiments = vec![multi_feature_experiment];
-    let (enrollments, _) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &prev_experiments,
         &next_experiments,
@@ -1934,6 +2208,26 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
             .collect::<HashSet<_>>()
     );
 
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "mixed-feature-experiment".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["about_welcome".into(), "newtab".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "multi-feature-experiment".into(),
+                branch_slug: "treatment".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into(), "newtab".into(), "onboarding".into()]
+            }
+        ]
+    );
+
     Ok(())
 }
 
@@ -1964,7 +2258,7 @@ fn test_evolver_experiment_update_was_enrolled() -> Result<()> {
         )?
         .unwrap();
     assert_eq!(enrollment, existing_enrollment);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -2176,7 +2470,7 @@ fn test_evolve_enrollments_with_coenrolling_features() -> Result<()> {
     let all_experiments = [exp1, exp2, exp3.clone(), exp4.clone()];
     let no_experiments: [Experiment; 0] = [];
 
-    let (enrollments, _) = evolver.evolve_enrollment_recipes(
+    let (enrollments, events) = evolver.evolve_enrollment_recipes(
         true,
         &no_experiments,
         &all_experiments,
@@ -2207,8 +2501,42 @@ fn test_evolve_enrollments_with_coenrolling_features() -> Result<()> {
     ]);
     assert_eq!(observed, expected);
 
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "exp1".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["colliding".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp2".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["coenrolling".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp3".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["coenrolling".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp4".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["colliding".into()]
+            }
+        ]
+    );
+
     let experiments = [exp3, exp4];
-    let (enrollments, _) = evolver.evolve_enrollment_recipes(
+    let (enrollments, events) = evolver.evolve_enrollment_recipes(
         true,
         &all_experiments,
         &experiments,
@@ -2237,6 +2565,34 @@ fn test_evolve_enrollments_with_coenrolling_features() -> Result<()> {
         ),
     ]);
     assert_eq!(observed, expected);
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "exp1".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["colliding".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp2".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["coenrolling".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp4".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["colliding".into()]
+            }
+        ]
+    );
+
     Ok(())
 }
 
@@ -2274,7 +2630,7 @@ fn test_evolve_enrollments_with_coenrolling_multi_features() -> Result<()> {
     let all_experiments = [exp1, exp2, exp3.clone(), exp4.clone()];
     let no_experiments: [Experiment; 0] = [];
 
-    let (enrollments, _) = evolver.evolve_enrollment_recipes(
+    let (enrollments, events) = evolver.evolve_enrollment_recipes(
         true,
         &no_experiments,
         &all_experiments,
@@ -2311,8 +2667,42 @@ fn test_evolve_enrollments_with_coenrolling_multi_features() -> Result<()> {
     ]);
     assert_eq!(observed, expected);
 
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "exp1".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["coenrolling".into(), "colliding".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp2".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["coenrolling".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp3".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["coenrolling".into(), "colliding".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp4".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["another".into(), "coenrolling".into()]
+            }
+        ]
+    );
+
     let experiments = [exp3, exp4];
-    let (enrollments, _) = evolver.evolve_enrollment_recipes(
+    let (enrollments, events) = evolver.evolve_enrollment_recipes(
         true,
         &all_experiments,
         &experiments,
@@ -2349,6 +2739,33 @@ fn test_evolve_enrollments_with_coenrolling_multi_features() -> Result<()> {
         ),
     ]);
     assert_eq!(observed, expected);
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "exp1".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["coenrolling".into(), "colliding".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp2".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Unenrollment,
+                feature_ids: vec!["coenrolling".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "exp3".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["coenrolling".into(), "colliding".into()]
+            }
+        ]
+    );
 
     Ok(())
 }
@@ -2469,11 +2886,7 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
         "no new enrollments should have been returned"
     );
 
-    assert_eq!(
-        events.len(),
-        0,
-        "no new enrollments should have been returned"
-    );
+    assert_eq!(&events, &[], "no new enrollments should have been returned");
 
     // Test that evolve_enrollments correctly handles the case where a
     // record with a previous enrollment gets dropped
@@ -2493,8 +2906,14 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
     );
 
     assert_eq!(
-        events.len(),
-        1,
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-silver".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["about_welcome".into()]
+        }],
         "only 1 of 2 enrollment events should have been returned, since one caused evolve_enrollment to err"
     );
 
@@ -2529,7 +2948,16 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
         "One enrollment should have been returned"
     );
 
-    assert_eq!(events.len(), 1, "One event should have been returned");
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "another-monkey".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
 
     // we change the app_id so the targeting will only target
     // against the `is_already_enrolled`
@@ -2555,8 +2983,8 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
     );
 
     assert_eq!(
-        events.len(),
-        0,
+        &events,
+        &[],
         "no new events should have been returned, the user was already enrolled"
     );
     Ok(())
@@ -2592,7 +3020,16 @@ fn test_evolver_experiment_update_error() -> Result<()> {
         enrollment.status,
         EnrollmentStatus::Enrolled { .. }
     ));
-    assert_eq!(events.len(), 1);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "treatment".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
     Ok(())
 }
 
@@ -2629,10 +3066,16 @@ fn test_evolver_experiment_ended_was_enrolled() -> Result<()> {
     } else {
         panic!("Wrong variant!");
     }
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].branch_slug, "control");
-    assert_eq!(events[0].change, EnrollmentChangeEventType::Unenrollment);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Unenrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
     Ok(())
 }
 
@@ -2667,10 +3110,16 @@ fn test_evolver_experiment_ended_was_disqualified() -> Result<()> {
     } else {
         panic!("Wrong variant!");
     }
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].experiment_slug, exp.slug);
-    assert_eq!(events[0].branch_slug, "control");
-    assert_eq!(events[0].change, EnrollmentChangeEventType::Unenrollment);
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Unenrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
     Ok(())
 }
 
@@ -2698,7 +3147,7 @@ fn test_evolver_experiment_ended_was_not_enrolled() -> Result<()> {
         None,
     )?;
     assert!(enrollment.is_none());
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -2726,7 +3175,7 @@ fn test_evolver_garbage_collection_before_threshold() -> Result<()> {
         None,
     )?;
     assert_eq!(enrollment.unwrap(), existing_enrollment);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -2754,7 +3203,7 @@ fn test_evolver_garbage_collection_after_threshold() -> Result<()> {
         None,
     )?;
     assert!(enrollment.is_none());
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
     Ok(())
 }
 
@@ -2772,16 +3221,18 @@ fn test_evolver_new_experiment_enrollment_already_exists() {
     let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
+    let mut events = vec![];
     let res = evolver.evolve_enrollment(
         true,
         None,
         Some(&exp),
         Some(&existing_enrollment),
-        &mut vec![],
+        &mut events,
         #[cfg(feature = "stateful")]
         None,
     );
     assert!(res.is_err());
+    assert_eq!(&events, &[]);
 }
 
 #[test]
@@ -2791,16 +3242,18 @@ fn test_evolver_existing_experiment_has_no_enrollment() {
     let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
+    let mut events = vec![];
     let res = evolver.evolve_enrollment(
         true,
         Some(&exp),
         Some(&exp),
         None,
-        &mut vec![],
+        &mut events,
         #[cfg(feature = "stateful")]
         None,
     );
     assert!(res.is_err());
+    assert_eq!(&events, &[]);
 }
 
 #[test]
@@ -2869,7 +3322,25 @@ fn test_evolver_rollouts_do_not_conflict_with_experiments() -> Result<()> {
         None,
     )?;
     assert_eq!(enrollments.len(), 2);
-    assert_eq!(events.len(), 2);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "rollout1".into(),
+                branch_slug: "".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["alice".into(), "bob".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "experiment1".into(),
+                branch_slug: "".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["alice".into(), "bob".into()]
+            }
+        ]
+    );
 
     assert_eq!(
         enrollments
@@ -2936,7 +3407,32 @@ fn test_evolver_rollouts_do_not_conflict_with_rollouts() -> Result<()> {
         None,
     )?;
     assert_eq!(enrollments.len(), 3);
-    assert_eq!(events.len(), 3);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "rollout1".into(),
+                branch_slug: "".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["alice".into(), "bob".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "rollout2".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["alice".into(), "bob".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "experiment1".into(),
+                branch_slug: "".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["alice".into(), "bob".into()]
+            }
+        ]
+    );
 
     let enrollments: Vec<ExperimentEnrollment> = enrollments
         .into_iter()
@@ -3163,7 +3659,7 @@ fn test_rollouts_end_to_end() -> Result<()> {
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
-    let (enrollments, _events) = evolver.evolve_enrollments(
+    let (enrollments, events) = evolver.evolve_enrollments(
         Participation::default(),
         &[],
         recipes,
@@ -3171,6 +3667,26 @@ fn test_rollouts_end_to_end() -> Result<()> {
         #[cfg(feature = "stateful")]
         None,
     )?;
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "rollout1".into(),
+                branch_slug: "rollout1".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["bob".into(), "charlie".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "experiment1".into(),
+                branch_slug: "experiment1".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["alice".into(), "bob".into()]
+            }
+        ]
+    );
 
     let features = map_features_by_feature_id(&enrollments, recipes, &no_coenrolling_features());
 
@@ -3193,11 +3709,16 @@ fn test_enrollment_explicit_opt_in() -> Result<()> {
             ..
         }
     ));
-    assert_eq!(events.len(), 1);
-    assert!(matches!(
-        events[0].change,
-        EnrollmentChangeEventType::Enrollment
-    ));
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
     Ok(())
 }
 
@@ -3214,7 +3735,7 @@ fn test_enrollment_enrolled_explicit_opt_out() {
     let exp = get_test_experiments()[0].clone();
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
-        slug: exp.slug,
+        slug: exp.slug.clone(),
         status: EnrollmentStatus::Enrolled {
             branch: "control".to_owned(),
             reason: EnrolledReason::Qualified,
@@ -3223,6 +3744,7 @@ fn test_enrollment_enrolled_explicit_opt_out() {
         },
     };
     let enrollment = existing_enrollment.on_explicit_opt_out(
+        Some(&exp),
         &mut events,
         #[cfg(feature = "stateful")]
         None,
@@ -3232,11 +3754,16 @@ fn test_enrollment_enrolled_explicit_opt_out() {
     } else {
         panic!("Wrong variant!");
     }
-    assert_eq!(events.len(), 1);
-    assert!(matches!(
-        events[0].change,
-        EnrollmentChangeEventType::Disqualification
-    ));
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "control".into(),
+            reason: Some("optout".into()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some_control".into()]
+        }]
+    );
 }
 
 #[test]
@@ -3244,12 +3771,13 @@ fn test_enrollment_not_enrolled_explicit_opt_out() {
     let exp = get_test_experiments()[0].clone();
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
-        slug: exp.slug,
+        slug: exp.slug.clone(),
         status: EnrollmentStatus::NotEnrolled {
             reason: NotEnrolledReason::NotTargeted,
         },
     };
     let enrollment = existing_enrollment.on_explicit_opt_out(
+        Some(&exp),
         &mut events,
         #[cfg(feature = "stateful")]
         None,
@@ -3261,7 +3789,7 @@ fn test_enrollment_not_enrolled_explicit_opt_out() {
             ..
         }
     ));
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
 }
 
 #[test]
@@ -3276,12 +3804,13 @@ fn test_enrollment_disqualified_explicit_opt_out() {
         },
     };
     let enrollment = existing_enrollment.on_explicit_opt_out(
+        None,
         &mut events,
         #[cfg(feature = "stateful")]
         None,
     );
     assert_eq!(enrollment, existing_enrollment);
-    assert!(events.is_empty());
+    assert_eq!(&events, &[]);
 }
 
 #[test]
@@ -3452,7 +3981,7 @@ fn test_evolve_enrollments_ordering() -> Result<()> {
     let all_experiments = [exp1, exp2];
     let no_experiments: [Experiment; 0] = [];
 
-    let (enrollments, _) = evolver.evolve_enrollment_recipes(
+    let (enrollments, events) = evolver.evolve_enrollment_recipes(
         true,
         &no_experiments,
         &all_experiments,
@@ -3472,6 +4001,26 @@ fn test_evolve_enrollments_ordering() -> Result<()> {
         ),
     )]);
     assert_eq!(observed, expected);
+
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "slug-2".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["colliding-feature".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "slug-1".into(),
+                branch_slug: "N/A".into(),
+                reason: Some("feature-conflict".into()),
+                change: EnrollmentChangeEventType::EnrollFailed,
+                feature_ids: vec!["colliding-feature".into()]
+            }
+        ]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Enrollment change events now include the feature IDs of the changed enrollments when possible. This will allow us to trigger update handlers in client applications.

Additionally, a bug was fixed where change events were not emitted when rollouts re-enrolled after previously unenrolling.

Some of these tests have been made more deterministic by using a fixed UUID for the Nimbus ID instead of a random UUID, resulting in enrolling in the same branches every test run.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
