### PR TITLE
Bug 2036453 - Lengthen timeout for symbol uploads

### DIFF
--- a/automation/symbols-generation/upload_symbols.py
+++ b/automation/symbols-generation/upload_symbols.py
@@ -35,7 +35,7 @@ def upload_symbols(zip_file, token_file):
         print("'faketoken` detected, not pushing anything", file=sys.stdout)
         sys.exit(0)
 
-    for i, _ in enumerate(redo.retrier(attempts=MAX_RETRIES), start=1):
+    for i, _ in enumerate(redo.retrier(attempts=MAX_RETRIES, sleeptime=60, sleepscale=1), start=1):
         print("Attempt %d of %d..." % (i, MAX_RETRIES))
         try:
             if zip_file.startswith("http"):
@@ -47,9 +47,8 @@ def upload_symbols(zip_file, token_file):
                 headers={"Auth-Token": auth_token},
                 allow_redirects=False,
                 # Allow a longer read timeout because uploading by URL means the server
-                # has to fetch the entire zip file, which can take a while. The load balancer
-                # in front of symbols.mozilla.org has a 300 second timeout, so we'll use that.
-                timeout=(10, 300),
+                # has to fetch the entire zip file, which can take a while.
+                timeout=(300, 600),
                 **zip_arg,
             )
             # 500 is likely to be a transient failure.


### PR DESCRIPTION
Backporting https://phabricator.services.mozilla.com/D299371 so that it doesn't get overridden by the next vendor.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
