### PR TITLE
Remove unused `error_support` macro re-exports in application-services components

### DIFF
--- a/components/merino/src/curated_recommendations/error.rs
+++ b/components/merino/src/curated_recommendations/error.rs
@@ -4,7 +4,7 @@
 
 use error_support::{ErrorHandling, GetErrorHandling};
 // Re-export logging helpers.
-pub use error_support::{error, trace};
+pub use error_support::trace;
 
 /// Internal convenience wrapper for `std::Result`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/merino/src/suggest/error.rs
+++ b/components/merino/src/suggest/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use error_support::error;
 use error_support::{ErrorHandling, GetErrorHandling};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/merino/src/worldcup/error.rs
+++ b/components/merino/src/worldcup/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use error_support::error;
 use error_support::{ErrorHandling, GetErrorHandling};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -4,7 +4,7 @@
 
 use error_support::{ErrorHandling, GetErrorHandling};
 // reexport logging helpers.
-pub use error_support::{debug, error, info, warn};
+pub use error_support::{debug, info, warn};
 
 pub type Result<T, E = PushError> = std::result::Result<T, E>;
 

--- a/components/relay/src/error.rs
+++ b/components/relay/src/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use error_support::error;
 use error_support::{ErrorHandling, GetErrorHandling};
 use remote_settings::RemoteSettingsError;
 


### PR DESCRIPTION
This necessary for the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D313318

