### PR TITLE
Add additional indexes for address bar autocomplete

### DIFF
--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -42,7 +42,9 @@ CREATE INDEX IF NOT EXISTS frecencyindex ON moz_places(frecency);
 CREATE INDEX IF NOT EXISTS lastvisitdatelocalindex ON moz_places(last_visit_date_local);
 CREATE INDEX IF NOT EXISTS lastvisitdateremoteindex ON moz_places(last_visit_date_remote);
 CREATE UNIQUE INDEX IF NOT EXISTS guid_uniqueindex ON moz_places(guid);
-CREATE INDEX IF NOT EXISTS originidindex ON moz_places(origin_id);
+
+-- speeds up the per-origin ORDER BY frecency DESC in api/matcher.rs URL_SQL
+CREATE INDEX IF NOT EXISTS idx_places_origin_frecency ON moz_places(origin_id, frecency);
 
 -- partial index to help speed up the fetch_outgoing query in history.rs
 CREATE INDEX IF NOT EXISTS idx_places_outgoing_by_frecency
@@ -156,6 +158,9 @@ CREATE TABLE IF NOT EXISTS moz_origins (
 );
 
 CREATE INDEX IF NOT EXISTS hostindex ON moz_origins(rev_host);
+
+-- speeds up the host range scan and TOTAL(frecency) in api/matcher.rs ORIGIN_SQL
+CREATE INDEX IF NOT EXISTS idx_origins_host_frecency ON moz_origins(host, frecency);
 
 
 -- This table holds key-value metadata for Places and its consumers. Sync stores

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -14,7 +14,7 @@ use sql_support::ConnExt;
 
 use super::db::{Pragma, PragmaGuard};
 
-pub const VERSION: u32 = 20;
+pub const VERSION: u32 = 21;
 
 // Shared schema and temp tables for the read-write and Sync connections.
 const CREATE_SHARED_SCHEMA_SQL: &str = include_str!("../../sql/create_shared_schema.sql");
@@ -340,6 +340,17 @@ pub fn upgrade_from(db: &Connection, from: u32) -> rusqlite::Result<()> {
             // Manually call analyze so the planner can start using the indexes immediately
             db.execute("ANALYZE moz_places", [])?;
             db.execute("ANALYZE moz_historyvisits", [])?;
+        }
+        20 => {
+            // Drop the old originidindex, then create its replacement
+            // (idx_places_origin_frecency) and idx_origins_host_frecency by
+            // calling the shared schema file
+            db.execute("DROP INDEX IF EXISTS originidindex", [])?;
+            db.execute_batch(CREATE_SHARED_SCHEMA_SQL)?;
+            // Manually call analyze so the planner can start using the indexes
+            // immediately, and to refresh stale stats on existing profiles
+            db.execute("ANALYZE moz_origins", [])?;
+            db.execute("ANALYZE moz_places", [])?;
         }
         // Add more migrations here...
 

--- a/testing/separated/places-bench/src/bench.rs
+++ b/testing/separated/places-bench/src/bench.rs
@@ -9,7 +9,8 @@ mod matching;
 
 use criterion::{criterion_group, criterion_main};
 use database::{
-    bench_match_url, bench_outgoing_candidates, bench_search_frecent, bench_top_frecent,
+    bench_match_url, bench_origin_autocomplete, bench_origin_frecency_index,
+    bench_outgoing_candidates, bench_search_frecent, bench_top_frecent,
 };
 use matching::bench_match_anywhere;
 
@@ -18,7 +19,9 @@ criterion_group!(
     bench_search_frecent,
     bench_match_url,
     bench_outgoing_candidates,
-    bench_top_frecent
+    bench_top_frecent,
+    bench_origin_autocomplete,
+    bench_origin_frecency_index
 );
 criterion_group!(bench_mem, bench_match_anywhere);
 criterion_main!(bench_db, bench_mem);

--- a/testing/separated/places-bench/src/database.rs
+++ b/testing/separated/places-bench/src/database.rs
@@ -529,3 +529,152 @@ pub fn bench_top_frecent(c: &mut Criterion) {
         });
     }
 }
