### PR TITLE
Bug 2047565 - Update to Glean v69.0.0 (iOS only)

### DIFF
--- a/megazords/ios-rust/Package.resolved
+++ b/megazords/ios-rust/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "e3d12488af5c6fb56de9ddf11c8c4c032a386b49",
-        "version" : "68.0.0"
+        "revision" : "afd55ed0bea2aeefc1394f06ab02ad3c6d9178dc",
+        "version" : "69.0.0"
       }
     }
   ],

--- a/megazords/ios-rust/Package.swift
+++ b/megazords/ios-rust/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "MozillaRustComponents", targets: ["MozillaRustComponentsWrapper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mozilla/glean-swift", from: "68.0.0"),
+        .package(url: "https://github.com/mozilla/glean-swift", from: "69.0.0"),
     ],
     targets: [
         // Binary target XCFramework, contains our rust binaries and headers


### PR DESCRIPTION
We're deploying Glean v69.0.0 on iOS first and for that we need to update it in appservices too.

Note for compatibility: the generated code is source-compatible. That's why appservices can be on 68 for Android and 69 for iOS.