### PR TITLE
Bug 2048052 - Remove setExperimentsLocally from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Enrollment change events (visible to the UDL) now include the feature IDs of the features involved when possible. ([#7391](https://github.com/mozilla/application-services/pull/7391/))
 - Removed NimbusInterface.getPreviousGeckoPrefsState since it is unimplemented and the underlying SDK method is only used by tests. ([#7412](https://github.com/mozilla/application-services/pull/7412/))
+- `setExperimentsLocally()` is no longer exposed by NimbusInterface. ([#7426](https://bugzilla.mozilla.org/show_bug.cgi?id=2048051))
+
 ## 🔧 What's Fixed 🔧
 
 ### Logins

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/ArgumentProcessor.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/ArgumentProcessor.kt
@@ -37,10 +37,8 @@ fun NimbusInterface.initializeTooling(context: Context, intent: Intent) {
     }
 
     args.experiments?.let { experiments ->
-        setExperimentsLocally(experiments)
-        val job = applyPendingExperiments()
         runBlocking {
-            job.join()
+            applyLocalExperiments(experiments).join()
         }
         setFetchEnabled(false)
     }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -369,10 +369,10 @@ open class Nimbus(
         applyLocalExperiments { loadRawResource(file) }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun applyLocalExperiments(getString: suspend () -> String): Job =
+    internal fun applyLocalExperiments(readExperiments: suspend () -> String): Job =
         dbScope.launch {
             val payload = try {
-                getString()
+                readExperiments()
             } catch (e: CancellationException) {
                 // TODO consider reporting a glean event here.
                 logger(e.stackTraceToString())
@@ -381,15 +381,26 @@ open class Nimbus(
                 logger(e.stackTraceToString())
                 null
             }
-            withContext(NonCancellable) {
-                if (payload != null) {
-                    setExperimentsLocallyOnThisThread(payload)
-                    applyPendingExperimentsOnThisThread()
-                } else {
-                    initializeOnThisThread()
-                }
+
+            applyLocalExperimentsOnThisThread(payload)
+        }
+
+    override fun applyLocalExperiments(experimentsJson: String): Job {
+        return dbScope.launch {
+            applyLocalExperimentsOnThisThread(experimentsJson)
+        }
+    }
+
+    internal suspend fun applyLocalExperimentsOnThisThread(experimentsJson: String?) {
+        withContext(NonCancellable) {
+            if (experimentsJson != null) {
+                setExperimentsLocallyOnThisThread(experimentsJson)
+                applyPendingExperimentsOnThisThread()
+            } else {
+                initializeOnThisThread()
             }
         }
+    }
 
     @WorkerThread
     private fun postEnrolmentCalculation(initial: Boolean = false) {
@@ -412,28 +423,10 @@ open class Nimbus(
         }
     }
 
-    override fun setExperimentsLocally(
-        @RawRes file: Int,
-    ) {
-        dbScope.launch {
-            withCatchAll("setExperimentsLocally") {
-                loadRawResource(file)
-            }?.let { payload ->
-                setExperimentsLocallyOnThisThread(payload)
-            }
-        }
-    }
-
     private fun loadRawResource(file: Int): String =
         context.resources.openRawResource(file).use {
             it.bufferedReader().readText()
         }
-
-    override fun setExperimentsLocally(payload: String) {
-        dbScope.launch {
-            setExperimentsLocallyOnThisThread(payload)
-        }
-    }
 
     @WorkerThread
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -133,25 +133,17 @@ interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusE
     fun applyPendingExperiments(): Job = Job()
 
     /**
-     * Set the experiments as the passed string, just as `fetchExperiments` gets the string from
-     * the server. Like `fetchExperiments`, this requires `applyPendingExperiments` to be called
-     * before enrolments are affected.
+     * Apply the set of local experiments.
      *
-     * The string should be in the same JSON format that is delivered from the server.
+     * The format of the file should be in the same JSON format that is
+     * delivered from the Remote Settings API.
      *
-     * This is performed on a background thread.
-     */
-    fun setExperimentsLocally(payload: String) = Unit
-
-    /**
-     * This is functionally equivalent to a sequence of {setExperimentsLocally} the
-     * {applyPendingExperiments}.
+     * The work will be performed on a background thread.
      *
      * Following completion of the returned job, the SDK's Feature API is ready to be used. If
      * cancelled, the SDK will still prepare the SDK for safe use.
      *
-     * Most apps will not need to call this method directly, as it is called on first run
-     * as part of {initialize}.
+     * Most apps will not need to call this method directly.
      *
      * @param a `raw` resource identifier resolving to a JSON file downloaded from RemoteSettings
      *       at build time.
@@ -164,11 +156,20 @@ interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusE
     ): Job = Job()
 
     /**
-     * A utility method to load a file from resources and pass it to `setExperimentsLocally(String)`.
+     * Apply the set of local experiments.
+     *
+     * The format of the file should be in the same JSON format that is
+     * delivered from the Remote Settings API.
+     *
+     * The work will be performed on a background thread.
+     *
+     * NB: This function is only exposed for usage by the Nimbus CLI. Callers
+     * should prefer `applyLocalExperiments` with a file resource instead.
+     *
+     * @param The experiments JSON, as returned by Remote Settings.
+     * @return A Job. It cannot be cancelled.
      */
-    fun setExperimentsLocally(
-        @RawRes file: Int,
-    ) = Unit
+    fun applyLocalExperiments(experimentsJson: String): Job = Job()
 
     /**
      * Testing method to reset the enrollments and experiments database back to its initial state.


### PR DESCRIPTION
The `setExperimentsLocally()` public API is a foot gun in that it always needs to be followed by a call to `applyPendingExperiments()`. It seems like it was only exposed to allow `nimbus-cli` to set the list of experiments.

There is an existing `applyLocalExperiments()` method that is the combination of `setExperimentsLocally()` and
`applyPendingExperiments()`, but it only accepts a raw file resource ID. This patch adds an override that accepts the experiment JSON as a string to allow `nimbus-cli` to continue settings the list of experiments.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