+
+// -----------------------------------------------------------------------------------------
+// origin autocomplete benchmark, speeding up the moz_origins host scan via an index
+// -----------------------------------------------------------------------------------------
+
+// Insert many origins, spread over leading letters and frecencies, so the host scan and
+// GROUP BY in ORIGIN_SQL have real work to do. moz_origins has no insert triggers.
+fn seed_db_for_origin_autocomplete(db: &PlacesDb) -> places::Result<()> {
+    db.execute_batch(
+        r#"
+        WITH RECURSIVE seq(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < 6000
+        )
+        INSERT OR IGNORE INTO moz_origins (prefix, host, rev_host, frecency)
+        SELECT
+            'https',
+            char(97 + (i % 26)) || 'host' || i || '.example.com',
+            reverse_host(char(97 + (i % 26)) || 'host' || i || '.example.com'),
+            (i * 7) % 100000
+        FROM seq;
+        "#,
+    )?;
+    db.execute_batch("ANALYZE; PRAGMA optimize;")?;
+    Ok(())
+}
+
+fn create_origins_host_frecency_index(db: &PlacesDb) -> places::Result<()> {
+    db.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_origins_host_frecency ON moz_origins(host, frecency);",
+    )?;
+    db.execute_batch("ANALYZE; PRAGMA optimize;")?;
+    Ok(())
+}
+
+fn drop_origins_host_frecency_index(db: &PlacesDb) -> places::Result<()> {
+    db.execute_batch("DROP INDEX IF EXISTS idx_origins_host_frecency;")?;
+    db.execute_batch("ANALYZE; PRAGMA optimize;")?;
+    Ok(())
+}
+
+pub fn bench_origin_autocomplete(c: &mut Criterion) {
+    // A single-letter query routes through looks_like_origin to ORIGIN_SQL.
+    const QUERY: &str = "a";
+
+    // Create two independent DBs so index state changes do not leak between benches.
+    let db_no_index = TestDb::new();
+    seed_db_for_origin_autocomplete(&db_no_index.db).unwrap();
+    drop_origins_host_frecency_index(&db_no_index.db).unwrap();
+
+    let db_with_index = TestDb::new();
+    seed_db_for_origin_autocomplete(&db_with_index.db).unwrap();
+    create_origins_host_frecency_index(&db_with_index.db).unwrap();
+
+    // 1) Without idx_origins_host_frecency
+    {
+        let tdb = db_no_index.clone();
+        c.bench_function("origin_autocomplete: NO idx_origins_host_frecency", move |b| {
+            let db = &tdb.db;
+            b.iter(|| match_url(db, QUERY).unwrap())
+        });
+    }
+
+    // 2) With idx_origins_host_frecency
+    {
+        let tdb = db_with_index.clone();
+        c.bench_function("origin_autocomplete: idx_origins_host_frecency", move |b| {
+            let db = &tdb.db;
+            b.iter(|| match_url(db, QUERY).unwrap())
+        });
+    }
+}
+
+// -----------------------------------------------------------------------------------------
+// per-origin url benchmark, replacing originidindex with an (origin_id, frecency) index
+// -----------------------------------------------------------------------------------------
+
+// Create many pages that all share one origin, so URL_SQL's per-origin ORDER BY frecency has
+// a large set to walk. Real URLs let the afterinsert trigger wire up origin_id, as init_db does.
+fn seed_db_for_origin_frecency(db: &PlacesDb) -> places::Result<()> {
+    db.execute_batch(
+        r#"
+        WITH RECURSIVE seq(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < 12000
+        )
+        INSERT INTO moz_places (url, guid, frecency, hidden, url_hash)
+        SELECT
+            'https://example.com/page/' || i,
+            'bench_of_' || i,
+            (i * 7919) % 100000,
+            0,
+            hash('https://example.com/page/' || i)
+        FROM seq;
+        "#,
+    )?;
+    places::storage::delete_pending_temp_tables(db)?;
+    db.execute_batch("ANALYZE; PRAGMA optimize;")?;
+    Ok(())
+}
+
+// Baseline: the single-column index that idx_places_origin_frecency replaces.
+fn create_origin_id_index(db: &PlacesDb) -> places::Result<()> {
+    db.execute_batch(
+        "DROP INDEX IF EXISTS idx_places_origin_frecency;
+         CREATE INDEX IF NOT EXISTS originidindex ON moz_places(origin_id);",
+    )?;
+    db.execute_batch("ANALYZE; PRAGMA optimize;")?;
+    Ok(())
+}
+
+fn create_origin_frecency_index(db: &PlacesDb) -> places::Result<()> {
+    db.execute_batch(
+        "DROP INDEX IF EXISTS originidindex;
+         CREATE INDEX IF NOT EXISTS idx_places_origin_frecency ON moz_places(origin_id, frecency);",
+    )?;
+    db.execute_batch("ANALYZE; PRAGMA optimize;")?;
+    Ok(())
+}
+
+pub fn bench_origin_frecency_index(c: &mut Criterion) {
+    // A query containing '/' routes to URL_SQL, scoped to the heavy origin.
+    const QUERY: &str = "example.com/";
+
+    // Create two independent DBs so index state changes do not leak between benches.
+    let db_origin_id = TestDb::new();
+    seed_db_for_origin_frecency(&db_origin_id.db).unwrap();
+    create_origin_id_index(&db_origin_id.db).unwrap();
+
+    let db_origin_frecency = TestDb::new();
+    seed_db_for_origin_frecency(&db_origin_frecency.db).unwrap();
+    create_origin_frecency_index(&db_origin_frecency.db).unwrap();
+
+    // 1) Old single-column originidindex
+    {
+        let tdb = db_origin_id.clone();
+        c.bench_function("origin_url: originidindex", move |b| {
+            let db = &tdb.db;
+            b.iter(|| match_url(db, QUERY).unwrap())
+        });
+    }
+
+    // 2) New idx_places_origin_frecency
+    {
+        let tdb = db_origin_frecency.clone();
+        c.bench_function("origin_url: idx_places_origin_frecency", move |b| {
+            let db = &tdb.db;
+            b.iter(|| match_url(db, QUERY).unwrap())
+        });
+    }
+}


