### PR TITLE
tabs/tracing-support: Refactorings for `uniffi_parse_rs`

### DIFF
--- a/components/support/tracing/src/layer.rs
+++ b/components/support/tracing/src/layer.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{
     Layer,
 };
 
-use crate::{EventSink, Level};
+use crate::{EventSink, TracingLevel};
 use tracing::field::{Field, Visit};
 
 static SINKS: RwLock<Vec<RegisteredEventSink>> = const_rwlock(Vec::new());
@@ -52,13 +52,13 @@ pub struct EventSinkSpecification {
     pub targets: Vec<EventTarget>,
     // Send events have a `min_level` or above.
     #[uniffi(default)]
-    pub min_level: Option<Level>,
+    pub min_level: Option<TracingLevel>,
 }
 
 #[derive(uniffi::Record, Debug)]
 pub struct EventTarget {
     pub target: String,
-    pub level: Level,
+    pub level: TracingLevel,
 }
 
 #[uniffi::export]
@@ -124,7 +124,7 @@ fn find_sinks_for_event(event: &tracing::Event<'_>) -> Vec<Arc<dyn EventSink>> {
         Some(index) => &target[..index],
         None => target,
     };
-    let level = Level::from(*event.metadata().level());
+    let level = TracingLevel::from(*event.metadata().level());
 
     // This requires a iterating through the entire SINKS vec, which could have performance impacts
     // if we have many sinks registered.  In practice, there should only be a handful of these so

--- a/components/support/tracing/src/lib.rs
+++ b/components/support/tracing/src/lib.rs
@@ -12,8 +12,8 @@ pub use filters::{
 };
 
 pub use layer::{
-    register_event_sink, simple_event_layer, unregister_event_sink, EventSinkId,
-    EventSinkSpecification, EventTarget,
+    register_event_sink, register_event_sink_box, simple_event_layer, unregister_event_sink,
+    EventSinkId, EventSinkSpecification, EventTarget,
 };
 // Re-export tracing so that our dependencies can use it.
 pub use tracing;
@@ -152,7 +152,7 @@ pub struct TracingEvent {
     pub target: String,
     pub name: String,
     pub message: String,
-    pub fields: serde_json::Value,
+    pub fields: TracingJsonValue,
 }
 
 #[uniffi::export(callback_interface)]

--- a/components/tabs/src/lib.rs
+++ b/components/tabs/src/lib.rs
@@ -30,7 +30,9 @@ uniffi::custom_type!(TabsGuid, String, {
     lower: |obj| obj.into(),
 });
 
-pub use crate::storage::{ClientRemoteTabs, LocalTabsInfo, RemoteTabRecord, TabsDeviceType};
+pub use crate::storage::{
+    ClientRemoteTabs, LocalTabsInfo, RemoteTabRecord, TabGroup, TabsDeviceType, Window, WindowType,
+};
 pub use crate::store::{RemoteCommandStore, TabsStore};
 pub use error::{ApiResult, Error, Result, TabsApiError};
 use sync15::DeviceType;


### PR DESCRIPTION
I'm working on a new UniFFI parser
(https://github.com/mozilla/uniffi-rs/pull/2841) and it currently has a couple extra requirements for types used in exported functions:

 * The types are publicly available from other crates.
 * The name matches the one used in the `custom_type!` macro.

I could maybe rework the parser to avoid these requirements, but the changes feel like improvements to me.  Please push back if you don't think so.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
