### PR TITLE
Use proguard-android-optimize.txt for the default ProGuard rules

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             consumerProguardFiles "$appServicesRootDir/proguard-rules-consumer-jna.pro"
         }
     }

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -21,7 +21,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
         }
     }


### PR DESCRIPTION
AGP 9 disallows the non-optimized `proguard-android.txt` file (`android.r8.proguardAndroidTxt.disallowed=true` by default), so its `getDefaultProguardFile('proguard-android.txt')` call will fail at the eventual AGP 9 bump. Switching to `proguard-android-optimize.txt` is the AGP 9-supported replacement and is **behavior-neutral here** because both touched modules set `minifyEnabled = false` on the release build type, so ProGuard/R8 does not run today.

This is the application-services parallel to the Firefox-side change already landed as [Bug 2046159](https://bugzilla.mozilla.org/show_bug.cgi?id=2046159) (mozilla-firefox/firefox D305683), filed ahead of time so the eventual app-services AGP 9 bump is one less thing to fix.

Build remains on AGP 8.13.2; this is 8.13-compatible prep with no flag debt.

## Test plan
- [x] `./gradlew :full-megazord:help` configures clean (no resolution / proguard-file errors)
- [ ] CI: existing pipeline runs (no minification path is exercised since `minifyEnabled = false`, so the swap cannot regress anything that is exercised today)