### PR TITLE
refactor(ads-client): telemetry callback interface

### DIFF
--- a/components/ads-client/src/ffi.rs
+++ b/components/ads-client/src/ffi.rs
@@ -157,8 +157,8 @@ impl MozAdsClientBuilder {
         self
     }
 
-    pub fn telemetry(self: Arc<Self>, telemetry: Arc<dyn MozAdsTelemetry>) -> Arc<Self> {
-        self.0.lock().telemetry = Some(telemetry);
+    pub fn telemetry(self: Arc<Self>, telemetry: Box<dyn MozAdsTelemetry>) -> Arc<Self> {
+        self.0.lock().telemetry = Some(Arc::from(telemetry));
         self
     }
 }

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -12,7 +12,7 @@ use crate::http_cache::{CacheOutcome, HttpCacheBuilderError};
 use crate::mars::error::{RecordClickError, RecordImpressionError, ReportAdError};
 use crate::telemetry::Telemetry;
 
-#[uniffi::export(with_foreign)]
+#[uniffi::export(callback_interface)]
 pub trait MozAdsTelemetry: Send + Sync {
     fn record_build_cache_error(&self, label: String, value: String);
     fn record_client_error(&self, label: String, value: String);


### PR DESCRIPTION
Revives #7407, rebased on the latest `main`.

`MozAdsTelemetry` is always implemented by the foreign side (JS/Kotlin/Swift) and is only ever passed from foreign code to Rust — never the other way around. `callback_interface` is the correct semantic for this pattern and enables the geckojs `uniffi-bindgen-gecko-js` pipeline to generate FireAndForget vtable handlers, avoiding a deadlock where Rust calls telemetry methods synchronously from within a `callSync` on the JS main thread.

The builder's `telemetry()` argument changes from `Arc<dyn MozAdsTelemetry>` to `Box<dyn MozAdsTelemetry>` accordingly.

### Pull Request checklist ###
- [x] **Quality**: This PR builds and tests run cleanly (`cargo test -p ads-client`: 88 passed)
- [x] **Tests**: Covered by existing ads-client tests; this is a binding-semantics change with no behavioral difference on the Rust side.
- [ ] **Changelog**: No changelog entry — internal binding refactor.