### PR TITLE
Bug 2052250 - add support for re-enrolling into rollouts

### DIFF
--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -1247,10 +1247,22 @@ impl<'a> EnrollmentsEvolver<'a> {
                 )?)
             }
             (None, None, Some(enrollment)) => enrollment.maybe_garbage_collect(),
-            (None, Some(_), Some(_)) => {
-                return Err(NimbusError::InternalError(
-                    "New experiment but enrollment already exists.",
-                ));
+            (None, Some(experiment), Some(enrollment)) => {
+                if experiment.is_rollout()
+                    && matches!(&enrollment.status, EnrollmentStatus::WasEnrolled { .. })
+                {
+                    Some(ExperimentEnrollment::from_new_experiment(
+                        is_user_participating,
+                        self.available_randomization_units,
+                        experiment,
+                        &targeting_helper,
+                        out_enrollment_events,
+                    )?)
+                } else {
+                    return Err(NimbusError::InternalError(
+                        "New experiment but enrollment already exists.",
+                    ));
+                }
             }
             (Some(_), None, None) | (Some(_), Some(_), None) => {
                 return Err(NimbusError::InternalError(

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -3667,6 +3667,55 @@ fn test_evolver_new_experiment_enrollment_already_exists() {
 }
 
 #[test]
+fn test_evolver_relaunched_rollout_reenrolls_from_was_enrolled() -> Result<()> {
+    let rollout = get_bucketed_rollout("secure-gold", 10_000);
+    let existing_enrollment = ExperimentEnrollment {
+        slug: rollout.slug.clone(),
+        status: EnrollmentStatus::WasEnrolled {
+            branch: "control".to_owned(),
+            experiment_ended_at: now_secs(),
+        },
+    };
+    let (_, app_ctx, aru) = local_ctx();
+    let mut th = app_ctx.into();
+    let ids = no_coenrolling_features();
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
+    let mut events = vec![];
+
+    let enrollment = evolver
+        .evolve_enrollment(
+            true,
+            None,
+            Some(&rollout),
+            Some(&existing_enrollment),
+            &mut events,
+            #[cfg(feature = "stateful")]
+            None,
+        )?
+        .unwrap();
+
+    assert!(matches!(
+        enrollment.status,
+        EnrollmentStatus::Enrolled {
+            branch,
+            reason: EnrolledReason::Qualified,
+            ..
+        } if branch == "control"
+    ));
+    assert_eq!(
+        &events,
+        &[EnrollmentChangeEvent {
+            experiment_slug: "secure-gold".into(),
+            branch_slug: "control".into(),
+            reason: None,
+            change: EnrollmentChangeEventType::Enrollment,
+            feature_ids: vec!["a-feature".into()],
+        }]
+    );
+    Ok(())
+}
+
+#[test]
 fn test_evolver_existing_experiment_has_no_enrollment() {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();


### PR DESCRIPTION
updates Nimbus enrollment evolution to support re enabled rollouts with the same slug. If a rollout reappears after ending (pausing) and the client only has a previous WasEnrolled tombstone, the SDK now evaluates it like a new rollout instead of treating it as an internal error

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
