### PR TITLE
relay: ensure API types are public

### DIFF
--- a/components/relay/src/lib.rs
+++ b/components/relay/src/lib.rs
@@ -9,6 +9,7 @@ uniffi::setup_scaffolding!("relay");
 
 pub use error::{ApiResult, Error, RelayApiError, Result};
 use error_support::handle_error;
+pub use rs::RelayRemoteSettingsClient;
 
 use serde::{Deserialize, Serialize};
 use url::Url;


### PR DESCRIPTION
I'm working on a new UniFFI parser
(https://github.com/mozilla/uniffi-rs/pull/2841) and it currently requires that types used in the exported functions are publicly available from other crates.

I could maybe rework the parser to handle this another way, but this feels cleaner to me anyways.  It feels weird if a type can be used by foreign languages but not other Rust crates.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
