### PR TITLE
CI: Update the Rust image in use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
   build-desktop-libs:
     steps:
       - run: sudo apt-get update
-      - run: sudo apt-get install python tcl
+      - run: sudo apt-get install python3 tcl
       - run: sudo apt-get install python3-venv
       - run: sudo apt-get install libclang-dev
       - run:
@@ -196,7 +196,7 @@ executors:
   # Unfortunately some of our jobs can only run successfully on macos.
   docker:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.91.0
   macos:
     macos:
       xcode: "26.0"


### PR DESCRIPTION
Note: rustup will still be used to install the right version as defined in rust-toolchain.toml or the minimum version defined in .circleci/config.yml

However newer Rust images come with newer tooling as well (such as a not outdated Python version)
