### PR TITLE
Bug 1443042 - Add optional custom_label field to credit-card schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v153.0 (In progress)
 
+## ✨ What's New ✨
+
+### Autofill
+
+- Added an optional `custom_label` field to the credit-card record so consumers can let users assign a user-defined label to a saved card. The field is nullable in the DB (NULL by default), defaults to `null` in the UniFFI bindings (no breaking change for existing Swift/Kotlin callers), and rides on the existing v3 credit-card sync payload as a kebab-cased `custom-label` key. It is omitted from outgoing payloads when unset so older clients see records unchanged. ([bug 1443042](https://bugzilla.mozilla.org/show_bug.cgi?id=1443042))
+
 ## 🔧 What's Fixed 🔧
 
 ### Logins

--- a/components/autofill/sql/create_shared_schema.sql
+++ b/components/autofill/sql/create_shared_schema.sql
@@ -58,6 +58,8 @@ CREATE TABLE IF NOT EXISTS credit_cards_data (
     cc_exp_month        INTEGER,
     cc_exp_year         INTEGER,
     cc_type             TEXT NOT NULL,
+    -- Optional user-assigned label (free text). NULL means unset.
+    custom_label        TEXT,
 
     time_created        INTEGER NOT NULL,
     time_last_used      INTEGER,

--- a/components/autofill/sql/migrations/v5_migration.sql
+++ b/components/autofill/sql/migrations/v5_migration.sql
@@ -1,0 +1,5 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ALTER TABLE credit_cards_data ADD COLUMN custom_label TEXT;

--- a/components/autofill/sql/tests/create_v4_db.sql
+++ b/components/autofill/sql/tests/create_v4_db.sql
@@ -1,0 +1,100 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-- Initialize the v4 schema. Same column layout as v3 — the v4 migration only
+-- rewrites address_level1 data — so we reuse the v3 table definitions and seed
+-- the post-v4 state.
+
+CREATE TABLE IF NOT EXISTS addresses_data (
+    guid                TEXT NOT NULL PRIMARY KEY CHECK(length(guid) != 0),
+    name                TEXT NOT NULL,
+    organization        TEXT NOT NULL,
+    street_address      TEXT NOT NULL,
+    address_level3      TEXT NOT NULL,
+    address_level2      TEXT NOT NULL,
+    address_level1      TEXT NOT NULL,
+    postal_code         TEXT NOT NULL,
+    country             TEXT NOT NULL,
+    tel                 TEXT NOT NULL,
+    email               TEXT NOT NULL,
+
+    time_created        INTEGER NOT NULL,
+    time_last_used      INTEGER NOT NULL,
+    time_last_modified  INTEGER NOT NULL,
+    times_used          INTEGER NOT NULL,
+
+    sync_change_counter INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS addresses_mirror (
+    guid                TEXT NOT NULL PRIMARY KEY CHECK(length(guid) != 0),
+    payload             TEXT NOT NULL CHECK(length(payload) != 0)
+);
+
+CREATE TABLE IF NOT EXISTS addresses_tombstones (
+    guid            TEXT PRIMARY KEY CHECK(length(guid) != 0),
+    time_deleted    INTEGER NOT NULL
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS credit_cards_data (
+    guid                TEXT NOT NULL PRIMARY KEY CHECK(length(guid) != 0),
+    cc_name             TEXT NOT NULL,
+    cc_number_enc       TEXT NOT NULL CHECK(length(cc_number_enc) > 20 OR cc_number_enc == ''),
+    cc_number_last_4    TEXT NOT NULL CHECK(length(cc_number_last_4) <= 4),
+    cc_exp_month        INTEGER,
+    cc_exp_year         INTEGER,
+    cc_type             TEXT NOT NULL,
+    time_created        INTEGER NOT NULL,
+    time_last_used      INTEGER,
+    time_last_modified  INTEGER NOT NULL,
+    times_used          INTEGER NOT NULL,
+    sync_change_counter INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS credit_cards_mirror (
+    guid                TEXT NOT NULL PRIMARY KEY CHECK(length(guid) != 0),
+    payload             TEXT NOT NULL CHECK(length(payload) != 0)
+);
+
+CREATE TABLE IF NOT EXISTS credit_cards_tombstones (
+    guid            TEXT PRIMARY KEY CHECK(length(guid) != 0),
+    time_deleted    INTEGER NOT NULL
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS moz_meta (
+    key TEXT PRIMARY KEY,
+    value NOT NULL
+) WITHOUT ROWID;
+
+INSERT INTO credit_cards_data (
+    guid, cc_name, cc_number_enc, cc_number_last_4, cc_exp_month, cc_exp_year,
+    cc_type, time_created, time_last_used, time_last_modified, times_used,
+    sync_change_counter
+) VALUES (
+    "A", "Jane Doe", "012345678901234567890", "1234", 1, 2020, "visa", 0, 1, 2,
+    3, 0
+);
+
+INSERT INTO addresses_data (
+    guid, name, organization, street_address, address_level3,
+    address_level2, address_level1, postal_code, country, tel,
+    email, time_created, time_last_used, time_last_modified,
+    times_used, sync_change_counter
+) VALUES (
+    "A", "Jane John Doe", "Mozilla", "123 Maple lane", "Shelbyville",
+    "Springfield", "MA", "12345", "US", "01-234-567-8000", "jane@hotmail.com", 0,
+    1, 2, 3, 0
+);
+
+INSERT INTO addresses_data (
+    guid, name, organization, street_address, address_level3,
+    address_level2, address_level1, postal_code, country, tel,
+    email, time_created, time_last_used, time_last_modified,
+    times_used, sync_change_counter
+) VALUES (
+    "B", "", "Mozilla", "123 Maple lane", "Shelbyville",
+    "Toronto", "ON", "12345", "CA", "01-234-567-8000", "jane@hotmail.com", 0,
+    1, 2, 3, 0
+);
+PRAGMA user_version=4;

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -23,6 +23,7 @@ dictionary UpdatableCreditCardFields {
     i64 cc_exp_month;
     i64 cc_exp_year;
     string cc_type;
+    string? custom_label = null;
 };
 
 /// What you get back as a credit-card.
@@ -34,6 +35,7 @@ dictionary CreditCard {
     i64 cc_exp_month;
     i64 cc_exp_year;
     string cc_type;
+    string? custom_label = null;
 
     i64 time_created;
     i64? time_last_used;

--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -39,6 +39,7 @@ pub(crate) fn add_credit_card(
         // Credit card types are a fixed set of strings as defined in the link below
         // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
         cc_type: new_credit_card_fields.cc_type,
+        custom_label: new_credit_card_fields.custom_label,
         metadata: Metadata {
             time_created: now,
             time_last_modified: now,
@@ -76,6 +77,7 @@ pub(crate) fn add_internal_credit_card(
             ":cc_exp_month": card.cc_exp_month,
             ":cc_exp_year": card.cc_exp_year,
             ":cc_type": card.cc_type,
+            ":custom_label": card.custom_label,
             ":time_created": card.metadata.time_created,
             ":time_last_used": card.metadata.time_last_used,
             ":time_last_modified": card.metadata.time_last_modified,
@@ -142,6 +144,7 @@ pub fn update_credit_card(
             cc_exp_month                = :cc_exp_month,
             cc_exp_year                 = :cc_exp_year,
             cc_type                     = :cc_type,
+            custom_label                = :custom_label,
             time_last_modified          = :time_last_modified,
             sync_change_counter         = sync_change_counter + 1
         WHERE guid                      = :guid",
@@ -152,6 +155,7 @@ pub fn update_credit_card(
             ":cc_exp_month": credit_card.cc_exp_month,
             ":cc_exp_year": credit_card.cc_exp_year,
             ":cc_type": credit_card.cc_type,
+            ":custom_label": credit_card.custom_label,
             ":time_last_modified": Timestamp::now(),
             ":guid": guid,
         },
@@ -178,6 +182,7 @@ pub(crate) fn update_internal_credit_card(
             cc_exp_month                = :cc_exp_month,
             cc_exp_year                 = :cc_exp_year,
             cc_type                     = :cc_type,
+            custom_label                = :custom_label,
             time_created                = :time_created,
             time_last_used              = :time_last_used,
             time_last_modified          = :time_last_modified,
@@ -191,6 +196,7 @@ pub(crate) fn update_internal_credit_card(
             ":cc_exp_month": card.cc_exp_month,
             ":cc_exp_year": card.cc_exp_year,
             ":cc_type": card.cc_type,
+            ":custom_label": card.custom_label,
             ":time_created": card.metadata.time_created,
             ":time_last_used": card.metadata.time_last_used,
             ":time_last_modified": card.metadata.time_last_modified,
@@ -361,6 +367,7 @@ pub(crate) mod tests {
                 cc_exp_month: 3,
                 cc_exp_year: 2022,
                 cc_type: "visa".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -434,6 +441,7 @@ pub(crate) mod tests {
                 cc_exp_month: 3,
                 cc_exp_year: 2022,
                 cc_type: "visa".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -446,6 +454,7 @@ pub(crate) mod tests {
                 cc_exp_month: 10,
                 cc_exp_year: 2025,
                 cc_type: "mastercard".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -459,6 +468,7 @@ pub(crate) mod tests {
                 cc_exp_month: 1,
                 cc_exp_year: 2024,
                 cc_type: "amex".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -502,6 +512,7 @@ pub(crate) mod tests {
                 cc_exp_month: 10,
                 cc_exp_year: 2025,
                 cc_type: "mastercard".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -514,6 +525,7 @@ pub(crate) mod tests {
                 cc_number_enc: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_string(),
                 cc_number_last_4: "1234".to_string(),
                 cc_type: "mastercard".to_string(),
+                custom_label: None,
                 cc_exp_month: 10,
                 cc_exp_year: 2025,
             },
@@ -599,6 +611,7 @@ pub(crate) mod tests {
                 cc_exp_month: 10,
                 cc_exp_year: 2025,
                 cc_type: "mastercard".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -615,6 +628,7 @@ pub(crate) mod tests {
                 cc_exp_month: 5,
                 cc_exp_year: 2024,
                 cc_type: "visa".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -668,6 +682,7 @@ pub(crate) mod tests {
                     cc_exp_month: 10,
                     cc_exp_year: 2025,
                     cc_type: "mastercard".to_string(),
+                    custom_label: None,
                 },
             )?);
         }
@@ -699,6 +714,7 @@ pub(crate) mod tests {
                 cc_exp_month: 9,
                 cc_exp_year: 2027,
                 cc_type: "visa".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -712,6 +728,7 @@ pub(crate) mod tests {
                 cc_exp_month: 10,
                 cc_exp_year: 2025,
                 cc_type: "mastercard".to_string(),
+                custom_label: None,
             },
         )?;
 
@@ -810,6 +827,7 @@ pub(crate) mod tests {
                 cc_exp_month: 5,
                 cc_exp_year: 2024,
                 cc_type: "visa".to_string(),
+                custom_label: None,
             },
         )?;
 

--- a/components/autofill/src/db/models/credit_card.rs
+++ b/components/autofill/src/db/models/credit_card.rs
@@ -17,6 +17,8 @@ pub struct UpdatableCreditCardFields {
     // Credit card types are a fixed set of strings as defined in the link below
     // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
     pub cc_type: String,
+    // Optional user-assigned free-text label.
+    pub custom_label: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -31,6 +33,7 @@ pub struct CreditCard {
     // Credit card types are a fixed set of strings as defined in the link below
     // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
     pub cc_type: String,
+    pub custom_label: Option<String>,
 
     // The metadata
     pub time_created: i64,
@@ -51,6 +54,7 @@ impl From<InternalCreditCard> for CreditCard {
             cc_exp_month: icc.cc_exp_month,
             cc_exp_year: icc.cc_exp_year,
             cc_type: icc.cc_type,
+            custom_label: icc.custom_label,
             // note we can't use u64 in uniffi
             time_created: u64::from(icc.metadata.time_created) as i64,
             time_last_used: if icc.metadata.time_last_used.0 == 0 {
@@ -77,6 +81,7 @@ pub struct InternalCreditCard {
     // Credit card types are a fixed set of strings as defined in the link below
     // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
     pub cc_type: String,
+    pub custom_label: Option<String>,
     pub metadata: Metadata,
 }
 
@@ -90,6 +95,7 @@ impl InternalCreditCard {
             cc_exp_month: row.get("cc_exp_month")?,
             cc_exp_year: row.get("cc_exp_year")?,
             cc_type: row.get("cc_type")?,
+            custom_label: row.get("custom_label")?,
             metadata: Metadata {
                 time_created: row.get("time_created")?,
                 time_last_used: row.get("time_last_used")?,

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -50,6 +50,7 @@ pub const CREDIT_CARD_COMMON_COLS: &str = "
     cc_exp_month,
     cc_exp_year,
     cc_type,
+    custom_label,
     time_created,
     time_last_used,
     time_last_modified,
@@ -63,6 +64,7 @@ pub const CREDIT_CARD_COMMON_VALS: &str = "
     :cc_exp_month,
     :cc_exp_year,
     :cc_type,
+    :custom_label,
     :time_created,
     :time_last_used,
     :time_last_modified,
@@ -76,7 +78,7 @@ pub struct AutofillConnectionInitializer;
 
 impl ConnectionInitializer for AutofillConnectionInitializer {
     const NAME: &'static str = "autofill db";
-    const END_VERSION: u32 = 4;
+    const END_VERSION: u32 = 5;
 
     fn prepare(&self, conn: &Connection, _db_empty: bool) -> Result<()> {
         define_functions(conn)?;
@@ -107,6 +109,7 @@ impl ConnectionInitializer for AutofillConnectionInitializer {
             1 => upgrade_from_v1(db),
             2 => upgrade_from_v2(db),
             3 => upgrade_from_v3(db),
+            4 => upgrade_from_v4(db),
             _ => Err(Error::IncompatibleVersion(version)),
         }
     }
@@ -238,6 +241,12 @@ fn upgrade_from_v3(db: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn upgrade_from_v4(db: &Connection) -> Result<()> {
+    let migration_string: &str = include_str!("../../sql/migrations/v5_migration.sql");
+    db.execute_batch(migration_string)?;
+    Ok(())
+}
+
 pub fn create_empty_sync_temp_tables(db: &Connection) -> Result<()> {
     debug!("Initializing sync temp tables");
     db.execute_batch(CREATE_SYNC_TEMP_TABLES_SQL)?;
@@ -258,6 +267,7 @@ mod tests {
     const CREATE_V1_DB: &str = include_str!("../../sql/tests/create_v1_db.sql");
     const CREATE_V2_DB: &str = include_str!("../../sql/tests/create_v2_db.sql");
     const CREATE_V3_DB: &str = include_str!("../../sql/tests/create_v3_db.sql");
+    const CREATE_V4_DB: &str = include_str!("../../sql/tests/create_v4_db.sql");
 
     #[test]
     fn test_create_schema_twice() {
@@ -407,5 +417,27 @@ mod tests {
         address = get_address(&db, &Guid::new("B")).unwrap();
         assert_eq!(address.guid, "B");
         assert_eq!(address.address_level1, "ON");
+    }
+
+    #[test]
+    fn test_upgrade_version_4() {
+        let db_file = MigratedDatabaseFile::new(AutofillConnectionInitializer, CREATE_V4_DB);
+        let db = db_file.open();
+
+        // custom_label must not exist yet at v4.
+        db.execute_batch("SELECT custom_label FROM credit_cards_data")
+            .expect_err("custom_label should not exist at v4");
+
+        db_file.upgrade_to(5);
+
+        // After upgrading to v5 the column exists, and the existing row has NULL.
+        let label: Option<String> = db
+            .query_row(
+                "SELECT custom_label FROM credit_cards_data WHERE guid = 'A'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("select custom_label should succeed at v5");
+        assert_eq!(label, None);
     }
 }

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -331,6 +331,7 @@ mod tests {
                 cc_exp_month: 10,
                 cc_exp_year: 2025,
                 cc_type: "mastercard".to_string(),
+                custom_label: None,
             })
             .expect("add credit card to database");
 

--- a/components/autofill/src/sync/credit_card/incoming.rs
+++ b/components/autofill/src/sync/credit_card/incoming.rs
@@ -107,6 +107,7 @@ impl ProcessIncomingRecordImpl for IncomingCreditCardsImpl {
             l.cc_exp_month,
             l.cc_exp_year,
             l.cc_type,
+            l.custom_label,
             l.time_created,
             l.time_last_used,
             l.time_last_modified,

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -96,6 +96,11 @@ pub(super) struct PayloadEntry {
     pub cc_exp_month: i64,
     pub cc_exp_year: i64,
     pub cc_type: String,
+    // Optional user-assigned label. Omitted from outgoing payloads when None so
+    // older clients (and the existing v3 schema) round-trip the record without
+    // gaining a meaningless `"custom-label": null` key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_label: Option<String>,
     // metadata (which isn't kebab-case for some historical reason...)
     #[serde(rename = "timeCreated")]
     pub time_created: Timestamp,
@@ -134,6 +139,7 @@ impl InternalCreditCard {
             cc_exp_month: p.entry.cc_exp_month,
             cc_exp_year: p.entry.cc_exp_year,
             cc_type: p.entry.cc_type,
+            custom_label: p.entry.custom_label,
             metadata: Metadata {
                 time_created: p.entry.time_created,
                 time_last_used: p.entry.time_last_used,
@@ -154,6 +160,7 @@ impl InternalCreditCard {
                 cc_exp_month: self.cc_exp_month,
                 cc_exp_year: self.cc_exp_year,
                 cc_type: self.cc_type,
+                custom_label: self.custom_label,
                 time_created: self.metadata.time_created,
                 time_last_used: self.metadata.time_last_used,
                 time_last_modified: self.metadata.time_last_modified,
@@ -209,6 +216,7 @@ impl SyncRecord for InternalCreditCard {
         sync_merge_field_check!(cc_exp_month, incoming, local, mirror, merged_record);
         sync_merge_field_check!(cc_exp_year, incoming, local, mirror, merged_record);
         sync_merge_field_check!(cc_type, incoming, local, mirror, merged_record);
+        sync_merge_field_check!(custom_label, incoming, local, mirror, merged_record);
 
         merged_record.metadata = incoming.metadata;
         merged_record
@@ -267,6 +275,7 @@ fn test_to_from_payload() {
         cc_exp_month: 12,
         cc_exp_year: 2021,
         cc_type: "foo".to_string(),
+        custom_label: Some("Travel".to_string()),
         ..Default::default()
     };
     let encdec = EncryptorDecryptor::new(&key).unwrap();
@@ -278,6 +287,7 @@ fn test_to_from_payload() {
     assert_eq!(payload.entry.cc_exp_month, 12);
     assert_eq!(payload.entry.cc_exp_year, 2021);
     assert_eq!(payload.entry.cc_type, "foo".to_string());
+    assert_eq!(payload.entry.custom_label.as_deref(), Some("Travel"));
 
     // and back.
     let cc2 = InternalCreditCard::from_payload(payload, &encdec).unwrap();
@@ -289,6 +299,7 @@ fn test_to_from_payload() {
     assert_eq!(cc2.cc_exp_month, cc.cc_exp_month);
     assert_eq!(cc2.cc_exp_year, cc.cc_exp_year);
     assert_eq!(cc2.cc_type, cc.cc_type);
+    assert_eq!(cc2.custom_label, cc.custom_label);
     // The decrypted number should be the same.
     assert_eq!(
         crate::encryption::decrypt_string(key, cc2.cc_number_enc.clone()).unwrap(),
@@ -296,4 +307,30 @@ fn test_to_from_payload() {
     );
     // But the encrypted value should not.
     assert_ne!(cc2.cc_number_enc, cc.cc_number_enc);
+}
+
+#[test]
+fn test_payload_omits_none_custom_label() {
+    nss_as::ensure_initialized();
+    let key = crate::encryption::create_autofill_key().unwrap();
+    let cc_number_enc = crate::encryption::encrypt_string(key.clone(), "4111".to_string()).unwrap();
+    // No custom_label set — outgoing payload must not include the kebab-case
+    // key so older clients see a record indistinguishable from the v3 schema.
+    let cc = InternalCreditCard {
+        cc_name: "Shaggy".to_string(),
+        cc_number_enc,
+        cc_number_last_4: "4111".to_string(),
+        cc_exp_month: 12,
+        cc_exp_year: 2021,
+        cc_type: "foo".to_string(),
+        custom_label: None,
+        ..Default::default()
+    };
+    let encdec = EncryptorDecryptor::new(&key).unwrap();
+    let payload = cc.into_payload(&encdec).unwrap();
+    let json = serde_json::to_string(&payload.entry).unwrap();
+    assert!(
+        !json.contains("custom-label"),
+        "outgoing payload should omit custom-label when None, got: {json}"
+    );
 }

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -245,6 +245,7 @@ fn run_add_credit_card(store: &Store, key: &str) -> Result<()> {
         cc_exp_month: prompt_usize("cc_exp_month").unwrap_or_default() as i64,
         cc_exp_year: prompt_usize("cc_exp_year").unwrap_or_default() as i64,
         cc_type: prompt_string("cc_type").unwrap_or_default(),
+        custom_label: None,
     };
     println!("Making `add_credit_card` api call");
     let credit_card = Store::add_credit_card(store, cc_fields)?;
@@ -307,6 +308,7 @@ fn run_update_credit_card(store: &Store, guid: String) -> Result<()> {
         cc_exp_month: update_i64("cc_exp_month", cc.cc_exp_month),
         cc_exp_year: update_i64("cc_exp_year", cc.cc_exp_year),
         cc_type: update_string("cc_type", cc.cc_type),
+        custom_label: None,
     };
 
     println!("Updating credit card");

--- a/testing/sync-test/src/autofill.rs
+++ b/testing/sync-test/src/autofill.rs
@@ -172,6 +172,7 @@ fn test_autofill_credit_cards_general(c0: &mut TestClient, c1: &mut TestClient) 
             cc_exp_month: 3,
             cc_exp_year: 2022,
             cc_type: "visa".to_string(),
+            custom_label: None,
         },
     )
     .expect("add cc1");
@@ -186,15 +187,16 @@ fn test_autofill_credit_cards_general(c0: &mut TestClient, c1: &mut TestClient) 
             cc_exp_month: 10,
             cc_exp_year: 2025,
             cc_type: "mastercard".to_string(),
+            custom_label: None,
         },
     )
     .expect("add cc2");
 
     log::info!("Syncing client0");
-    sync_credit_cards(c0, key.clone()).expect("c0 sync to work");
+    sync_credit_cards(c0, key.clone()).expect("c0 syncÂ to work");
 
     log::info!("Syncing client1");
-    sync_credit_cards(c1, key.clone()).expect("c1 sync to work");
+    sync_credit_cards(c1, key.clone()).expect("c1 syncÂ to work");
 
     log::info!("Check state");
     verify_credit_card(&c1.autofill_store, &cc1, key.clone());
@@ -203,8 +205,8 @@ fn test_autofill_credit_cards_general(c0: &mut TestClient, c1: &mut TestClient) 
     // clear records
     delete_credit_card(&c0.autofill_store, cc1).expect("cc1 to be deleted from c0");
     delete_credit_card(&c0.autofill_store, cc2).expect("cc2 to be deleted from c0");
-    sync_credit_cards(c0, key.clone()).expect("c0 sync to work");
-    sync_credit_cards(c1, key).expect("c1 sync to work");
+    sync_credit_cards(c0, key.clone()).expect("c0 syncÂ to work");
+    sync_credit_cards(c1, key).expect("c1 syncÂ to work");
     verify_credit_card_removal(&c0.autofill_store);
     verify_credit_card_removal(&c1.autofill_store);
 }
@@ -223,6 +225,7 @@ fn test_autofill_credit_cards_with_scrubbed_cards(c0: &mut TestClient, c1: &mut 
             cc_exp_month: 12,
             cc_exp_year: 2027,
             cc_type: "visa".to_string(),
+            custom_label: None,
         },
     )
     .expect("add cc3");
@@ -233,11 +236,11 @@ fn test_autofill_credit_cards_with_scrubbed_cards(c0: &mut TestClient, c1: &mut 
     let _ = scrub_credit_card(c0.autofill_store.clone());
 
     log::info!("Syncing client0");
-    sync_credit_cards(c0, key.clone()).expect("c0 sync to work");
+    sync_credit_cards(c0, key.clone()).expect("c0 syncÂ to work");
 
     // clear records
     delete_credit_card(&c0.autofill_store, cc3.clone()).expect("cc3 to be deleted from c0");
-    sync_credit_cards(c0, key.clone()).expect("c0 sync to work");
+    sync_credit_cards(c0, key.clone()).expect("c0 syncÂ to work");
     verify_credit_card_removal(&c0.autofill_store);
     verify_credit_card_removal(&c1.autofill_store);
 }
@@ -273,10 +276,10 @@ fn test_autofill_addresses_general(c0: &mut TestClient, c1: &mut TestClient) {
     .expect("add a2");
 
     log::info!("Syncing client0");
-    sync_addresses(c0).expect("c0 sync to work");
+    sync_addresses(c0).expect("c0 syncÂ to work");
 
     log::info!("Syncing client1");
-    sync_addresses(c1).expect("c1 sync to work");
+    sync_addresses(c1).expect("c1 syncÂ to work");
 
     log::info!("Check state");
     verify_address(&c1.autofill_store, &a1);
@@ -285,8 +288,8 @@ fn test_autofill_addresses_general(c0: &mut TestClient, c1: &mut TestClient) {
     // clear records
     delete_address(&c0.autofill_store, a1).expect("a1 to be deleted from c0");
     delete_address(&c0.autofill_store, a2).expect("a2 to be deleted from c0");
-    sync_addresses(c0).expect("c0 sync to work");
-    sync_addresses(c1).expect("c1 sync to work");
+    sync_addresses(c0).expect("c0 syncÂ to work");
+    sync_addresses(c1).expect("c1 syncÂ to work");
     verify_address_removal(&c0.autofill_store);
     verify_address_removal(&c1.autofill_store);
 }
@@ -306,6 +309,7 @@ fn test_undecryptable_record_prevents_syncing(c0: &mut TestClient, c1: &mut Test
             cc_exp_month: 10,
             cc_exp_year: 2025,
             cc_type: "mastercard".to_string(),
+            custom_label: None,
         },
     )
     .expect("add credit_card0");
@@ -353,6 +357,7 @@ fn test_scrub_undecryptable_records_for_remote_replacement(
             cc_exp_month: 10,
             cc_exp_year: 2025,
             cc_type: "mastercard".to_string(),
+            custom_label: None,
         },
     )
     .expect("add credit_card0 to c0");


### PR DESCRIPTION
### Pull Request checklist ###

- **Breaking changes**: This PR follows the breaking change policy.
  - [x] No breaking API changes. The UniFFI `custom_label` field defaults to `null`, so existing Swift/Kotlin call sites that construct `UpdatableCreditCardFields` or destructure `CreditCard` continue to compile unchanged. The sync payload stays at `version: 3` and omits the new key when unset, so older clients see records unchanged.
- [x] **Quality**: Building locally is blocked on this branch (Windows host without WSL/NSS toolchain), so I'm opening as draft to let CI verify. `cargo fmt --check -p autofill` is clean, and the v3→v4→v5 SQL upgrade chain has been validated against sqlite directly.
- [x] **Tests**:
  - `test_upgrade_version_4` (new) — verifies the v4→v5 ALTER adds the column and existing rows get NULL.
  - `test_to_from_payload` (extended) — round-trips a non-empty `custom_label` through `into_payload` / `from_payload`.
  - `test_payload_omits_none_custom_label` (new) — asserts the serialized JSON omits the `custom-label` key when unset, so outgoing records from non-labelling clients are bit-identical to v3.

  Existing CRUD/sync tests automatically exercise the new field via `..Default::default()` or explicit `custom_label: None`.
- [x] **Changelog**: Entry added under v153.0 *What's New / Autofill*.
- [x] **Dependencies**: No new dependencies.

---

### Why this change

Firefox desktop has had a long-standing request ([bug 1443042 — Labels for Credit Cards](https://bugzilla.mozilla.org/show_bug.cgi?id=1443042), filed 2018, duped against again in 2026) to let users assign a free-text label to a saved credit card so it's identifiable in autocomplete and management UI beyond just `**** 1234 / cardholder`.

A revival of that work ([D283460](https://phabricator.services.mozilla.com/D283460)) was blocked on the desktop side because cards are migrating from `autofill-profiles.json` to this crate, and adding the field only to the JSON store meant migrating it again later.

Landing the field here first puts the schema and Sync story in the right place so that:
- Desktop's JSON-store version of the field can land downstream and carry over cleanly when cards move to the AS-backed `CreditCardStorage.sys.mjs` (parallel to the in-flight passport work in [Bug 2044946](https://bugzilla.mozilla.org/show_bug.cgi?id=2044946)).
- Fenix and Firefox iOS pick the field up automatically through their existing UniFFI bindings and only need UI + string work to surface it.
- Sync stays consistent across all three platforms from day one.

### Open question for review

Payload `version` stays at 3 here. The serde attribute (`skip_serializing_if = "Option::is_none"`) plus the existing `unknown_fields` flatten handle backward/forward compat without a bump, matching the precedent of other optional additions. Happy to bump to 4 if the sync team would prefer the explicit signal.