### PR TITLE
Bug 2045100 - Do not apply pending experiments after toggling experiment/rollout participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug where enrollment change events were not emitted for rollouts that re-enrolled after previously unenrolling. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
 - Attempting to opt-out from an experiment that is not currently enrolled is now a no-op. ([#7399](https://github.com/mozilla/application-services/pull/7399))
 - There are new separate DisqualifiedReason and NotEnrolledReason for global (experiment and rollout) opt-outs. ([#7400](https://github.com/mozilla/application-services/pull/7400))
+- Changing experiment and/or rollout participation no longer triggers a double update. Enrollment change telemetry is now appropriately triggered when this occurs. ([#7401](https://github.com/mozilla/application-services/pull/7401))
 
 [Full Changelog](In progress)
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -166,7 +166,6 @@ open class Nimbus(
         set(active) {
             dbScope.launch {
                 setExperimentParticipationOnThisThread(active)
-                applyPendingExperimentsOnThisThread()
             }
         }
 
@@ -175,7 +174,6 @@ open class Nimbus(
         set(active) {
             dbScope.launch {
                 setRolloutParticipationOnThisThread(active)
-                applyPendingExperimentsOnThisThread()
             }
         }
 


### PR DESCRIPTION
Changing experiment or rollout participation already triggers an evolution based on the current set of cached experiments. Calling `applyLocalExperimentsOnThisThread()` does a second evolution, with the set of pending experiments.

Additionally, these properties were calling `nimbusClient.set{Experiment,Rollout}Participation` instead of the Kotlin-based helpers `set{Experiment,Rollout}ParticipationOnThisThread` which are responsible for submitting telemetry. This has been corrected.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
