### PR TITLE
Bug 2050036 - Add Store::shutdown() to close the autofill DB connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Full Changelog](In progress)
 
+## ✨ What's Changed ✨
+
+### Autofill
+
+- Add `Store::shutdown()`, which closes the database connection early so it happens before Firefox Desktop's late-write shutdown barrier rather than during GC. Operations after shutdown return `DatabaseClosed`. ([Bug 2050036](https://bugzilla.mozilla.org/show_bug.cgi?id=2050036))
+
 # v154.0 (_2026-07-20_)
 
 ## ✨ What's Changed ✨

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "lazy_static",
  "libsqlite3-sys",
  "nss-as",
+ "parking_lot",
  "rusqlite",
  "serde",
  "serde_derive",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -14,6 +14,7 @@ error-support = { path = "../support/error" }
 interrupt-support = { path = "../support/interrupt" }
 jwcrypto = { path = "../support/jwcrypto" }
 lazy_static = "1.4"
+parking_lot = ">=0.11,<=0.12"
 rusqlite = { version = "0.37.0", features = ["functions", "bundled", "serde_json", "unlock_notify"] }
 serde = "1"
 serde_derive = "1"

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -208,6 +208,8 @@ interface Store {
     [Throws=AutofillApiError]
     void run_maintenance();
 
+    void shutdown();
+
     [Self=ByArc]
     void register_with_sync_manager();
 };

--- a/components/autofill/src/db/mod.rs
+++ b/components/autofill/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod store;
 
 use crate::error::*;
 
+use error_support::error;
 use interrupt_support::{SqlInterruptHandle, SqlInterruptScope};
 use rusqlite::{Connection, OpenFlags};
 use sql_support::open_database;
@@ -60,6 +61,13 @@ impl AutofillDb {
     #[inline]
     pub fn begin_interrupt_scope(&self) -> Result<SqlInterruptScope> {
         Ok(self.interrupt_handle.begin_interrupt_scope()?)
+    }
+
+    pub fn close(self) {
+        if let Err((_, err)) = self.writer.close() {
+            // Log the error, but continue with shutdown.
+            error!("Failed to close the connection: {:?}", err);
+        }
     }
 }
 

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -10,13 +10,14 @@ use crate::db::{
 };
 use crate::error::*;
 use error_support::handle_error;
+use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 use rusqlite::{
     types::{FromSql, ToSql},
     Connection,
 };
 use sql_support::{self, run_maintenance, ConnExt};
 use std::path::Path;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Weak};
 use sync15::engine::{SyncEngine, SyncEngineId};
 use sync_guid::Guid;
 
@@ -25,7 +26,8 @@ lazy_static::lazy_static! {
     // Mutex: just taken long enough to update the contents - needed to wrap
     //        the Weak as it isn't `Sync`
     // [Arc/Weak]<Store>: What the sync manager actually needs.
-    static ref STORE_FOR_MANAGER: Mutex<Weak<Store>> = Mutex::new(Weak::new());
+    static ref STORE_FOR_MANAGER: std::sync::Mutex<Weak<Store>> =
+        std::sync::Mutex::new(Weak::new());
 }
 
 /// Called by the sync manager to get a sync engine via the store previously
