### PR TITLE
Rename the viaduct Android package to `viaduct`.

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -63,13 +63,13 @@ projects:
     - name: rust-log-forwarder
       type: aar
     description: Forward logs from Rust
-  httpconfig:
+  viaduct:
     path: components/viaduct/android
-    artifactId: httpconfig
+    artifactId: viaduct
     publications:
-    - name: httpconfig
+    - name: viaduct
       type: aar
-    description: Component allowing the configuration of Rust HTTP stack.
+    description: Rust HTTP bridge.
   push:
     path: components/push/android
     artifactId: push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - init_backend and `viaduct_init_backend_hyper` no longer throw an error if they're called multiple times.
   Instead, we report the error via the Rust components error ping.
   This is a breaking change for iOS, since the functions no longer throw.
+- Renamed the Android package to `mozilla.appservices.viaduct`
 
 ## 🔧 What's Fixed 🔧
 

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -53,5 +53,5 @@ dependencies {
     } else {
         testImplementation libs.mozilla.concept.fetch
     }
-    testImplementation project(":httpconfig")
+    testImplementation project(":viaduct")
 }

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -2,7 +2,7 @@ apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
 apply from: "$appServicesRootDir/publish.gradle"
 
 android {
-    namespace 'org.mozilla.appservices.httpconfig'
+    namespace 'org.mozilla.appservices.viaduct'
 }
 
 dependencies {

--- a/components/viaduct/android/src/main/java/mozilla/appservices/viaduct/FetchBackend.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/viaduct/FetchBackend.kt
@@ -2,13 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.appservices.httpconfig
+package mozilla.appservices.viaduct
 
-import mozilla.appservices.viaduct.Backend
-import mozilla.appservices.viaduct.ClientSettings
-import mozilla.appservices.viaduct.Method
-import mozilla.appservices.viaduct.Request
-import mozilla.appservices.viaduct.Response
 import java.util.concurrent.TimeUnit
 import mozilla.components.concept.fetch.Client as FetchClient
 import mozilla.components.concept.fetch.Header as FetchHeader

--- a/components/viaduct/android/src/main/java/mozilla/appservices/viaduct/HttpConfig.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/viaduct/HttpConfig.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package mozilla.appservices.httpconfig
+package mozilla.appservices.viaduct
 
 import mozilla.appservices.viaduct.initBackend
 import mozilla.components.concept.fetch.Client


### PR DESCRIPTION
Before it was named `httpconfig` for historical reasons, this one seems more natural.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
