### PR TITLE
Bug 2045793 - Add feature update callback registration to FeatureHolder

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -135,6 +135,23 @@ class FeatureHolder<T : FMLFeatureInterface>(
     }
 
     /**
+     * Add a callback to be called when the feature updates.
+     *
+     * This **must** be called after Nimbus is initialized, otherwise the
+     * callback will not be registered.
+     */
+    fun addUpdateCallback(callback: () -> Unit) {
+        getSdk()?.getFeatureUpdateDispatcher()?.addCallback(featureId, callback)
+    }
+
+    /**
+     * Remove a feature update callback.
+     */
+    fun removeUpdateCallback(callback: () -> Unit) {
+        getSdk()?.getFeatureUpdateDispatcher()?.removeCallback(featureId, callback)
+    }
+
+    /**
      * Is this feature the focus of an automated test.
      *
      * A utility flag to be used in conjunction with {HardcodedNimbusFeatures}.


### PR DESCRIPTION
These methods allow methods for adding and removing update callbacks with Nimbus without passing string constants around in client code, making it less likely to cause misregistration due to typos.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