### PR DESCRIPTION
This PR aims to address cause 2 identified in bug https://bugzilla.mozilla.org/show_bug.cgi?id=2056115.

In rare cases where the table stats of the places DB get stuck in a poisoned state, the lack of an index on moz_origins(host) can cause extremely poor performance. One way of mitigating this scenario is by indexing moz_origins(host).

Aside from that, while investigating this bug I also observed that indexes on moz_origins(host, frecency) and moz_places(origin_id, frecency) could help improve the performance of some queries in the address bar autocomplete path even in the absense of the poisoned table stats.

Here you can see the benchmark results on my machine, including two benchmarks which cover the poisoned-stats case (which I didn't include in the changes here since I intend to address the root cause of this in another PR):

```
origin_autocomplete: NO idx_origins_host_frecency
                        time:   [3.0447 ms 3.0638 ms 3.0885 ms]
origin_autocomplete: idx_origins_host_frecency
                        time:   [497.98 µs 501.11 µs 504.27 µs]
origin_url: originidindex
                        time:   [4.6239 ms 4.6674 ms 4.7581 ms]
origin_url: idx_places_origin_frecency
                        time:   [128.45 µs 130.27 µs 132.25 µs]

# I didn't include these next two in the changes, but they're here for completeness
origin_autocomplete (poisoned stats): NO idx_origins_host_frecency
                        time:   [7.6453 s 7.6775 s 7.7142 s]
origin_autocomplete (poisoned stats): idx_origins_host_frecency
                        time:   [3.4920 ms 3.5073 ms 3.5369 ms]
```

Observe how these changes fix the poisoned stats case but also provide a notable improvement in the healthy stats case.

I used Claude to assist with this investigation, and also this is my first contribution to a Mozilla project. So this change may warrant some scruitiny from those more experienced with the codebase. But to the best of my knowledge, it seems to be a positive change which helps in part to address the original issue I faced.

Thanks, Shawn

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - **This PR only adds benchmarks -- it doesn't add unit tests, since there should be no behavioural change. Existing unit tests already cover testing the schema migration code.**
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
  - **This change doesn't include any user-facing functional changes and historically, index changes like this haven't gotten changelog entries.**
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
