### PR TITLE
search: ensure API types are public

### DIFF
--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 /// The list of possible submission methods for search engine urls.
 #[derive(Debug, uniffi::Enum, PartialEq, Deserialize, Clone, Default)]
 #[serde(rename_all = "UPPERCASE")]
-pub(crate) enum JSONEngineMethod {
+pub enum JSONEngineMethod {
     Post = 2,
     #[serde(other)]
     #[default]
@@ -36,7 +36,7 @@ impl JSONEngineMethod {
 /// configuration.
 #[derive(Debug, uniffi::Record, PartialEq, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct JSONEngineUrl {
+pub struct JSONEngineUrl {
     /// The PrePath and FilePath of the URL. May include variables for engines
     /// which have a variable FilePath, e.g. `{searchTerms}` for when a search
     /// term is within the path of the url.

--- a/components/search/src/lib.rs
+++ b/components/search/src/lib.rs
@@ -13,7 +13,7 @@ pub use error::SearchApiError;
 pub mod selector;
 pub mod types;
 
-pub(crate) use crate::configuration_types::*;
+pub use crate::configuration_types::*;
 pub use crate::types::*;
 pub use selector::SearchEngineSelector;
 pub type SearchApiResult<T> = std::result::Result<T, error::SearchApiError>;


### PR DESCRIPTION
I'm working on a new UniFFI parser
(https://github.com/mozilla/uniffi-rs/pull/2841) and it currently requires that types used in the exported functions are publicly available from other crates.

I could maybe rework the parser to handle this another way, but this feels cleaner to me anyways.  It feels weird if a type can be used by foreign languages but not other Rust crates.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
