### PR TITLE
Bug 2045853 - Trigger postEnrolmentCalculation() on all enrollment changes

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -165,7 +165,7 @@ open class Nimbus(
         get() = nimbusClient.getExperimentParticipation()
         set(active) {
             dbScope.launch {
-                nimbusClient.setExperimentParticipation(active)
+                setExperimentParticipationOnThisThread(active)
                 applyPendingExperimentsOnThisThread()
             }
         }
@@ -174,7 +174,7 @@ open class Nimbus(
         get() = nimbusClient.getRolloutParticipation()
         set(active) {
             dbScope.launch {
-                nimbusClient.setRolloutParticipation(active)
+                setRolloutParticipationOnThisThread(active)
                 applyPendingExperimentsOnThisThread()
             }
         }
@@ -458,9 +458,7 @@ open class Nimbus(
         prefUnenrollReason: PrefUnenrollReason,
     ) {
         dbScope.launch {
-            withCatchAll("unenrollForGeckoPref") {
-                unenrollForGeckoPrefOnThisThread(geckoPrefState, prefUnenrollReason)
-            }
+            unenrollForGeckoPrefOnThisThread(geckoPrefState, prefUnenrollReason)
         }
     }
 
@@ -469,10 +467,13 @@ open class Nimbus(
     internal fun unenrollForGeckoPrefOnThisThread(
         geckoPrefState: GeckoPrefState,
         prefUnenrollReason: PrefUnenrollReason,
-    ): List<EnrollmentChangeEvent> {
-        val events = nimbusClient.unenrollForGeckoPref(geckoPrefState, prefUnenrollReason)
-        recordExperimentTelemetryEvents(events)
-        return events
+    ): List<EnrollmentChangeEvent>? {
+        return withCatchAll("unenrollForGeckoPref") {
+            val enrollmentChangeEvents = nimbusClient.unenrollForGeckoPref(geckoPrefState, prefUnenrollReason)
+            recordExperimentTelemetryEvents(enrollmentChangeEvents)
+            postEnrolmentCalculation()
+            enrollmentChangeEvents
+        }
     }
 
     override fun registerPreviousGeckoPrefStates(geckoPrefStates: List<GeckoPrefState>) {
@@ -491,25 +492,42 @@ open class Nimbus(
 
     @WorkerThread
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun optOutOnThisThread(experimentId: String) = withCatchAll("optOut") {
-        nimbusClient.optOut(experimentId).also(::recordExperimentTelemetryEvents)
+    internal fun optOutOnThisThread(experimentId: String) {
+        withCatchAll("optOut") {
+            nimbusClient.optOut(experimentId).also(::recordExperimentTelemetryEvents)
+            postEnrolmentCalculation()
+        }
     }
 
+    @AnyThread
     override fun resetTelemetryIdentifiers() {
         dbScope.launch {
-            withCatchAll("resetTelemetryIdentifiers") {
-                nimbusClient.resetTelemetryIdentifiers().also { enrollmentChangeEvents ->
-                    recordExperimentTelemetryEvents(enrollmentChangeEvents)
-                }
-            }
+            resetTelemetryIdentifiersOnThisThread()
+        }
+    }
+
+    @WorkerThread
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun resetTelemetryIdentifiersOnThisThread() {
+        withCatchAll("resetTelemetryIdentifiers") {
+            val enrollmentChangeEvents = nimbusClient.resetTelemetryIdentifiers()
+            recordExperimentTelemetryEvents(enrollmentChangeEvents)
+            postEnrolmentCalculation()
         }
     }
 
     override fun optInWithBranch(experimentId: String, branch: String) {
         dbScope.launch {
-            withCatchAll("optIn") {
-                nimbusClient.optInWithBranch(experimentId, branch).also(::recordExperimentTelemetryEvents)
-            }
+            optInWithBranchOnThisThread(experimentId, branch)
+        }
+    }
+
+    @WorkerThread
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun optInWithBranchOnThisThread(experimentId: String, branch: String) {
+        withCatchAll("optIn") {
+            nimbusClient.optInWithBranch(experimentId, branch).also(::recordExperimentTelemetryEvents)
+            postEnrolmentCalculation()
         }
     }
 

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -942,7 +942,8 @@ class NimbusTests {
             PrefUnenrollReason.FAILED_TO_SET,
         )
 
-        assertEquals(1, events.size)
+        assertNotNull(events)
+        assertEquals(1, events!!.size)
         assertEquals(EnrollmentChangeEventType.DISQUALIFICATION, events[0].change)
         assertEquals(0, handler.setValues?.size)
     }


### PR DESCRIPTION
`postEnrolmentCalculation()` is responsible for recording the active experiments and triggering the `onUpdatesApplied` observer -- which is in turn used to invalidate the FML feature cache. Several enrolment change mechanisms were not properly triggering `onUpdatesApplied`, which has lead to stale feature value caching issues (see-also https://github.com/mozilla-mobile/fenix/issues/21838). These issues have been band-aided by calling applyPendingExperiments() in most cases, which results in ~correct behaviour but does a double update.

Now we trigger `postEnrolmentCalculation()` and therefore feature invalidation on all enrollment changes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
