### PR TITLE
Don't panic when the same backend is set multiple times [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@
 - Removed NimbusInterface.getPreviousGeckoPrefsState since it is unimplemented and the underlying SDK method is only used by tests. ([#7412](https://github.com/mozilla/application-services/pull/7412/))
 - `setExperimentsLocally()` is no longer exposed by NimbusInterface. ([#7426](https://bugzilla.mozilla.org/show_bug.cgi?id=2048051))
 
+### Viaduct
+- init_backend and `viaduct_init_backend_hyper` no longer throw an error if they're called multiple times.
+  Instead, we report the error via the Rust components error ping.
+  This is a breaking change for iOS, since the functions no longer throw.
+
 ## 🔧 What's Fixed 🔧
 
 ### Logins

--- a/components/ads-client/integration-tests/tests/mars.rs
+++ b/components/ads-client/integration-tests/tests/mars.rs
@@ -12,8 +12,7 @@ use ads_client::{
 };
 
 fn init_backend() {
-    // Err means the backend is already initialized.
-    let _ = viaduct_hyper::viaduct_init_backend_hyper();
+    viaduct_hyper::viaduct_init_backend_hyper();
 }
 
 fn prod_client() -> ads_client::MozAdsClient {

--- a/components/suggest/suggest-bench/benches/benchmark_all.rs
+++ b/components/suggest/suggest-bench/benches/benchmark_all.rs
@@ -50,7 +50,7 @@ fn run_benchmarks<B: BenchmarkWithInput, M: Measurement>(
 fn setup_viaduct() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
-        viaduct_hyper::viaduct_init_backend_hyper().expect("error initializing viaduct")
+        viaduct_hyper::viaduct_init_backend_hyper();
     });
 }
 

--- a/components/suggest/suggest-bench/src/bin/debug_ingestion_sizes.rs
+++ b/components/suggest/suggest-bench/src/bin/debug_ingestion_sizes.rs
@@ -5,6 +5,6 @@
 use suggest::benchmarks::ingest;
 
 fn main() {
-    viaduct_hyper::viaduct_init_backend_hyper().expect("Error initializing viaduct");
+    viaduct_hyper::viaduct_init_backend_hyper();
     ingest::print_debug_ingestion_sizes()
 }

--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -23,7 +23,7 @@ pub(crate) static USER_AGENT: &str =
     concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 fn main() -> Result<()> {
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
     let cmds = get_commands_from_cli(std::env::args_os())?;
     for c in cmds {
         let success = cmd::process_cmd(&c)?;

--- a/components/support/viaduct-dev/src/lib.rs
+++ b/components/support/viaduct-dev/src/lib.rs
@@ -104,10 +104,7 @@ fn send_request(request: Request, settings: ClientSettings) -> Result<Response> 
 pub fn init_backend_dev() {
     info!("initializing dev backend");
     let backend = Arc::new(DevBackend::new());
-    // Register our backend with viaduct.  This is only used in the testing situations, so we can
-    // ignore any `BackendAlreadyInitialized` errors. The first call will take effect and all
-    // others can be safely ignored.
-    let _ = init_backend(backend);
+    init_backend(backend);
 }
 
 impl DevBackend {

--- a/components/support/viaduct-hyper/src/lib.rs
+++ b/components/support/viaduct-hyper/src/lib.rs
@@ -34,7 +34,7 @@ struct HyperBackend {
 /// Named `viaduct_init_backend_hyper` since that reads better on iOS/Swift where there aren't any
 /// namespaces.  Once we move to UniFII 0.31 we can use the renaming feature to do this instead.
 #[uniffi::export]
-pub fn viaduct_init_backend_hyper() -> Result<()> {
+pub fn viaduct_init_backend_hyper() {
     info!("initializing hyper backend");
     // Create a multi-threaded runtime, with 1 worker thread.
     //

--- a/components/support/viaduct-reqwest/src/lib.rs
+++ b/components/support/viaduct-reqwest/src/lib.rs
@@ -107,8 +107,7 @@ static INIT_REQWEST_BACKEND: Once = Once::new();
 
 pub fn use_reqwest_backend() {
     INIT_REQWEST_BACKEND.call_once(|| {
-        viaduct::set_backend(Box::leak(Box::new(ReqwestBackend)))
-            .expect("Backend already set (FFI)");
+        viaduct::set_backend(Box::leak(Box::new(ReqwestBackend)));
     })
 }
 

--- a/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
@@ -31,19 +31,13 @@ class UnsupportedRequestMethodError(method: String) :
  */
 @OptIn(ExperimentalAtomicApi::class)
 object RustHttpConfig {
-    // Used to only initialize the client once
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1989865.
-    private var backendInitialized = AtomicBoolean(false)
-
     /**
      * Set the HTTP client to be used by all Rust code.
      * the `Lazy`'s value is not read until the first request is made.
      */
     @Synchronized
     fun setClient(c: Lazy<Client>) {
-        if (backendInitialized.compareAndSet(false, true)) {
-            initBackend(FetchBackend(c))
-        }
+        initBackend(FetchBackend(c))
     }
 
     /** Allows connections to the hard-coded address the Android Emulator uses

--- a/components/viaduct/src/backend.rs
+++ b/components/viaduct/src/backend.rs
@@ -28,10 +28,10 @@ pub trait Backend: Send + Sync + 'static {
 
 static BACKEND: OnceCell<&'static dyn Backend> = OnceCell::new();
 
-pub fn set_backend(b: &'static dyn Backend) -> Result<(), crate::ViaductError> {
-    BACKEND
-        .set(b)
-        .map_err(|_| crate::error::ViaductError::SetBackendError)
+pub fn set_backend(b: &'static dyn Backend) {
+    // Ignore errors when setting the OnceCell multiple times.
+    // `new_backend::init_backend` will catch and report these.
+    let _ = BACKEND.set(b);
 }
 
 pub(crate) fn get_backend() -> &'static dyn Backend {

--- a/components/viaduct/src/new_backend.rs
+++ b/components/viaduct/src/new_backend.rs
@@ -29,11 +29,14 @@ pub trait Backend: Send + Sync + 'static {
 static REGISTERED_BACKEND: OnceLock<Arc<dyn Backend>> = OnceLock::new();
 
 #[uniffi::export]
-pub fn init_backend(backend: Arc<dyn Backend>) -> Result<()> {
-    old_backend::set_backend(Box::leak(Box::new(backend.clone())))?;
-    REGISTERED_BACKEND
-        .set(backend)
-        .map_err(|_| ViaductError::BackendAlreadyInitialized)
+pub fn init_backend(backend: Arc<dyn Backend>) {
+    old_backend::set_backend(Box::leak(Box::new(backend.clone())));
+    if REGISTERED_BACKEND.set(backend).is_err() {
+        error_support::report_error!(
+            "viaduct-multiple-init-backend",
+            "init_backend called multiple times"
+        );
+    }
 }
 
 pub fn get_backend() -> Result<&'static Arc<dyn Backend>> {

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -477,7 +477,7 @@ fn get_encryption_key(store: &Store, db_path: &str, opts: &Opts) -> Result<Strin
 
 fn main() -> Result<()> {
     nss_as::ensure_initialized();
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     let opts = Opts::parse();
     if !opts.no_logging {

--- a/examples/example-cli/src/main.rs
+++ b/examples/example-cli/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> ApiResult<()> {
     init_logging(&cli);
     // Applications must initialize viaduct for the HTTP client to work.
     // This example uses the `hyper` backend because it's easy to setup.
-    viaduct_hyper::viaduct_init_backend_hyper().expect("Error initializing viaduct");
+    viaduct_hyper::viaduct_init_backend_hyper();
     let component = build_example_component()?;
     println!();
     match cli.command {

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -80,7 +80,7 @@ enum Command {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     nss_as::ensure_initialized();
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
     cli_support::init_logging_with("info");
 
     println!();

--- a/examples/merino-cli/src/main.rs
+++ b/examples/merino-cli/src/main.rs
@@ -119,7 +119,7 @@ enum WorldCupEndpoint {
 }
 
 fn main() -> Result<()> {
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     let cli = Cli::parse();
 

--- a/examples/nimbus/src/main.rs
+++ b/examples/nimbus/src/main.rs
@@ -149,7 +149,7 @@ fn main() -> Result<()> {
     // Possible values are "info", "debug", "warn" and "error"
     // Check [`env_logger`](https://docs.rs/env_logger/) for more details
     error_support::init_for_tests_with_level(error_support::Level::Info);
-    viaduct_hyper::viaduct_init_backend_hyper().expect("Error initalizing viaduct");
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     // Initiate the matches for the command line arguments
     let args = Args::parse();

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -234,7 +234,7 @@ fn sync(
     nsyncs: u32,
     wait: u64,
 ) -> Result<()> {
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     let mut cli = CliFxa::new(get_default_fxa_config(), Some(&cred_file))?;
     cli.ensure_logged_in(&[SYNC_SCOPE])?;

--- a/examples/push-livetest/src/livetest.rs
+++ b/examples/push-livetest/src/livetest.rs
@@ -14,7 +14,7 @@ use push::{BridgeType, PushConfiguration, PushManager};
  */
 fn test_live_server() {
     let tempdir = tempfile::tempdir().unwrap();
-    viaduct_hyper::viaduct_init_backend_hyper().expect("Error initializing viaduct");
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     let push_config = PushConfiguration {
         server_host: "localhost:8082".to_string(),

--- a/examples/relay-cli/src/main.rs
+++ b/examples/relay-cli/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     init_logging(&cli);
 
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     let token = prompt_token()?;
     let client = RelayClient::new("https://relay.firefox.com".to_string(), Some(token));

--- a/examples/relevancy-cli/src/main.rs
+++ b/examples/relevancy-cli/src/main.rs
@@ -35,7 +35,7 @@ struct Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     nss_as::ensure_initialized();
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
     cli_support::ensure_cli_data_dir_exists();
     let mut builder = Builder::new();
     builder.filter_level(log::LevelFilter::Info);

--- a/examples/remote-settings-cli/src/main.rs
+++ b/examples/remote-settings-cli/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
         DEFAULT_LOG_FILTER
     });
     nss_as::ensure_initialized();
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
     let service = build_service(&cli)?;
     match cli.command {
         Commands::Sync { collections } => sync(service, collections),

--- a/examples/suggest-cli/src/main.rs
+++ b/examples/suggest-cli/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<()> {
         DEFAULT_LOG_FILTER
     });
     nss_as::ensure_initialized();
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
     let store = build_store(&cli)?;
     match cli.command {
         Commands::Ingest {

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -364,7 +364,7 @@ fn do_sync(
 #[allow(clippy::cognitive_complexity)] // FIXME
 fn main() -> Result<()> {
     cli_support::init_trace_logging();
-    viaduct_hyper::viaduct_init_backend_hyper().expect("Error initializing viaduct");
+    viaduct_hyper::viaduct_init_backend_hyper();
 
     let matches = clap::Command::new("sync_pass_sql")
         .about("CLI login syncing tool")

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -95,7 +95,7 @@ fn do_sync(
 
 fn main() -> Result<()> {
     nss_as::ensure_initialized();
-    viaduct_hyper::viaduct_init_backend_hyper()?;
+    viaduct_hyper::viaduct_init_backend_hyper();
     cli_support::init_logging();
     let opts = Opts::parse();
 

--- a/examples/viaduct-cli/src/main.rs
+++ b/examples/viaduct-cli/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> Result<()> {
 
             match backend_style {
                 BackendStyle::New => {
-                    viaduct_hyper::viaduct_init_backend_hyper()?;
+                    viaduct_hyper::viaduct_init_backend_hyper();
                     let settings = ClientSettings {
                         timeout: cli.timeout.unwrap_or(0) as u32,
                         ..ClientSettings::default()
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
                     print_response(client.send_sync(req));
                 }
                 BackendStyle::Bridged => {
-                    viaduct_hyper::viaduct_init_backend_hyper()?;
+                    viaduct_hyper::viaduct_init_backend_hyper();
                     if let Some(t) = cli.timeout {
                         set_old_global_timeout(t);
                     }
@@ -141,7 +141,7 @@ fn run_ohttp_example(
     match backend_style {
         BackendStyle::New | BackendStyle::Bridged => {
             println!("Using new/bridged backend (hyper-based)");
-            viaduct_hyper::viaduct_init_backend_hyper()?;
+            viaduct_hyper::viaduct_init_backend_hyper();
         }
         BackendStyle::Old => {
             println!("Using old backend (reqwest-based, global settings will be used)");

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -28,7 +28,7 @@ macro_rules! cleanup_clients {
 }
 
 pub fn init_testing() {
-    viaduct_hyper::viaduct_init_backend_hyper().expect("Error initializing viaduct");
+    viaduct_hyper::viaduct_init_backend_hyper();
     ensure_initialized();
 
     // Enable backtraces.


### PR DESCRIPTION
This has been caused crashes on Android and we haven't been able to figure out why (https://bugzilla.mozilla.org/show_bug.cgi?id=1655930, https://bugzilla.mozilla.org/show_bug.cgi?id=2037900).  We can avoid the crashes by just ignoring the second call.  Report an error to the rust components error ping so we can still track the rate.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
