### PR TITLE
Cached profile for a user should be wiped on disconnect.

### DIFF
--- a/components/fxa-client/src/internal/profile.rs
+++ b/components/fxa-client/src/internal/profile.rs
@@ -139,13 +139,23 @@ mod tests {
                         avatar: "https://foo.avatar".to_string(),
                         avatar_default: true,
                     },
-                    etag: None,
+                    etag: Some("123".to_string()),
                 }))
             });
         fxa.set_client(Arc::new(client));
 
         let p = fxa.get_profile(false).unwrap();
         assert_eq!(p.email, "foo@bar.com");
+        // do it again to check our caching - if it wasn't cached and we hit our mock
+        // of fetching the profile we'd still fail due to the mock only expecting 1 call.
+        let p = fxa.get_profile(false).unwrap();
+        assert_eq!(p.email, "foo@bar.com");
+
+        // make sure the cached value doesn't survive a disconnect.
+        fxa.disconnect();
+        // now we should have no cached value, but wont even try to hit the server as we
+        // have no session token.
+        assert!(matches!(fxa.get_profile(false), Err(Error::NoSessionToken)));
     }
 
     #[test]

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -208,6 +208,7 @@ impl StateManager {
         self.persisted_state.server_local_device_info = None;
         self.persisted_state.session_token = None;
         self.persisted_state.logged_out_from_auth_issues = false;
+        self.persisted_state.last_seen_profile = None;
         self.flow_store.clear();
     }
 


### PR DESCRIPTION
Currently after calling disconnect and reconnecting another user, calling `get_profile` may return the previous user until the cache expires, or `ignore_cache = true` is specified.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
