### PR TITLE
Skip the `kotlin-android` plugin under AGP 9 for mozilla-central builds

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -10,7 +10,13 @@
 import javax.inject.Inject
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// When built as part of mozilla-central (mozconfig present), AGP 9 provides
+// built-in Kotlin support and rejects this plugin; standalone builds still use
+// an older AGP that requires it.
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: 'kotlin-android'
+}
 
 // Typed task used in the standalone app-services build, where the megazord
 // dynamic library is produced by a separate gradle task and only exists when

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: 'kotlin-android'
     apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 }
 


### PR DESCRIPTION
This necessary for the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D313772

AGP 9.0+ ships built-in Kotlin support and hard errors when the
`org.jetbrains.kotlin.android` plugin is also applied. When `application-services`
is built as part of mozilla-central it now uses AGP 9.2.1, so applying the
plugin fails the build.

Gate the plugin on the `mozilla-central` build so it skipped there but still
applied for standalone `application-services` builds, which are on an older
AGP that requires it.