@@ -48,14 +50,14 @@ pub fn get_registered_sync_engine(engine_id: &SyncEngineId) -> Option<Box<dyn Sy
 
 // This is the type that uniffi exposes.
 pub struct Store {
-    pub(crate) db: Mutex<AutofillDb>,
+    pub(crate) db: Mutex<Option<AutofillDb>>,
 }
 
 impl Store {
     #[handle_error(Error)]
     pub fn new(db_path: impl AsRef<Path>) -> ApiResult<Self> {
         Ok(Self {
-            db: Mutex::new(AutofillDb::new(db_path)?),
+            db: Mutex::new(Some(AutofillDb::new(db_path)?)),
         })
     }
 
@@ -63,7 +65,7 @@ impl Store {
     #[cfg(test)]
     pub fn new_memory() -> Self {
         Self {
-            db: Mutex::new(crate::db::test::new_mem_db()),
+            db: Mutex::new(Some(crate::db::test::new_mem_db())),
         }
     }
 
@@ -71,26 +73,30 @@ impl Store {
     #[handle_error(Error)]
     pub fn new_shared_memory(db_name: &str) -> ApiResult<Self> {
         Ok(Self {
-            db: Mutex::new(AutofillDb::new_memory(db_name)?),
+            db: Mutex::new(Some(AutofillDb::new_memory(db_name)?)),
         })
+    }
+
+    pub(crate) fn lock_db(&self) -> Result<MappedMutexGuard<'_, AutofillDb>> {
+        MutexGuard::try_map(self.db.lock(), |db| db.as_mut()).map_err(|_| Error::DatabaseClosed)
     }
 
     #[handle_error(Error)]
     pub fn add_credit_card(&self, fields: UpdatableCreditCardFields) -> ApiResult<CreditCard> {
-        let credit_card = credit_cards::add_credit_card(&self.db.lock().unwrap().writer, fields)?;
+        let credit_card = credit_cards::add_credit_card(&self.lock_db()?.writer, fields)?;
         Ok(credit_card.into())
     }
 
     #[handle_error(Error)]
     pub fn get_credit_card(&self, guid: String) -> ApiResult<CreditCard> {
         let credit_card =
-            credit_cards::get_credit_card(&self.db.lock().unwrap().writer, &Guid::new(&guid))?;
+            credit_cards::get_credit_card(&self.lock_db()?.writer, &Guid::new(&guid))?;
         Ok(credit_card.into())
     }
 
     #[handle_error(Error)]
     pub fn get_all_credit_cards(&self) -> ApiResult<Vec<CreditCard>> {
-        let credit_cards = credit_cards::get_all_credit_cards(&self.db.lock().unwrap().writer)?
+        let credit_cards = credit_cards::get_all_credit_cards(&self.lock_db()?.writer)?
             .into_iter()
             .map(|x| x.into())
             .collect();
@@ -99,7 +105,7 @@ impl Store {
 
     #[handle_error(Error)]
     pub fn count_all_credit_cards(&self) -> ApiResult<i64> {
-        let count = credit_cards::count_all_credit_cards(&self.db.lock().unwrap().writer)?;
+        let count = credit_cards::count_all_credit_cards(&self.lock_db()?.writer)?;
         Ok(count)
     }
 
@@ -109,36 +115,32 @@ impl Store {
         guid: String,
         credit_card: UpdatableCreditCardFields,
     ) -> ApiResult<()> {
-        credit_cards::update_credit_card(
-            &self.db.lock().unwrap().writer,
-            &Guid::new(&guid),
-            &credit_card,
-        )
+        credit_cards::update_credit_card(&self.lock_db()?.writer, &Guid::new(&guid), &credit_card)
     }
 
     #[handle_error(Error)]
     pub fn delete_credit_card(&self, guid: String) -> ApiResult<bool> {
-        credit_cards::delete_credit_card(&self.db.lock().unwrap().writer, &Guid::new(&guid))
+        credit_cards::delete_credit_card(&self.lock_db()?.writer, &Guid::new(&guid))
     }
 
     #[handle_error(Error)]
     pub fn touch_credit_card(&self, guid: String) -> ApiResult<()> {
-        credit_cards::touch(&self.db.lock().unwrap().writer, &Guid::new(&guid))
+        credit_cards::touch(&self.lock_db()?.writer, &Guid::new(&guid))
     }
 
     #[handle_error(Error)]
     pub fn add_address(&self, new_address: UpdatableAddressFields) -> ApiResult<Address> {
-        Ok(addresses::add_address(&self.db.lock().unwrap().writer, new_address)?.into())
+        Ok(addresses::add_address(&self.lock_db()?.writer, new_address)?.into())
     }
 
     #[handle_error(Error)]
     pub fn get_address(&self, guid: String) -> ApiResult<Address> {
-        Ok(addresses::get_address(&self.db.lock().unwrap().writer, &Guid::new(&guid))?.into())
+        Ok(addresses::get_address(&self.lock_db()?.writer, &Guid::new(&guid))?.into())
     }
 
     #[handle_error(Error)]
     pub fn get_all_addresses(&self) -> ApiResult<Vec<Address>> {
-        let addresses = addresses::get_all_addresses(&self.db.lock().unwrap().writer)?
+        let addresses = addresses::get_all_addresses(&self.lock_db()?.writer)?
             .into_iter()
             .map(|x| x.into())
             .collect();
@@ -147,38 +149,38 @@ impl Store {
 
     #[handle_error(Error)]
     pub fn count_all_addresses(&self) -> ApiResult<i64> {
-        let count = addresses::count_all_addresses(&self.db.lock().unwrap().writer)?;
+        let count = addresses::count_all_addresses(&self.lock_db()?.writer)?;
         Ok(count)
     }
 
     #[handle_error(Error)]
     pub fn update_address(&self, guid: String, address: UpdatableAddressFields) -> ApiResult<()> {
-        addresses::update_address(&self.db.lock().unwrap().writer, &Guid::new(&guid), &address)
+        addresses::update_address(&self.lock_db()?.writer, &Guid::new(&guid), &address)
     }
 
     #[handle_error(Error)]
     pub fn delete_address(&self, guid: String) -> ApiResult<bool> {
-        addresses::delete_address(&self.db.lock().unwrap().writer, &Guid::new(&guid))
+        addresses::delete_address(&self.lock_db()?.writer, &Guid::new(&guid))
     }
 
     #[handle_error(Error)]
     pub fn touch_address(&self, guid: String) -> ApiResult<()> {
-        addresses::touch(&self.db.lock().unwrap().writer, &Guid::new(&guid))
+        addresses::touch(&self.lock_db()?.writer, &Guid::new(&guid))
     }
 
     #[handle_error(Error)]
     pub fn add_passport(&self, fields: UpdatablePassportFields) -> ApiResult<Passport> {
-        Ok(passports::add_passport(&self.db.lock().unwrap().writer, fields)?.into())
+        Ok(passports::add_passport(&self.lock_db()?.writer, fields)?.into())
     }
 
     #[handle_error(Error)]
     pub fn get_passport(&self, guid: String) -> ApiResult<Passport> {
-        Ok(passports::get_passport(&self.db.lock().unwrap().writer, &Guid::new(&guid))?.into())
+        Ok(passports::get_passport(&self.lock_db()?.writer, &Guid::new(&guid))?.into())
     }
 
     #[handle_error(Error)]
     pub fn get_all_passports(&self) -> ApiResult<Vec<Passport>> {
-        let passports = passports::get_all_passports(&self.db.lock().unwrap().writer)?
+        let passports = passports::get_all_passports(&self.lock_db()?.writer)?
             .into_iter()
             .map(|x| x.into())
             .collect();
@@ -187,7 +189,7 @@ impl Store {
 
     #[handle_error(Error)]
     pub fn count_all_passports(&self) -> ApiResult<i64> {
-        passports::count_all_passports(&self.db.lock().unwrap().writer)
+        passports::count_all_passports(&self.lock_db()?.writer)
     }
 
     #[handle_error(Error)]
@@ -196,28 +198,24 @@ impl Store {
         guid: String,
         passport: UpdatablePassportFields,
     ) -> ApiResult<()> {
-        passports::update_passport(
-            &self.db.lock().unwrap().writer,
-            &Guid::new(&guid),
-            &passport,
-        )
+        passports::update_passport(&self.lock_db()?.writer, &Guid::new(&guid), &passport)
     }
 
     #[handle_error(Error)]
     pub fn delete_passport(&self, guid: String) -> ApiResult<bool> {
-        passports::delete_passport(&self.db.lock().unwrap().writer, &Guid::new(&guid))
+        passports::delete_passport(&self.lock_db()?.writer, &Guid::new(&guid))
     }
 
     #[handle_error(Error)]
     pub fn touch_passport(&self, guid: String) -> ApiResult<()> {
-        passports::touch(&self.db.lock().unwrap().writer, &Guid::new(&guid))
+        passports::touch(&self.lock_db()?.writer, &Guid::new(&guid))
     }
 
     #[handle_error(Error)]
     pub fn scrub_encrypted_data(self: Arc<Self>) -> ApiResult<()> {
         // scrub the data on disk
         // Currently only credit cards have encrypted data
-        credit_cards::scrub_encrypted_credit_card_data(&self.db.lock().unwrap().writer)?;
+        credit_cards::scrub_encrypted_credit_card_data(&self.lock_db()?.writer)?;
         // Force the sync engine to refetch data (only need to do this for the credit cards, since the
         // addresses engine doesn't store encrypted data).
         crate::sync::credit_card::create_engine(self).reset_local_sync_data()?;
@@ -229,10 +227,10 @@ impl Store {
         self: Arc<Self>,
         local_encryption_key: String,
     ) -> ApiResult<CreditCardsDeletionMetrics> {
-        let db = &self.db.lock().unwrap().writer;
+        let db = self.lock_db()?;
         let deletion_stats =
             credit_cards::scrub_undecryptable_credit_card_data_for_remote_replacement(
-                db,
+                &db.writer,
                 local_encryption_key,
             )?;
 
@@ -241,15 +239,21 @@ impl Store {
         // record that exists on the sync server to overwrite the local record and restore
         // the scrubbed credit card number.
         crate::sync::credit_card::create_engine(self.clone())
-            .reset_local_sync_data_for_verification(db)?;
+            .reset_local_sync_data_for_verification(&db.writer)?;
         Ok(deletion_stats)
     }
 
     #[handle_error(Error)]
     pub fn run_maintenance(&self) -> ApiResult<()> {
-        let conn = self.db.lock().unwrap();
+        let conn = self.lock_db()?;
         run_maintenance(&conn)?;
         Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        if let Some(db) = self.db.lock().take() {
+            db.close();
+        }
     }
 
     // This allows the embedding app to say "make this instance available to
@@ -362,6 +366,22 @@ mod tests {
         // dropping the registered object should drop the registration.
         drop(store);
         assert!(STORE_FOR_MANAGER.lock().unwrap().upgrade().is_none());
+    }
+
+    #[test]
+    fn test_shutdown_closes_the_store() {
+        let store = Store::new_shared_memory("shutdown-test").expect("create store");
+        // Operations succeed before shutdown.
+        assert_eq!(store.count_all_passports().expect("count"), 0);
+
+        store.shutdown();
+
+        // After shutdown, operations return an error rather than panicking or
+        // operating on a half-closed store.
+        assert!(store.count_all_passports().is_err());
+
+        // shutdown is idempotent.
+        store.shutdown();
     }
 
     #[test]

--- a/components/autofill/src/error.rs
+++ b/components/autofill/src/error.rs
@@ -65,6 +65,9 @@ pub enum Error {
 
     #[error("No record with guid exists: {0}")]
     NoSuchRecord(String),
+
+    #[error("The store is closed")]
+    DatabaseClosed,
 }
 
 // Define how our internal errors are handled and converted to external errors
@@ -125,6 +128,13 @@ impl GetErrorHandling for Error {
             Self::NoSuchRecord(guid) => {
                 ErrorHandling::convert(AutofillApiError::NoSuchRecord { guid: guid.clone() })
                     .log_warning()
+            }
+
+            Self::DatabaseClosed => {
+                ErrorHandling::convert(AutofillApiError::UnexpectedAutofillApiError {
+                    reason: "The store is closed".to_string(),
+                })
+                .report_error("autofill-database-closed")
             }
         }
     }

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -76,7 +76,7 @@ impl<T> ConfigSyncEngine<T> {
     }
     // Reset the local sync data so the next server request fetches all records.
     pub fn reset_local_sync_data(&self) -> Result<()> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let tx = db.unchecked_transaction()?;
         self.storage_impl.reset_storage(&tx)?;
         self.put_meta(&tx, LAST_SYNC_META_KEY, &0)?;
@@ -109,7 +109,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
         &self,
         _get_client_data: &dyn Fn() -> sync15::ClientData,
     ) -> anyhow::Result<()> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let signal = db.begin_interrupt_scope()?;
         crate::db::schema::create_empty_sync_temp_tables(&db.writer)?;
         signal.err_if_interrupted()?;
@@ -121,7 +121,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
         inbound: Vec<IncomingBso>,
         telem: &mut telemetry::Engine,
     ) -> anyhow::Result<()> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let signal = db.begin_interrupt_scope()?;
 
         // Stage all incoming items.
@@ -141,7 +141,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
         timestamp: ServerTimestamp,
         _telem: &mut telemetry::Engine,
     ) -> anyhow::Result<Vec<OutgoingBso>> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let signal = db.begin_interrupt_scope()?;
         let tx = db.writer.unchecked_transaction()?;
         let incoming_impl = self.storage_impl.get_incoming_impl(&self.local_enc_key)?;
@@ -173,7 +173,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
     }
 
     fn set_uploaded(&self, new_timestamp: ServerTimestamp, ids: Vec<Guid>) -> anyhow::Result<()> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         self.put_meta(&db.writer, LAST_SYNC_META_KEY, &new_timestamp.as_millis())?;
         let tx = db.writer.unchecked_transaction()?;
         let outgoing_impl = self.storage_impl.get_outgoing_impl(&self.local_enc_key)?;
@@ -186,7 +186,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
         &self,
         server_timestamp: ServerTimestamp,
     ) -> anyhow::Result<Option<CollectionRequest>> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let since = ServerTimestamp(
             self.get_meta::<i64>(&db.writer, LAST_SYNC_META_KEY)?
                 .unwrap_or_default(),
@@ -203,7 +203,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
     }
 
     fn get_sync_assoc(&self) -> anyhow::Result<EngineSyncAssociation> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let global = self.get_meta(&db.writer, GLOBAL_SYNCID_META_KEY)?;
         let coll = self.get_meta(&db.writer, COLLECTION_SYNCID_META_KEY)?;
         Ok(if let (Some(global), Some(coll)) = (global, coll) {
@@ -214,7 +214,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
     }
 
     fn reset(&self, assoc: &EngineSyncAssociation) -> anyhow::Result<()> {
-        let db = &self.store.db.lock().unwrap();
+        let db = self.store.lock_db()?;
         let tx = db.unchecked_transaction()?;
         self.storage_impl.reset_storage(&tx)?;
         // Reset the last sync time, so that the next sync fetches fresh records
@@ -294,7 +294,8 @@ mod tests {
             .set_local_encryption_key(&test_key)
             .unwrap();
         {
-            create_empty_sync_temp_tables(&credit_card_engine.store.db.lock().unwrap())?;
+            let db = credit_card_engine.store.lock_db()?;
+            create_empty_sync_temp_tables(&db.writer)?;
         }
 
         let mut telem = telemetry::Engine::new("whatever");
@@ -303,7 +304,8 @@ mod tests {
         assert!(result.is_ok());
 
         // check that last sync metadata was set
-        let conn = &credit_card_engine.store.db.lock().unwrap().writer;
+        let db = credit_card_engine.store.lock_db()?;
+        let conn = &db.writer;
 
         assert_eq!(
             credit_card_engine.get_meta::<i64>(conn, LAST_SYNC_META_KEY)?,
@@ -332,7 +334,8 @@ mod tests {
             coll: coll_guid,
         };
         {
-            let conn = &credit_card_engine.store.db.lock().unwrap().writer;
+            let db = credit_card_engine.store.lock_db()?;
+            let conn = &db.writer;
             credit_card_engine.put_meta(conn, GLOBAL_SYNCID_META_KEY, &ids.global)?;
             credit_card_engine.put_meta(conn, COLLECTION_SYNCID_META_KEY, &ids.coll)?;
         }
@@ -364,7 +367,7 @@ mod tests {
 
         {
             // temp scope for the mutex lock.
-            let db = &engine.store.db.lock().unwrap();
+            let db = engine.store.lock_db()?;
             let tx = db.writer.unchecked_transaction()?;
             // create a normal record, a mirror record and a tombstone.
             add_internal_credit_card(&tx, &cc)?;
@@ -385,7 +388,8 @@ mod tests {
             coll: coll_guid.clone(),
         };
         {
-            let conn = &engine.store.db.lock().unwrap().writer;
+            let db = engine.store.lock_db()?;
+            let conn = &db.writer;
             engine.put_meta(conn, GLOBAL_SYNCID_META_KEY, &ids.global)?;
             engine.put_meta(conn, COLLECTION_SYNCID_META_KEY, &ids.coll)?;
         }
@@ -396,7 +400,8 @@ mod tests {
             .expect("should work");
 
         {
-            let conn = &engine.store.db.lock().unwrap().writer;
+            let db = engine.store.lock_db()?;
+            let conn = &db.writer;
 
             // check that the mirror and tombstone tables have no records
             assert!(get_all(conn, "credit_cards_mirror".to_string())?.is_empty());
@@ -434,7 +439,8 @@ mod tests {
             .reset(&EngineSyncAssociation::Connected(ids))
             .expect("should work");
 
-        let conn = &engine.store.db.lock().unwrap().writer;
+        let db = engine.store.lock_db()?;
+        let conn = &db.writer;
         // check that the meta records were set
         let retrieved_global_sync_id = engine.get_meta::<String>(conn, GLOBAL_SYNCID_META_KEY)?;
         assert_eq!(

--- a/components/autofill/src/sync/tests/test_migrate_remote_address.rs
+++ b/components/autofill/src/sync/tests/test_migrate_remote_address.rs
@@ -320,7 +320,7 @@ fn test_migrate_remote_addresses() -> Result<()> {
     for test_case in j.as_array().unwrap() {
         let desc = test_case["description"].as_str().unwrap();
         let store = Arc::new(Store::new_memory());
-        let db = store.db.lock().unwrap();
+        let db = store.lock_db().unwrap();
         let tx = db.unchecked_transaction().unwrap();
 
         create_empty_sync_temp_tables(&tx)?;
@@ -387,7 +387,7 @@ fn test_migrate_remote_addresses() -> Result<()> {
         };
 
         // get a DB reference back to we can check the results.
-        let db = store.db.lock().unwrap();
+        let db = store.lock_db().unwrap();
 
         let all = addresses::get_all_addresses(&db)?;
 

--- a/components/autofill/src/sync/tests/test_reconcile.rs
+++ b/components/autofill/src/sync/tests/test_reconcile.rs
@@ -613,7 +613,7 @@ fn test_reconcile_addresses() -> Result<()> {
     for test_case in j.as_array().unwrap() {
         let desc = test_case["description"].as_str().unwrap();
         let store = Arc::new(Store::new_memory());
-        let db = store.db.lock().unwrap();
+        let db = store.lock_db().unwrap();
         let tx = db.unchecked_transaction().unwrap();
 
         create_empty_sync_temp_tables(&tx)?;
@@ -680,7 +680,7 @@ fn test_reconcile_addresses() -> Result<()> {
         };
 
         // get a DB reference back to we can check the results.
-        let db = store.db.lock().unwrap();
+        let db = store.lock_db().unwrap();
 
         let all = addresses::get_all_addresses(&db)?;
 


### PR DESCRIPTION
The connection is otherwise only closed when the Store is dropped, which on Firefox Desktop happens during GC at shutdown -- past the late-write barrier, so the flush crashes debug builds.

Wrap the connection in Mutex<Option<AutofillDb>> behind a fallible lock_db() helper (mirroring LoginStore); shutdown() closes it early, and later operations return DatabaseClosed.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
