### PR TITLE
Migrate UniFFI bindings generation off libraryVariants to androidComponents.onVariants

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -7,9 +7,64 @@
 // apply from: "$rootDir/build-scripts/component-common.gradle"
 // ```
 
+import javax.inject.Inject
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+
+// Typed Exec subclass used in the moz-central build, where the embedded
+// uniffi-bindgen tool and the native megazord library are already built before
+// gradle runs. Exposes outputDir as a DirectoryProperty so the generated
+// sources can be wired into the variant via addGeneratedSourceDirectory.
+abstract class GenerateUniffiBindingsEmbedded extends Exec {
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+}
+
+// Typed task used in the standalone app-services build, where the megazord
+// dynamic library is produced by a separate gradle task and only exists when
+// generateUniffiBindings runs (not at configuration time).
+abstract class GenerateUniffiBindingsCargo extends DefaultTask {
+    @InputFiles
+    abstract ConfigurableFileCollection getMegazordNativeFiles()
+
+    @InputDirectory
+    abstract DirectoryProperty getBindgenToolDir()
+
+    @Input
+    abstract Property<String> getCrateName()
+
+    @Input
+    abstract Property<String> getNativeRustTarget()
+
+    @Internal
+    abstract DirectoryProperty getWorkingDirectory()
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+
+    @Inject
+    abstract ExecOperations getExecOperations()
+
+    @TaskAction
+    void run() {
+        def libraryPath = megazordNativeFiles.asFileTree.matching {
+            include "${nativeRustTarget.get()}/libmegazord.*"
+        }.singleFile
+
+        if (libraryPath == null) {
+            throw new GradleException("libmegazord dynamic library path not found")
+        }
+
+        execOperations.exec {
+            workingDir workingDirectory.get().asFile
+            commandLine '/usr/bin/env', 'cargo', 'uniffi-bindgen', 'generate',
+                    '--crate', crateName.get(), '--language', 'kotlin',
+                    '--out-dir', outputDir.get().asFile,
+                    '--no-format', libraryPath
+        }
+    }
+}
 
 android {
     compileSdk { version = release(config.compileSdkMajorVersion) { minorApiLevel = config.compileSdkMinorVersion } }
@@ -100,62 +155,41 @@ ext.configureUniFFIBindgen = { crateName ->
     // This will store the uniffi-bindgen generated files for our component
     def uniffiOutDir = layout.buildDirectory.dir("generated/uniffi/")
 
-    android {
-        sourceSets.main.kotlin.srcDirs += uniffiOutDir
-    }
-
     def generateUniffiBindings
     // Call `uniffi-bindgen` to generate the Kotlin bindings
     if (gradle.hasProperty("mozconfig")) {
         // in moz-central we can use an `Exec` task because we can assume the bindgen tool has already been built.
-        generateUniffiBindings = tasks.register("generateUniffiBindings", Exec) {
+        generateUniffiBindings = tasks.register("generateUniffiBindings", GenerateUniffiBindingsEmbedded) {
             def libraryPath = "${gradle.mozconfig.topobjdir}/dist/bin/libmegazord.so"
             def bindgen = gradle.ext.mozconfig.substs.EMBEDDED_UNIFFI_BINDGEN
 
+            outputDir.set(uniffiOutDir)
+
             workingDir project.rootDir
             commandLine bindgen
-            args 'generate', "--crate", crateName, '--language', 'kotlin', '--out-dir', uniffiOutDir.get(), '--no-format', libraryPath
+            args 'generate', "--crate", crateName, '--language', 'kotlin', '--out-dir', outputDir.get().asFile, '--no-format', libraryPath
 
-            outputs.dir uniffiOutDir
             // Re-generate when the native megazord library is rebuilt
             inputs.files libraryPath
             // Re-generate if our uniffi-bindgen tooling changes.
             inputs.files bindgen
         }
     } else {
-        // In app-services we can't use `Exec` because the megazord target isn't built yet, which we force via `doFirst`
-        generateUniffiBindings = tasks.register("generateUniffiBindings") {
-            def megazordNative = configurations.getByName("megazordNative")
-            doFirst {
-                def libraryPath = megazordNative.asFileTree.matching {
-                    include "${nativeRustTarget}/libmegazord.*"
-                }.singleFile
-
-                if (libraryPath == null) {
-                    throw new GradleException("libmegazord dynamic library path not found")
-                }
-                exec {
-                    workingDir project.rootDir
-                    commandLine '/usr/bin/env', 'cargo', 'uniffi-bindgen', 'generate', "--crate", crateName, '--language', 'kotlin', '--out-dir', uniffiOutDir.get(), '--no-format', libraryPath
-                }
-            }
-
-            outputs.dir uniffiOutDir
-            // Re-generate when the native megazord library is rebuilt
-            inputs.files megazordNative
-            // Re-generate if our uniffi-bindgen tooling changes.
-            inputs.dir "${project.appServicesRootDir}/tools/embedded-uniffi-bindgen/"
+        // In app-services we can't use `Exec` because the megazord target isn't built yet; the task
+        // resolves the library path from the megazordNative configuration when it runs.
+        generateUniffiBindings = tasks.register("generateUniffiBindings", GenerateUniffiBindingsCargo) {
+            // Qualify every property with `it.` because the `crateName` closure parameter shadows the
+            // task's crateName property; a bare `crateName.set(...)` would target the String, not the task.
+            it.megazordNativeFiles.from configurations.getByName("megazordNative")
+            it.bindgenToolDir.set(file("${project.appServicesRootDir}/tools/embedded-uniffi-bindgen/"))
+            it.crateName.set(crateName)
+            it.nativeRustTarget.set(rootProject.ext.nativeRustTarget)
+            it.workingDirectory.set(project.rootDir)
+            it.outputDir.set(uniffiOutDir)
         }
     }
 
-    afterEvaluate {
-        def megazordNative = configurations.getByName("megazordNative")
-        android.libraryVariants.all { variant ->
-            def compileTask = tasks["compile${variant.name.capitalize()}Kotlin"]
-            compileTask.dependsOn(generateUniffiBindings)
-            if (!gradle.hasProperty("mozconfig")) {
-                variant.registerJavaGeneratingTask(generateUniffiBindings, megazordNative.singleFile)
-            }
-        }
+    androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+        variant.sources.java.addGeneratedSourceDirectory(generateUniffiBindings) { it.outputDir }
     }
 }


### PR DESCRIPTION
## Summary

Completes the migration off the legacy `android.libraryVariants` API ahead of AGP 9 (which removes it). #7429 covered the trivial call sites; this handles the last one, the UniFFI bindings generation hook in `build-scripts/component-common.gradle`, which used `registerJavaGeneratingTask` plus a manual `sourceSets.main.kotlin.srcDirs` addition.

Changes:

- Convert `generateUniffiBindings` to typed task classes (`GenerateUniffiBindingsEmbedded extends Exec` for the moz-central case, `GenerateUniffiBindingsCargo extends DefaultTask` for the standalone case) with a wired `@OutputDirectory`.
- Register the generated source dir via `variant.sources.java.addGeneratedSourceDirectory(...)`, which wires both the source path and the task dependency.
- Drop the legacy `sourceSets.main.kotlin.srcDirs`, the explicit `compileKotlin.dependsOn`, and `registerJavaGeneratingTask`.

The directory is registered as `sources.java` (not `sources.kotlin`) because AGP wires generated java dirs into both javac and kotlinc, while `sources.kotlin` is only consumed by AGP's built-in Kotlin, not the external Kotlin plugin this build uses.

With this, there are no remaining `libraryVariants` / `registerJavaGeneratingTask` usages in the repo.

## Verification

- CI-equivalent `./gradlew clean assembleDebug testDebug` is green; the generation tasks run cold, the generated bindings compile, and the unit tests exercising them pass.
- The moz-central (`mozconfig`) branch is not exercised by a standalone build; it is structurally consistent with the standalone path (both resolve the output to the same directory) but should be confirmed when AGP 9 is exercised in mozilla-central.