### PR TITLE
Bug 2046584 - Remove getPreviousGeckoPrefStates from public NimbusClient API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Nimbus
 
 - Enrollment change events (visible to the UDL) now include the feature IDs of the features involved when possible. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
-
+- Removed NimbusInterface.getPreviousGeckoPrefsState since it is unimplemented and the underlying SDK method is only used by tests. ([#7412](https://github.com/mozilla/application-services/pull/7412/))
 ## 🔧 What's Fixed 🔧
 
 ### Logins

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -209,16 +209,6 @@ interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusE
     ) = Unit
 
     /**
-     * Retrieves a list of previous states, if available, on an enrolled experiment, from a given slug.
-     *
-     * @param experimentSlug The slug of the experiment.
-     * @return The previous Gecko pref states of the given slug. Will return null if not available or invalid slug.
-     */
-    fun getPreviousGeckoPrefStates(
-        experimentSlug: String,
-    ): List<PreviousGeckoPrefState>? = null
-
-    /**
      *  Reset internal state in response to application-level telemetry reset.
      *  Consumers should call this method when the user resets the telemetry state of the
      *  consuming application, such as by opting out of (or in to) submitting telemetry.


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
