### PR TITLE
Don't package the glean_sym files

### DIFF
--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -156,6 +156,12 @@ def generate_uniffi_bindings_for_target(out_dir, megazord):
         ["cargo", "uniffi-bindgen-library-mode", "-l", lib_path, "swift", out_dir]
     )
 
+    # We do NOT want glean-sym UniFFI symbols exported.
+    # These only exist to make the glean-sym Rust part work, but won't be linked in.
+    (out_dir / "glean_sym.swift").unlink(missing_ok=True)
+    (out_dir / "glean_sym.h").unlink(missing_ok=True)
+
+
 def ensure_dir(path):
     if not path.exists():
         os.makedirs(path)


### PR DESCRIPTION
Not sure that's really the best solution.
Right now I manually removed that file in https://github.com/mozilla-mobile/firefox-ios/pull/34478
I could also remove it in the script in fx-ios that updates appservices, but that feels even more wrong.
