### PR TITLE
Bug 2055331 - Report reason in unenrollment telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Firefox Accounts
 
-- Session-token authenticated requests to the FxA auth-server now use the typed-Bearer token scheme (`Authorization: Bearer fxs_<token_id>`) instead of Hawk. This is an internal change with no consumer-facing API impact; production routes accept both schemes. See the [authentication schemes reference](https://mozilla.github.io/ecosystem-platform/reference/authentication-schemes). ([#PRNUM](https://github.com/mozilla/application-services/pull/PRNUM))
+- Session-token authenticated requests to the FxA auth-server now use the typed-Bearer token scheme (`Authorization: Bearer fxs_<token_id>`) instead of Hawk. This is an internal change with no consumer-facing API impact; production routes accept both schemes. See the [authentication schemes reference](https://mozilla.github.io/ecosystem-platform/reference/authentication-schemes). ([#7432](https://github.com/mozilla/application-services/pull/7432))
 
 [Full Changelog](In progress)
 
@@ -16,7 +16,7 @@
 ### Logins
 
 - Add `LoginStore.bridgedEngine()`, which exposes the logins sync engine to Desktop's Sync. ([bug 2049263](https://bugzilla.mozilla.org/show_bug.cgi?id=2049263))
-- Add `LoginStore.delete_all()`, which deletes all logins 
+- Add `LoginStore.delete_all()`, which deletes all logins
   and `delete_all_axcept_fxa()`, which deletes all logins preserving the FxA session-credentials login
   and `LoginStore.wipe_local_except_fxa()`, a variant of `wipe_local()` that preserves the FxA session-credentials login
   ([#7467](https://github.com/mozilla/application-services/pull/7467)) ([Bug 2053557](https://bugzilla.mozilla.org/show_bug.cgi?id=2053557))
@@ -26,6 +26,10 @@
 ### Logins
 
 - The logins sync engine no longer holds its own long-lived clone of the `EncryptorDecryptor`, fetching it from the store on demand instead. This ensures no dangling reference keeps a foreign (e.g. JS) callback handle alive past `shutdown()`. ([#7478](https://github.com/mozilla/application-services/pull/7478))
+
+### Nimbus
+
+- Reasons are now reported in unenrollment events. ([#7480](https://github.com/mozilla/application-services/pull/7480))
 
 # v153.0 (_2026-06-15_)
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -665,6 +665,7 @@ open class Nimbus(
                         NimbusEvents.UnenrollmentExtra(
                             experiment = event.experimentSlug,
                             branch = event.branchSlug,
+                            reason = event.reason,
                         ),
                     )
 

--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -24,13 +24,12 @@ nimbus_events:
       branch:
         type: string
         description: The branch slug/identifier that was randomly chosen
-      experiment_type:
-        type: string
-        description: Indicates whether this is an experiment or rollout
     bugs:
       - https://jira.mozilla.com/browse/SDK-61
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2055331
     data_reviews:
       - https://github.com/mozilla-mobile/android-components/pull/9168#issuecomment-743461975
+      - https://github.com/mozilla/application-services/pull/7480#issuecomment-4995012840
     data_sensitivity:
       - technical
     notification_emails:


### PR DESCRIPTION
The `nimbsus_events.unenrollment` metric is supposed to contain the reason field, but it just hasn't been reported.

Additionally, this removes "is_rollout" field from the `nimbus_events.enrollment` metric as (a) that data is not already reported, (b) the data is not already available on the `EnrollmentChangeEvent` (and adding it would be a breaking change), and (c) the field is not all that useful.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
