### PR TITLE
Revert "Make Login::shutdown release its EncryoptorDecryptor (#7476)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,6 @@
   and `LoginStore.wipe_local_except_fxa()`, a variant of `wipe_local()` that preserves the FxA session-credentials login
   ([#7467](https://github.com/mozilla/application-services/pull/7467)) ([Bug 2053557](https://bugzilla.mozilla.org/show_bug.cgi?id=2053557))
 
-## 🔧 What's Fixed 🔧
-
-### Logins
-
-- `LoginStore.shutdown()` now releases its reference to the consumer-provided `EncryptorDecryptor` so foreign (e.g. JS) callback handles are unregistered during shutdown instead of lingering. ([#PRNUM](https://github.com/mozilla/application-services/pull/7476))
-
 # v153.0 (_2026-06-15_)
 
 ## ⚠️ Breaking Changes ⚠️

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -22,7 +22,7 @@
 ///     server.
 ///   - After we sync, we move all records from loginsL to loginsM, overwriting any previous data.
 ///     loginsL will be an empty table after this.  See mark_as_synchronized() for the details.
-use crate::encryption::{EncryptorDecryptor, NoopEncryptorDecryptor};
+use crate::encryption::EncryptorDecryptor;
 use crate::error::*;
 use crate::login::*;
 use crate::schema;
@@ -1079,11 +1079,7 @@ impl LoginDb {
         Ok(row_count)
     }
 
-    pub fn shutdown(mut self) -> Result<()> {
-        // Drop our reference to the (possibly foreign/JS-backed) encryptor before
-        // we tear the rest down, so its callback handle is released during
-        // shutdown instead of lingering.
-        self.encdec = Arc::new(NoopEncryptorDecryptor);
+    pub fn shutdown(self) -> Result<()> {
         self.db.close().map_err(|(_, e)| Error::SqlError(e))
     }
 }

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -88,29 +88,6 @@ impl<T: EncryptorDecryptor> EncryptorDecryptor for Arc<T> {
     }
 }
 
-/// A placeholder `EncryptorDecryptor` used after the store has been shut down.
-///
-/// On shutdown we swap the real encryptor (which, for foreign consumers like
-/// Desktop, is a JS-backed callback interface) out for this one. That drops our
-/// reference to the foreign callback so its handle is unregistered during
-/// shutdown rather than lingering. Any call that still reaches it (e.g. via a
-/// stray clone) fails cleanly instead of calling into torn-down foreign code.
-pub struct NoopEncryptorDecryptor;
-
-impl EncryptorDecryptor for NoopEncryptorDecryptor {
-    fn encrypt(&self, _clearbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
-        Err(LoginsApiError::UnexpectedLoginsApiError {
-            reason: "encrypt called on a shut-down store".to_string(),
-        })
-    }
-
-    fn decrypt(&self, _cipherbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
-        Err(LoginsApiError::UnexpectedLoginsApiError {
-            reason: "decrypt called on a shut-down store".to_string(),
-        })
-    }
-}
-
 /// The ManagedEncryptorDecryptor makes use of the NSS provided cryptographic algorithms. The
 /// ManagedEncryptorDecryptor uses a KeyManager for encryption key retrieval.
 pub struct ManagedEncryptorDecryptor {
@@ -393,21 +370,6 @@ mod tests {
         let key = create_key().unwrap();
         let key_manager = StaticKeyManager { key: key.clone() };
         assert_eq!(key.as_bytes(), key_manager.get_key().unwrap());
-    }
-
-    #[test]
-    fn test_noop_encdec_errors() {
-        // The placeholder we swap in on shutdown must never encrypt/decrypt; it
-        // should fail cleanly instead.
-        let encdec = NoopEncryptorDecryptor;
-        assert!(matches!(
-            encdec.encrypt("secret".as_bytes().into()).err().unwrap(),
-            LoginsApiError::UnexpectedLoginsApiError { .. }
-        ));
-        assert!(matches!(
-            encdec.decrypt("secret".as_bytes().into()).err().unwrap(),
-            LoginsApiError::UnexpectedLoginsApiError { .. }
-        ));
     }
 
     #[test]


### PR DESCRIPTION
This reverts commit 73048777916d7561bac001d1b875edfaec2236be.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
