### PR TITLE
Re-enable glean-sym - now with the proper release tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 [[package]]
 name = "glean-build"
 version = "20.0.0"
-source = "git+https://github.com/mozilla/glean?rev=3b00f26c4814a47044c6736563ee7589dfa3b399#3b00f26c4814a47044c6736563ee7589dfa3b399"
+source = "git+https://github.com/mozilla/glean?tag=v68.0.0#3b00f26c4814a47044c6736563ee7589dfa3b399"
 dependencies = [
  "xshell-venv",
 ]
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "glean-sym"
 version = "0.1.0"
-source = "git+https://github.com/mozilla/glean?rev=a16cb6034dc2c37ba62eae85f6304c637e53b2ae#a16cb6034dc2c37ba62eae85f6304c637e53b2ae"
+source = "git+https://github.com/mozilla/glean?tag=v68.0.0#3b00f26c4814a47044c6736563ee7589dfa3b399"
 dependencies = [
  "libloading",
  "once_cell",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -59,6 +59,7 @@ The following text applies to code linked from these dependencies:
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
 [glean-build](https://github.com/mozilla/glean),
+[glean-sym](https://github.com/mozilla/glean),
 [hawk](https://github.com/taskcluster/rust-hawk),
 [jexl-eval](https://github.com/mozilla/jexl-rs),
 [jexl-parser](https://github.com/mozilla/jexl-rs),

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 exclude = ["/android", "/ios"]
 
 [features]
-default = []
+default = ["glean-sym"]
 # Enable metric recording through glean-sym (Android only)
 glean-sym = ["dep:glean-sym"]
 
@@ -34,7 +34,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 thiserror = "2"
 anyhow = "1.0"
 uniffi = { version = "0.31" }
-glean-sym = { git = "https://github.com/mozilla/glean", rev = "a16cb6034dc2c37ba62eae85f6304c637e53b2ae", optional = true }
+glean-sym = { git = "https://github.com/mozilla/glean", tag = "v68.0.0", optional = true }
 
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }
@@ -43,4 +43,4 @@ sql-support = { path = "../support/sql" }
 
 [build-dependencies]
 uniffi = { version = "0.31", features=["build"]}
-glean-build = { git = "https://github.com/mozilla/glean", rev = "3b00f26c4814a47044c6736563ee7589dfa3b399" }
+glean-build = { git = "https://github.com/mozilla/glean", tag = "v68.0.0" }

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -44,6 +44,7 @@ The following text applies to code linked from these dependencies:
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
 [glean-build](https://github.com/mozilla/glean),
+[glean-sym](https://github.com/mozilla/glean),
 [hawk](https://github.com/taskcluster/rust-hawk),
 [jexl-eval](https://github.com/mozilla/jexl-rs),
 [jexl-parser](https://github.com/mozilla/jexl-rs),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -21,6 +21,10 @@ the details of which are reproduced below.
     <url>https://github.com/mozilla/glean/blob/main/LICENSE</url>
   </license>
   <license>
+    <name>Mozilla Public License 2.0: glean-sym</name>
+    <url>https://github.com/mozilla/glean/blob/main/LICENSE</url>
+  </license>
+  <license>
     <name>Mozilla Public License 2.0: hawk</name>
     <url>https://github.com/taskcluster/rust-hawk/blob/main/LICENSE</url>
   </license>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -54,6 +54,7 @@ The following text applies to code linked from these dependencies:
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
 [glean-build](https://github.com/mozilla/glean),
+[glean-sym](https://github.com/mozilla/glean),
 [hawk](https://github.com/taskcluster/rust-hawk),
 [jexl-eval](https://github.com/mozilla/jexl-rs),
 [jexl-parser](https://github.com/mozilla/jexl-rs),


### PR DESCRIPTION
In the previous change we updated the revision of `glean-build`, but NOT that of `glean-sym`.
Which then of course was the older version, not Glean v68.0.0, which the rest of the code used and which is in m-c.
That breaks now that we do proper checks and panic if those fail. Which eventually shows up as a crash in some other place.

By using the version tag in both places it's easy to observe if there's a difference (and the lock file has the exact revision)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
