### PR TITLE
viaduct: Use `ViaductUrl` consistently

### DIFF
--- a/components/viaduct/src/lib.rs
+++ b/components/viaduct/src/lib.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for Method {
 #[derive(Clone, uniffi::Record)]
 pub struct Request {
     pub method: Method,
-    pub url: Url,
+    pub url: ViaductUrl,
     pub headers: Headers,
     pub body: Option<Vec<u8>>,
 }
@@ -258,7 +258,7 @@ pub struct Response {
     /// The method used to request this response.
     pub request_method: Method,
     /// The URL of this response.
-    pub url: Url,
+    pub url: ViaductUrl,
     /// The HTTP Status code of this response.
     pub status: u16,
     /// The headers returned with this response.


### PR DESCRIPTION
I'm working on a new UniFFI parser
(https://github.com/mozilla/uniffi-rs/pull/2841) and it currently requires that the type name in exported functions match the one used in the `custom_type!` macro.

I could probably rework the parser to handle the type alias, but this way feels cleaner to me anyways.  Feel free to push back if you don't like this change though.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
