### PR TITLE
Bug 2045099 - Use separate DisqualifedReason for experiment/rollout opt-out vs individual opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enrollment change events (visible to the UDL) now include the feature IDs of the features involved when possible. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
 - Fixed a bug where enrollment change events were not emitted for rollouts that re-enrolled after previously unenrolling. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
 - Attempting to opt-out from an experiment that is not currently enrolled is now a no-op. ([#7399](https://github.com/mozilla/application-services/pull/7399))
+- There are new separate DisqualifiedReason and NotEnrolledReason for global (experiment and rollout) opt-outs. ([#7400](https://github.com/mozilla/application-services/pull/7400))
 
 [Full Changelog](In progress)
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -49,6 +49,7 @@ impl Display for EnrolledReason {
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️
 // ⚠️ in `src/stateful/tests/test_enrollment_bw_compat.rs` below, and may require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
+#[allow(deprecated)]
 pub enum NotEnrolledReason {
     /// The experiment targets a different application.
     DifferentAppName,
@@ -63,9 +64,29 @@ pub enum NotEnrolledReason {
     /// We are not being targeted for this experiment.
     NotTargeted,
     /// The user opted-out of experiments before we ever got enrolled to this one.
+    ExperimentsOptOut,
+    /// The user opted-out of rollouts before we ever got enrolled to this one.
+    RolloutsOptOut,
+
+    /// This state represents several cases:
+    ///
+    /// - this is an experiment and the user globally opted out of experiments
+    ///   (or the global participation opt-out pre Firefox 145);
+    /// - this is a rollout and the user globally opted out of rollouts (or the
+    ///   global participation opt-out pre Firefox 145); or
+    /// - this experiment or rollout was opted-out of manually by the user while
+    ///   not enrolled.
+    ///
+    /// The global participation opt-out was changed to individual experiments
+    /// and rollouts opt-outs in Firefox 145, but separate reasons were not
+    /// added until Firefox 153. It is therefore impossible to distinguish what
+    /// exactly this state represents and so we must interpet it in the most
+    /// strict sense in order to respect user choice.
+    #[deprecated]
     OptOut,
 }
 
+#[allow(deprecated)]
 impl Display for NotEnrolledReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(
@@ -76,6 +97,8 @@ impl Display for NotEnrolledReason {
                 NotEnrolledReason::FeatureConflict => "FeatureConflict",
                 NotEnrolledReason::NotSelected => "NotSelected",
                 NotEnrolledReason::NotTargeted => "NotTargeted",
+                NotEnrolledReason::ExperimentsOptOut => "ExperimentsOptOut",
+                NotEnrolledReason::RolloutsOptOut => "RolloutsOptOut",
                 NotEnrolledReason::OptOut => "OptOut",
             },
             f,
@@ -106,8 +129,12 @@ impl Default for Participation {
 pub enum DisqualifiedReason {
     /// There was an error.
     Error,
-    /// The user opted-out from this experiment or experiments in general.
+    /// The user opted-out from this experiment.
     OptOut,
+    /// The user opted-out from all rollouts.
+    ExperimentsOptOut,
+    /// The user reset their telemetry identifiers.
+    RolloutsOptOut,
     /// The targeting has changed for an experiment.
     NotTargeted,
     /// The bucketing has changed for an experiment.
@@ -123,6 +150,8 @@ impl Display for DisqualifiedReason {
             match self {
                 DisqualifiedReason::Error => "Error",
                 DisqualifiedReason::OptOut => "OptOut",
+                DisqualifiedReason::ExperimentsOptOut => "ExperimentsOptOut",
+                DisqualifiedReason::RolloutsOptOut => "ExperimentsOptOut",
                 DisqualifiedReason::NotSelected => "NotSelected",
                 DisqualifiedReason::NotTargeted => "NotTargeted",
                 #[cfg(feature = "stateful")]
@@ -205,7 +234,11 @@ impl ExperimentEnrollment {
             Self {
                 slug: experiment.slug.clone(),
                 status: EnrollmentStatus::NotEnrolled {
-                    reason: NotEnrolledReason::OptOut,
+                    reason: if experiment.is_rollout() {
+                        NotEnrolledReason::RolloutsOptOut
+                    } else {
+                        NotEnrolledReason::ExperimentsOptOut
+                    },
                 },
             }
         } else if experiment.is_enrollment_paused {
@@ -304,7 +337,11 @@ impl ExperimentEnrollment {
                     #[cfg(feature = "stateful")]
                     self.maybe_revert_all_gecko_pref_states(gecko_pref_store);
                     let updated_enrollment =
-                        self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
+                        self.disqualify_from_enrolled(if updated_experiment.is_rollout {
+                            DisqualifiedReason::RolloutsOptOut
+                        } else {
+                            DisqualifiedReason::ExperimentsOptOut
+                        });
                     out_enrollment_events
                         .push(updated_enrollment.get_change_event(Some(updated_experiment)));
                     updated_enrollment
@@ -398,14 +435,20 @@ impl ExperimentEnrollment {
                     Self {
                         slug: self.slug.clone(),
                         status: EnrollmentStatus::Disqualified {
-                            reason: DisqualifiedReason::OptOut,
+                            reason: if updated_experiment.is_rollout {
+                                DisqualifiedReason::RolloutsOptOut
+                            } else {
+                                DisqualifiedReason::ExperimentsOptOut
+                            },
                             branch: branch.clone(),
                         },
                     }
                 } else if updated_experiment.is_rollout
                     && matches!(
                         reason,
-                        DisqualifiedReason::NotSelected | DisqualifiedReason::NotTargeted,
+                        DisqualifiedReason::NotSelected
+                            | DisqualifiedReason::NotTargeted
+                            | DisqualifiedReason::RolloutsOptOut,
                     )
                 {
                     let updated_enrollment = evaluate_enrollment(
@@ -639,6 +682,8 @@ impl ExperimentEnrollment {
                     DisqualifiedReason::NotSelected => Some("bucketing"),
                     DisqualifiedReason::NotTargeted => Some("targeting"),
                     DisqualifiedReason::OptOut => Some("optout"),
+                    DisqualifiedReason::ExperimentsOptOut => Some("experiments-opt-out"),
+                    DisqualifiedReason::RolloutsOptOut => Some("rollouts-opt-out"),
                     DisqualifiedReason::Error => Some("error"),
                     #[cfg(feature = "stateful")]
                     DisqualifiedReason::PrefUnenrollReason { reason } => match reason {

--- a/components/nimbus/src/schema.rs
+++ b/components/nimbus/src/schema.rs
@@ -16,6 +16,7 @@ use crate::{NimbusError, Result};
 const DEFAULT_TOTAL_BUCKETS: u32 = 10000;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct EnrolledExperiment {
     pub feature_ids: Vec<String>,
     pub slug: String,

--- a/components/nimbus/src/tests/stateful/test_enrollment.rs
+++ b/components/nimbus/src/tests/stateful/test_enrollment.rs
@@ -151,7 +151,7 @@ fn test_updates() -> Result<()> {
     let mut writer = db.write()?;
     let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
     let aru = AvailableRandomizationUnits::with_nimbus_id(&nimbus_id);
-    let mut th = NimbusTargetingHelper::from(AppContext {
+    let th = NimbusTargetingHelper::from(AppContext {
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
         channel: "nightly".to_string(),
@@ -190,7 +190,8 @@ fn test_updates() -> Result<()> {
 
     // pretend we just updated from the server and one of the 2 is missing.
     let exps = &[exps[1].clone()];
-    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
+    let mut targeting_helper = th;
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_helper, &ids);
     let events = evolver.evolve_enrollments_in_db(&db, &mut writer, exps, None)?;
 
     // should only have 1 now.
@@ -213,13 +214,13 @@ fn test_updates() -> Result<()> {
 }
 
 #[test]
-fn test_global_opt_out() -> Result<()> {
+fn test_experiments_opt_out() -> Result<()> {
     error_support::init_for_tests();
     let tmp_dir = tempfile::tempdir()?;
     let db = Database::new(&tmp_dir, TestMetrics::new())?;
     let mut writer = db.write()?;
     let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
-    let mut th = NimbusTargetingHelper::from(AppContext {
+    let th = NimbusTargetingHelper::from(AppContext {
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
         channel: "nightly".to_string(),
@@ -248,7 +249,7 @@ fn test_global_opt_out() -> Result<()> {
             matches!(
                 enr.status,
                 EnrollmentStatus::NotEnrolled {
-                    reason: NotEnrolledReason::OptOut
+                    reason: NotEnrolledReason::ExperimentsOptOut
                 }
             )
         })
@@ -306,14 +307,14 @@ fn test_global_opt_out() -> Result<()> {
             EnrollmentChangeEvent {
                 experiment_slug: "secure-gold".into(),
                 branch_slug: "treatment".into(),
-                reason: Some("optout".into()),
+                reason: Some("experiments-opt-out".into()),
                 change: EnrollmentChangeEventType::Disqualification,
                 feature_ids: vec!["some_control".into()]
             },
             EnrollmentChangeEvent {
                 experiment_slug: "secure-silver".into(),
                 branch_slug: "treatment".into(),
-                reason: Some("optout".into()),
+                reason: Some("experiments-opt-out".into()),
                 change: EnrollmentChangeEventType::Disqualification,
                 feature_ids: vec!["about_welcome".into()]
             }
@@ -329,7 +330,7 @@ fn test_global_opt_out() -> Result<()> {
                 matches!(
                     enr.status,
                     EnrollmentStatus::Disqualified {
-                        reason: DisqualifiedReason::OptOut,
+                        reason: DisqualifiedReason::ExperimentsOptOut,
                         ..
                     }
                 )
@@ -341,7 +342,8 @@ fn test_global_opt_out() -> Result<()> {
     // Opting in again and updating SHOULD NOT enroll us again (we've been disqualified).
     set_experiment_participation(&db, &mut writer, true)?;
 
-    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
+    let mut targeting_helper = th;
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_helper, &ids);
     let events = evolver.evolve_enrollments_in_db(&db, &mut writer, &exps, None)?;
 
     let enrollments = get_enrollments(&db, &writer)?;
@@ -355,11 +357,189 @@ fn test_global_opt_out() -> Result<()> {
                 matches!(
                     enr.status,
                     EnrollmentStatus::Disqualified {
-                        reason: DisqualifiedReason::OptOut,
+                        reason: DisqualifiedReason::ExperimentsOptOut,
                         ..
                     }
                 )
             })
+            .count(),
+        2
+    );
+
+    writer.commit()?;
+    Ok(())
+}
+
+#[test]
+fn test_rollouts_opt_out() -> Result<()> {
+    let tmp_dir = tempfile::tempdir()?;
+    let db = Database::new(&tmp_dir, TestMetrics::new())?;
+    let mut writer = db.write()?;
+    let nimbus_id = Uuid::from_str("00000000-0000-0000-0000-000000000004")?;
+    let th = NimbusTargetingHelper::from(AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    });
+    let aru = AvailableRandomizationUnits::with_nimbus_id(&nimbus_id);
+    assert_eq!(get_enrollments(&db, &writer)?.len(), 0);
+    let recipes = {
+        let mut recipes = get_test_experiments();
+        recipes[0].is_rollout = true;
+        recipes[0].branches.remove(1);
+        recipes[1].is_rollout = true;
+        recipes[1].branches.remove(1);
+        recipes
+    };
+
+    set_rollout_participation(&db, &mut writer, false)?;
+
+    let coenrolling_feature_ids = no_coenrolling_features();
+
+    let mut targeting_helper = th.clone();
+    let mut evolver =
+        EnrollmentsEvolver::new(&aru, &mut targeting_helper, &coenrolling_feature_ids);
+
+    let events = evolver.evolve_enrollments_in_db(&db, &mut writer, &recipes, None)?;
+
+    let enrollments = get_enrollments(&db, &writer)?;
+    assert_eq!(&enrollments, &[]);
+    assert_eq!(&events, &[]);
+    let experiment_enrollments = get_experiment_enrollments(&db, &writer)?;
+    assert_eq!(experiment_enrollments.len(), 2);
+    let num_not_enrolled_enrollments = experiment_enrollments
+        .into_iter()
+        .filter(|enr| {
+            matches!(
+                enr.status,
+                EnrollmentStatus::NotEnrolled {
+                    reason: NotEnrolledReason::RolloutsOptOut
+                }
+            )
+        })
+        .count();
+    assert_eq!(num_not_enrolled_enrollments, 2);
+
+    set_rollout_participation(&db, &mut writer, true)?;
+
+    let mut targeting_helper = th.clone();
+    let mut evolver =
+        EnrollmentsEvolver::new(&aru, &mut targeting_helper, &coenrolling_feature_ids);
+
+    let events = evolver.evolve_enrollments_in_db(&db, &mut writer, &recipes, None)?;
+
+    let enrollments = get_enrollments(&db, &writer)?;
+    assert_eq!(enrollments.len(), 2);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()]
+            }
+        ]
+    );
+    // We should see 2 experiment enrollments.
+    assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
+    let num_enrolled_enrollments = get_experiment_enrollments(&db, &writer)?
+        .into_iter()
+        .filter(|enr| matches!(enr.status, EnrollmentStatus::Enrolled { .. }))
+        .count();
+    assert_eq!(num_enrolled_enrollments, 2);
+
+    set_rollout_participation(&db, &mut writer, false)?;
+
+    let mut targeting_helper = th.clone();
+    let mut evolver =
+        EnrollmentsEvolver::new(&aru, &mut targeting_helper, &coenrolling_feature_ids);
+    let events = evolver.evolve_enrollments_in_db(&db, &mut writer, &recipes, None)?;
+
+    let enrollments = get_enrollments(&db, &writer)?;
+    assert_eq!(enrollments.len(), 0);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "control".into(),
+                reason: Some("rollouts-opt-out".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "control".into(),
+                reason: Some("rollouts-opt-out".into()),
+                change: EnrollmentChangeEventType::Disqualification,
+                feature_ids: vec!["about_welcome".into()]
+            }
+        ]
+    );
+    // We should see 2 experiment enrolments, this time they're both opt outs
+    assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
+
+    assert_eq!(
+        get_experiment_enrollments(&db, &writer)?
+            .into_iter()
+            .filter(|enr| {
+                matches!(
+                    enr.status,
+                    EnrollmentStatus::Disqualified {
+                        reason: DisqualifiedReason::RolloutsOptOut,
+                        ..
+                    }
+                )
+            })
+            .count(),
+        2
+    );
+
+    // Opting in again and updating SHOULD re-enroll us again.
+    set_rollout_participation(&db, &mut writer, true)?;
+
+    let mut targeting_helper = th;
+    let mut evolver =
+        EnrollmentsEvolver::new(&aru, &mut targeting_helper, &coenrolling_feature_ids);
+    println!("====");
+    let events = evolver.evolve_enrollments_in_db(&db, &mut writer, &recipes, None)?;
+
+    let enrollments = get_enrollments(&db, &writer)?;
+    assert_eq!(enrollments.len(), 2);
+    assert_eq!(
+        &events,
+        &[
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-gold".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["some_control".into()]
+            },
+            EnrollmentChangeEvent {
+                experiment_slug: "secure-silver".into(),
+                branch_slug: "control".into(),
+                reason: None,
+                change: EnrollmentChangeEventType::Enrollment,
+                feature_ids: vec!["about_welcome".into()]
+            }
+        ]
+    );
+
+    assert_eq!(
+        get_experiment_enrollments(&db, &writer)?
+            .into_iter()
+            .filter(|enr| { matches!(enr.status, EnrollmentStatus::Enrolled { .. }) })
             .count(),
         2
     );
@@ -548,7 +728,7 @@ fn test_experiments_opt_out_with_rollouts_opt_in() -> Result<()> {
     assert!(matches!(
         experiment_enrollment.unwrap().status,
         EnrollmentStatus::NotEnrolled {
-            reason: NotEnrolledReason::OptOut
+            reason: NotEnrolledReason::ExperimentsOptOut
         }
     ));
 
@@ -637,7 +817,7 @@ fn test_rollouts_opt_out_with_experiments_opt_in() -> Result<()> {
     assert!(matches!(
         rollout_enrollment.unwrap().status,
         EnrollmentStatus::NotEnrolled {
-            reason: NotEnrolledReason::OptOut
+            reason: NotEnrolledReason::RolloutsOptOut
         }
     ));
 

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -466,7 +466,7 @@ fn test_ios_rollout_experiment() -> Result<()> {
 
 #[test]
 fn test_evolver_new_experiment_enrolled() -> Result<()> {
-    let exp = &get_test_experiments()[0];
+    let exp = &get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
     let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
@@ -552,7 +552,46 @@ fn test_evolver_new_experiment_globally_opted_out() -> Result<()> {
     assert!(matches!(
         enrollment.status,
         EnrollmentStatus::NotEnrolled {
-            reason: NotEnrolledReason::OptOut
+            reason: NotEnrolledReason::ExperimentsOptOut
+        }
+    ));
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (no previous enrollment, opted out)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_evolve_new_rollout_globally_opted_out() -> Result<()> {
+    let rollout = {
+        let mut rollout = get_test_experiments()[0].clone();
+        rollout.is_rollout = true;
+        rollout.branches.remove(1);
+        rollout
+    };
+
+    let (_, app_ctx, aru) = local_ctx();
+    let mut th = app_ctx.into();
+    let ids = no_coenrolling_features();
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
+    let mut events = vec![];
+    let enrollment = evolver
+        .evolve_enrollment(
+            false,
+            None,
+            Some(&rollout),
+            None,
+            &mut events,
+            #[cfg(feature = "stateful")]
+            None,
+        )?
+        .unwrap();
+    assert!(matches!(
+        enrollment.status,
+        EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::RolloutsOptOut
         }
     ));
     assert_eq!(
@@ -601,6 +640,8 @@ fn test_evolver_experiment_update_not_enrolled_opted_out() -> Result<()> {
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
+
+    #[allow(deprecated)]
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
         status: EnrollmentStatus::NotEnrolled {
@@ -622,8 +663,100 @@ fn test_evolver_experiment_update_not_enrolled_opted_out() -> Result<()> {
     assert_eq!(
         &events,
         &[],
-        "no change in enrollments (previous unenrolled (optout) enrollment, opted out)"
+        "no change in enrollments (previous unenrolled (legacy optout) enrollment, opted out)"
     );
+
+    let existing_enrollment = ExperimentEnrollment {
+        slug: exp.slug.clone(),
+        status: EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::ExperimentsOptOut,
+        },
+    };
+    let enrollment = evolver
+        .evolve_enrollment(
+            false,
+            Some(&exp),
+            Some(&exp),
+            Some(&existing_enrollment),
+            &mut events,
+            #[cfg(feature = "stateful")]
+            None,
+        )?
+        .unwrap();
+    assert_eq!(enrollment.status, existing_enrollment.status);
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (previous unenrolled (experiments optout) enrollment, opted out)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_evolve_rollout_update_not_enrolled_opted_out() -> Result<()> {
+    let recipe = {
+        let mut recipe = get_test_experiments()[0].clone();
+        recipe.is_rollout = true;
+        recipe.branches.remove(1);
+        recipe
+    };
+
+    let (_, app_ctx, aru) = local_ctx();
+    let mut th = app_ctx.into();
+    let ids = no_coenrolling_features();
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
+    let mut events = vec![];
+
+    #[allow(deprecated)]
+    let existing_enrollment = ExperimentEnrollment {
+        slug: recipe.slug.clone(),
+        status: EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::OptOut,
+        },
+    };
+    let enrollment = evolver
+        .evolve_enrollment(
+            false,
+            Some(&recipe),
+            Some(&recipe),
+            Some(&existing_enrollment),
+            &mut events,
+            #[cfg(feature = "stateful")]
+            None,
+        )?
+        .unwrap();
+    assert_eq!(enrollment.status, existing_enrollment.status);
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (previous unenrolled (legacy optout) enrollment, opted out)"
+    );
+
+    let existing_enrollment = ExperimentEnrollment {
+        slug: recipe.slug.clone(),
+        status: EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::RolloutsOptOut,
+        },
+    };
+    let enrollment = evolver
+        .evolve_enrollment(
+            false,
+            Some(&recipe),
+            Some(&recipe),
+            Some(&existing_enrollment),
+            &mut events,
+            #[cfg(feature = "stateful")]
+            None,
+        )?
+        .unwrap();
+    assert_eq!(enrollment.status, existing_enrollment.status);
+    assert_eq!(
+        &events,
+        &[],
+        "no change in enrollments (previous unenrolled (rllouts optout) enrollment, opted out)"
+    );
+
     Ok(())
 }
 
@@ -709,6 +842,9 @@ fn test_evolver_experiment_update_not_enrolled_resuming_selected() -> Result<()>
     let ids = no_coenrolling_features();
     let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
+
+    // TODO(bug 2044504): This test implies the existence of a enrollment paused ->
+    // enrollment unpaused workflow, which does not exist in practice.
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
         status: EnrollmentStatus::NotEnrolled {
@@ -775,10 +911,11 @@ fn test_evolver_experiment_update_enrolled_then_opted_out() -> Result<()> {
             None,
         )?
         .unwrap();
+    println!("{:?}", enrollment.status);
     assert!(matches!(
         enrollment.status,
         EnrollmentStatus::Disqualified {
-            reason: DisqualifiedReason::OptOut,
+            reason: DisqualifiedReason::ExperimentsOptOut,
             ..
         }
     ));
@@ -787,7 +924,62 @@ fn test_evolver_experiment_update_enrolled_then_opted_out() -> Result<()> {
         &[EnrollmentChangeEvent {
             experiment_slug: exp.slug.clone(),
             branch_slug: "control".into(),
-            reason: Some("optout".to_owned()),
+            reason: Some("experiments-opt-out".to_owned()),
+            change: EnrollmentChangeEventType::Disqualification,
+            feature_ids: vec!["some_control".into()],
+        }]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_evolve_rollout_update_enrolled_then_opted_out() -> Result<()> {
+    let recipe = {
+        let mut recipe = get_test_experiments()[0].clone();
+        recipe.is_rollout = true;
+        recipe.branches.remove(1);
+        recipe
+    };
+
+    let (_, app_ctx, aru) = local_ctx();
+    let mut th = app_ctx.into();
+    let ids = no_coenrolling_features();
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
+    let mut events = vec![];
+    let existing_enrollment = ExperimentEnrollment {
+        slug: recipe.slug.clone(),
+        status: EnrollmentStatus::Enrolled {
+            branch: "control".to_owned(),
+            reason: EnrolledReason::Qualified,
+            #[cfg(feature = "stateful")]
+            prev_gecko_pref_states: None,
+        },
+    };
+    let enrollment = evolver
+        .evolve_enrollment(
+            false,
+            Some(&recipe),
+            Some(&recipe),
+            Some(&existing_enrollment),
+            &mut events,
+            #[cfg(feature = "stateful")]
+            None,
+        )?
+        .unwrap();
+    println!("{:?}", enrollment.status);
+    assert!(matches!(
+        enrollment.status,
+        EnrollmentStatus::Disqualified {
+            reason: DisqualifiedReason::RolloutsOptOut,
+            ..
+        }
+    ));
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: recipe.slug.clone(),
+            branch_slug: "control".into(),
+            reason: Some("rollouts-opt-out".to_owned()),
             change: EnrollmentChangeEventType::Disqualification,
             feature_ids: vec!["some_control".into()],
         }]
@@ -1329,7 +1521,7 @@ fn test_evolver_experiment_update_disqualified_then_opted_out() -> Result<()> {
     assert!(matches!(
         enrollment.status,
         EnrollmentStatus::Disqualified {
-            reason: DisqualifiedReason::OptOut,
+            reason: DisqualifiedReason::ExperimentsOptOut,
             ..
         }
     ));


### PR DESCRIPTION
The `NotEnrolledReason::OptOut` variant is now deprecated as previously used to mark the global participation opt-out in addition to opt-ing out from inactive enrollments. This latter behaviour likely never ocurred due to it requiring what is essentially a bug in the embedding client. However, we cannot know for sure so instead of removing it (e.g., via a database migration), it is instead now marked deprecated and it is no longer possible to generate `EnrollmentStatus::NotEnrolled` with `NotEnrolledReason::OptOut`.

Now there are two new additional `NotEnrolledReason`s: `ExperimentsOptOut` and `RolloutsOptOut`, for when users have opted out of experiments and rollouts, respectfully. Likewise, there are also two new `DisqualificationReason`s with the same names.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
