### PR TITLE
Bug 2050966 - Remove stale code in RustComponentsErrorTelemetry.kt [ci full]

### DIFF
--- a/components/support/error/android/src/main/java/mozilla/appservices/errorsupport/RustComponentsErrorTelemetry.kt
+++ b/components/support/error/android/src/main/java/mozilla/appservices/errorsupport/RustComponentsErrorTelemetry.kt
@@ -57,13 +57,6 @@ internal data class TracingErrorFields(
     val breadcrumbs: String,
 )
 
-@Serializable
-internal data class TracingBreadcrumbFields(
-    val module: String,
-    val line: UInt,
-    val column: UInt,
-)
-
 private class ErrorEventSink : EventSink {
     val json = Json { ignoreUnknownKeys = true }
 
@@ -74,54 +67,6 @@ private class ErrorEventSink : EventSink {
             RustComponentErrors.details.set(event.message)
             RustComponentErrors.breadcrumbs.set(fields.breadcrumbs.split("\n"))
             Pings.rustComponentErrors.submit()
-
-            ApplicationErrorReporterRegistry.errorReporter?.reportError(fields.typeName, event.message)
-        } else if (event.target == "app-services-error-reporter::breadcrumb") {
-            val fields = json.decodeFromString<TracingBreadcrumbFields>(event.fields)
-
-            ApplicationErrorReporterRegistry.errorReporter?.reportBreadcrumb(
-                event.message,
-                fields.module,
-                fields.line,
-                fields.column,
-            )
         }
     }
-}
-
-/**
- * Report Rust errors to Sentry (supplied by the application
- *
- * This represents the legacy error reporting interface. We're keeping this around for now so that
- * Android can send errors to Sentry.  At some point we should migrate Android to only use
- * Glean-based error reporting.
- */
-public interface ApplicationErrorReporter {
-    /**
-     * Report an error
-     */
-    fun reportError(typeName: String, message: String)
-
-    /**
-     * Report a breadbcrumb
-     */
-    fun reportBreadcrumb(message: String, module: String, line: UInt, column: UInt)
-}
-
-/**
- * Set the global ApplicationErrorReporter
- */
-public fun setApplicationErrorReporter(errorReporter: ApplicationErrorReporter) {
-    ApplicationErrorReporterRegistry.errorReporter = errorReporter
-}
-
-/**
- * Unset the global ApplicationErrorReporter
- */
-public fun unsetApplicationErrorReporter() {
-    ApplicationErrorReporterRegistry.errorReporter = null
-}
-
-internal object ApplicationErrorReporterRegistry {
-    var errorReporter: ApplicationErrorReporter? = null
 }


### PR DESCRIPTION
Nowadays we're using the Rust error ping which is handled internally in the Kotlin module.  We no longer need to forward these events for recording in sentry.  The android side of this was removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1991443.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
