### PR TITLE
Use android-components publish.gradle for app-services components

### DIFF
--- a/components/ads-client/android/build.gradle
+++ b/components/ads-client/android/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -45,4 +45,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("ads_client")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.autofill'
@@ -9,12 +9,11 @@ dependencies {
     // Part of the public API.
     api project(':sync15')
 
-    testImplementation project(":syncmanager")
-
     testImplementation libs.androidx.test.core
     testImplementation libs.androidx.work.testing
+    testImplementation project(":syncmanager")
 }
 
 ext.configureUniFFIBindgen("autofill")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.crashtest'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("crashtest")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -47,4 +47,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("fxa_client")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/init_rust_components/android/build.gradle
+++ b/components/init_rust_components/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.init_rust_components'
@@ -15,4 +15,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("init_rust_components")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
@@ -58,4 +58,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("logins")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/merino/android/build.gradle
+++ b/components/merino/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.merino'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("merino")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -54,4 +54,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("nimbus")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -52,4 +52,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("places")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.push'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("push")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/relay/android/build.gradle
+++ b/components/relay/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.relay'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("relay")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -45,7 +45,7 @@ dependencies {
 
 ext.configureUniFFIBindgen("remote_settings")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
 
 dependencies {
     if (gradle.hasProperty("mozconfig")) {

--- a/components/search/android/build.gradle
+++ b/components/search/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.search'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("search")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/suggest/android/build.gradle
+++ b/components/suggest/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.suggest'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("suggest")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -29,7 +29,7 @@ plugins {
 apply plugin: 'kotlinx-serialization'
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
@@ -54,4 +54,4 @@ android {
 
 ext.configureUniFFIBindgen("error_support")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/support/rust-log-forwarder/android/build.gradle
+++ b/components/support/rust-log-forwarder/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.rust_log_forwarder'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("rust_log_forwarder")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/support/tracing/android/build.gradle
+++ b/components/support/tracing/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.tracing'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("tracing_support")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.sync15'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("sync15")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
@@ -55,4 +55,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("sync_manager")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.remotetabs'
@@ -14,4 +14,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("tabs")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.viaduct'
@@ -16,4 +16,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("viaduct")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -144,8 +144,8 @@ if (!gradle.hasProperty("mozconfig")) {
     }
 }
 
-apply from: "$appServicesRootDir/publish.gradle"
-ext.configurePublish()
+apply from: "$publishDir/publish.gradle"
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
 
 if (!gradle.hasProperty("mozconfig")) {
     afterEvaluate {

--- a/publish.gradle
+++ b/publish.gradle
@@ -11,10 +11,10 @@ def libProjectName = properties.libProjectName
 def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
-ext.configurePublish = {
-    def theGroupId = rootProject.config.componentsGroupId
-    def theArtifactId = project.ext.artifactId
-    def theDescription = project.ext.description
+ext.configurePublish = { groupId = null, artifactId = null, description = null ->
+    def theGroupId = groupId ?: rootProject.config.componentsGroupId
+    def theArtifactId = artifactId ?: project.ext.artifactId
+    def theDescription = description ?: project.ext.description
 
     // This is a little cludgey, but it seems unlikely to cause a problem, and
     // we are already doing it inside taskcluster.

--- a/settings.gradle
+++ b/settings.gradle
@@ -76,9 +76,11 @@ def setupProject(name, projectProps, appServicesRootDir) {
             // Expose the rest of the project properties, mostly for validation reasons.
             project.ext.configProps = projectProps
             project.ext.appServicesRootDir = appServicesRootDir
+            project.ext.publishDir = appServicesRootDir
 
             if (gradle.hasProperty("mozconfig")) {
-                project.buildDir = "${gradle.mozconfig.topobjdir}/gradle/build/app-services/android/$name"
+                project.buildDir = "${gradle.mozconfig.topobjdir}/gradle/build/application-services/android/$name"
+                project.ext.publishDir = "${gradle.mozconfig.topsrcdir}/mobile/android/android-components"
             }
         }
     }
@@ -88,6 +90,19 @@ def yaml = new Yaml()
 def buildconfig = yaml.load(new File(appServicesRootDir, '.buildconfig-android.yml').newInputStream())
 buildconfig.projects.each { project ->
     setupProject(project.key, project.value, appServicesRootDir)
+}
+
+if (gradle.root.hasProperty("mozconfig")) {
+    // The mozilla-central android-components/fenix "second pass" build resolves
+    // these components as Maven AARs from target.maven.zip, so the geckoview
+    // archive build must publish every app-services component, not just the
+    // megazord. Aggregate their publish tasks behind a single task.
+    def appServicesPublishTasks = buildconfig.projects.keySet().collect { ":${it}:publish" }
+    gradle.rootProject { rootProject ->
+        rootProject.tasks.register("publishAppServicesAndroid") { task ->
+            task.dependsOn(appServicesPublishTasks)
+        }
+    }
 }
 
 Properties localProperties = new Properties();

--- a/tools/start-bindings/templates/build.gradle
+++ b/tools/start-bindings/templates/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.{{ kotlin_module_name }}'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("{{ crate_name }}")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)


### PR DESCRIPTION
This necessary for the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D292602

In `mozilla-central`, a-s subprojects should publish through the same
publish.gradle as android-components, not a-s's own. This routes them
there when mozconfig is set, while the standalone a-s build is
unchanged. `configurePublish` takes explicit (groupId, artifactId,
description) args because m-c doesn't have a-s's `rootProject.config`.

We also add a `publishAppServicesAndroid` task that aggregates every
app-services component's publish task, so the geckoview archive build
publishes the full set to local maven in one step.