### PR TITLE
Normalize app-services groupId for mozilla-central builds and fix mozconfig check for nested Gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -136,7 +136,10 @@ def calcVersion(buildconfig) {
 }
 
 def calcGroupId(buildconfig) {
-    if (gradle.rootProject.hasProperty("nightlyVersion")) {
+    if (gradle.root.hasProperty("mozconfig")) {
+        // We are in m-c - always build `org.mozilla.appservices`.
+        return buildconfig.groupId
+    } else if (gradle.rootProject.hasProperty("nightlyVersion")) {
         return buildconfig.groupId + ".nightly"
     } else {
         return buildconfig.groupId
@@ -181,7 +184,7 @@ class Config {
 }
 
 gradle.projectsLoaded { ->
-    if (gradle.hasProperty("mozconfig")) {
+    if (gradle.root.hasProperty("mozconfig")) {
         gradle.rootProject.tasks.register("generateUniffiBindings")
     }
 


### PR DESCRIPTION
This necessary for the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D298762


In `mozilla-central`, a-s always publishes under `org.mozilla.appservices`,
never the `.nightly` variant. The mozconfig property lives on the root
Gradle instance, so the check uses `gradle.root` to work when this
settings.gradle is included from a nested build (m-c includes it from
android-components and fenix).