### PR TITLE
Migrate trivial libraryVariants call sites to androidComponents.onVariants

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -91,13 +91,6 @@ ext.dependsOnTheMegazord = {
         megazordNative project("path": ":full-megazord", "configuration": "megazordNative")
         implementation project("path": ":full-megazord", "configuration": "libsForTests")
     }
-
-    afterEvaluate {
-        android.libraryVariants.all { variant ->
-            def variantName = variant.name.capitalize();
-            def testTask = tasks["test${variantName}UnitTest"]
-        }
-    }
 }
 
 // Shared logic for projects that use UniFFI-generated bindings

--- a/build.gradle
+++ b/build.gradle
@@ -170,9 +170,10 @@ if (useDownloadedLibs) {
     }
 
     subprojects { project ->
-        afterEvaluate {
-            android.libraryVariants.all { v ->
-                v.preBuildProvider.configure {
+        project.pluginManager.withPlugin("com.android.library") {
+            def androidComponents = project.extensions.getByName("androidComponents")
+            androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+                project.tasks.named("pre${variant.name.capitalize()}Build").configure {
                     dependsOn(rootProject.untarAndroidLibs)
                     dependsOn(rootProject.untarDesktopLibs)
                 }

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -135,16 +135,11 @@ if (!gradle.hasProperty("mozconfig")) {
     }
 }
 
-afterEvaluate {
-    // The `cargoBuild` task isn't available until after evaluation.
-    android.libraryVariants.all { variant ->
-        def productFlavor = ""
-        variant.productFlavors.each {
-            productFlavor += "${it.name.capitalize()}"
-        }
-        if (!gradle.hasProperty("mozconfig")) {
-            def buildType = "${variant.buildType.name.capitalize()}"
-            tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
+if (!gradle.hasProperty("mozconfig")) {
+    androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+        // The `cargoBuild` task isn't available until after evaluation.
+        afterEvaluate {
+            tasks["merge${variant.name.capitalize()}JniLibFolders"].dependsOn(tasks["cargoBuild"])
         }
     }
 }


### PR DESCRIPTION
## Summary

Partial migration off the legacy `android.libraryVariants` API ahead of AGP 9 (which removes it). This PR covers the three mechanical call sites:

- `build.gradle` - subproject `untarAndroidLibs` / `untarDesktopLibs` pre-build wiring
- `build-scripts/component-common.gradle` - dropped a dead `afterEvaluate` block that resolved a `test${variantName}UnitTest` reference without using it
- `megazords/full/android/build.gradle` - `mergeJniLibFolders -> cargoBuild` wiring

Net: +9 / -20.

## Not in this PR

The UniFFI bindings generation hook in `build-scripts/component-common.gradle` (`registerJavaGeneratingTask`) is also still on the legacy API, but migrating it requires a more invasive rework (convert `generateUniffiBindings` to a typed `DefaultTask` with a wired `@OutputDirectory DirectoryProperty`, then register via `variant.sources.java.addGeneratedSourceDirectory(...)`). It will follow in a separate PR.

## Test plan

- [x] `./gradlew assembleDebug --no-daemon` green locally (BUILD SUCCESSFUL in 2m 57s, 650 actionable tasks)