### PR TITLE
Update glean-sym to a version that fixed the latest crash issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -597,7 +597,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.0",
+ "libloading",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.0",
+ "libloading",
 ]
 
 [[package]]
@@ -1816,9 +1816,9 @@ dependencies = [
 [[package]]
 name = "glean-sym"
 version = "0.1.0"
-source = "git+https://github.com/mozilla/glean?rev=0401cd87c365fd8356e5d3bb6d72a67c8940c934#0401cd87c365fd8356e5d3bb6d72a67c8940c934"
+source = "git+https://github.com/mozilla/glean?rev=a16cb6034dc2c37ba62eae85f6304c637e53b2ae#a16cb6034dc2c37ba62eae85f6304c637e53b2ae"
 dependencies = [
- "libloading 0.9.0",
+ "libloading",
  "once_cell",
  "serde",
  "uniffi",
@@ -2469,16 +2469,6 @@ checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "libloading"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
-dependencies = [
- "cfg-if",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5568,12 +5558,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -34,7 +34,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 thiserror = "2"
 anyhow = "1.0"
 uniffi = { version = "0.31" }
-glean-sym = { git = "https://github.com/mozilla/glean", rev = "0401cd87c365fd8356e5d3bb6d72a67c8940c934", optional = true }
+glean-sym = { git = "https://github.com/mozilla/glean", rev = "a16cb6034dc2c37ba62eae85f6304c637e53b2ae", optional = true }
 
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }


### PR DESCRIPTION
Update glean-sym to a version that fixed the latest crash issues

Usage of glean-sym remains default-disabled. This will make it easier to
test again. It will be enabled in a later change.
Also includes the libloading downgrade (to 0.8, inline with other usage here)