### PR TITLE
Only build `glean-sym` on Android and iOS

### DIFF
--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -34,6 +34,9 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 thiserror = "2"
 anyhow = "1.0"
 uniffi = { version = "0.31" }
+
+# glean-sym is only used on Android and iOS.
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 glean-sym = { git = "https://github.com/mozilla/glean", tag = "v68.0.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This necessary for the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D313319