### PR TITLE
Remove unused `error_support` macro re-exports in application-services components

### DIFF
--- a/components/ads-client/android/build.gradle
+++ b/components/ads-client/android/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -45,4 +45,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("ads_client")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.autofill'
@@ -9,12 +9,11 @@ dependencies {
     // Part of the public API.
     api project(':sync15')
 
-    testImplementation project(":syncmanager")
-
     testImplementation libs.androidx.test.core
     testImplementation libs.androidx.work.testing
+    testImplementation project(":syncmanager")
 }
 
 ext.configureUniFFIBindgen("autofill")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.crashtest'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("crashtest")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -47,4 +47,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("fxa_client")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/init_rust_components/android/build.gradle
+++ b/components/init_rust_components/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.init_rust_components'
@@ -15,4 +15,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("init_rust_components")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
@@ -58,4 +58,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("logins")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/merino/android/build.gradle
+++ b/components/merino/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.merino'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("merino")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/merino/src/curated_recommendations/error.rs
+++ b/components/merino/src/curated_recommendations/error.rs
@@ -4,7 +4,7 @@
 
 use error_support::{ErrorHandling, GetErrorHandling};
 // Re-export logging helpers.
-pub use error_support::{error, trace};
+pub use error_support::trace;
 
 /// Internal convenience wrapper for `std::Result`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/merino/src/suggest/error.rs
+++ b/components/merino/src/suggest/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use error_support::error;
 use error_support::{ErrorHandling, GetErrorHandling};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/merino/src/worldcup/error.rs
+++ b/components/merino/src/worldcup/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use error_support::error;
 use error_support::{ErrorHandling, GetErrorHandling};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -54,4 +54,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("nimbus")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -34,6 +34,9 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 thiserror = "2"
 anyhow = "1.0"
 uniffi = { version = "0.31" }
+
+# glean-sym is only used on Android and iOS.
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 glean-sym = { git = "https://github.com/mozilla/glean", tag = "v68.0.0", optional = true }
 
 [dev-dependencies]

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -52,4 +52,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("places")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.push'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("push")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -4,7 +4,7 @@
 
 use error_support::{ErrorHandling, GetErrorHandling};
 // reexport logging helpers.
-pub use error_support::{debug, error, info, warn};
+pub use error_support::{debug, info, warn};
 
 pub type Result<T, E = PushError> = std::result::Result<T, E>;
 

--- a/components/relay/android/build.gradle
+++ b/components/relay/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.relay'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("relay")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/relay/src/error.rs
+++ b/components/relay/src/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use error_support::error;
 use error_support::{ErrorHandling, GetErrorHandling};
 use remote_settings::RemoteSettingsError;
 

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 ext {
     gleanNamespace = "mozilla.telemetry.glean"
@@ -45,7 +45,7 @@ dependencies {
 
 ext.configureUniFFIBindgen("remote_settings")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
 
 dependencies {
     if (gradle.hasProperty("mozconfig")) {

--- a/components/search/android/build.gradle
+++ b/components/search/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.search'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("search")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/suggest/android/build.gradle
+++ b/components/suggest/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.suggest'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("suggest")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -29,7 +29,7 @@ plugins {
 apply plugin: 'kotlinx-serialization'
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
@@ -54,4 +54,4 @@ android {
 
 ext.configureUniFFIBindgen("error_support")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/support/rust-log-forwarder/android/build.gradle
+++ b/components/support/rust-log-forwarder/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.rust_log_forwarder'
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("rust_log_forwarder")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/support/tracing/android/build.gradle
+++ b/components/support/tracing/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.tracing'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("tracing_support")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.sync15'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("sync15")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -23,7 +23,7 @@ plugins {
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
@@ -55,4 +55,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("sync_manager")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.remotetabs'
@@ -14,4 +14,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("tabs")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.viaduct'
@@ -16,4 +16,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("viaduct")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -22,7 +22,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
+            consumerProguardFiles "$appServicesRootDir/proguard-rules-consumer-jna.pro"
         }
     }
 
@@ -72,32 +72,116 @@ dependencies {
     }
 }
 
-if (!gradle.hasProperty("mozconfig")) {
-    // Extract JNI dispatch libraries from the JAR into a directory, so that we can then package them
-    // into our own megazord-desktopLibraries JAR.
-    def extractLibJniDispatch = tasks.register("extractLibJniDispatch", Copy) {
-        from zipTree(configurations.jna.singleFile).matching {
-            include "**/libjnidispatch.*"
+abstract class GenerateJniLibsTask extends DefaultTask {
+    @Internal
+    abstract DirectoryProperty getNssLibsSourceDir()
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+
+    @javax.inject.Inject
+    abstract FileSystemOperations getFs()
+
+    @TaskAction
+    void generate() {
+        // Copy NSS shared libs that libmegazord.so depends on (NEEDED) into
+        // the megazord's jniLibs staging area. Standalone consumers like
+        // samples-glean don't include GeckoView and need these in the megazord AAR.
+        def nssLibs = ["libnss3.so", "libfreebl3.so", "libsoftokn3.so", "libmozglue.so"]
+        def srcBase = nssLibsSourceDir.get().asFile
+        if (!srcBase.exists()) {
+            // Some builds do not stage GeckoView, so its native libraries
+            // are not present. There is nothing to copy in that case.
+            return
         }
-        into layout.buildDirectory.dir("libjnidispatch").get()
+        fs.copy {
+            from srcBase
+            include nssLibs.collect { "**/${it}" }
+            into outputDir.get().asFile
+        }
+    }
+}
+
+if (gradle.hasProperty("mozconfig")) {
+    def isFatAar = gradle.mozconfig.substs.MOZ_ANDROID_FAT_AAR_ARCHITECTURES
+    def topobjdir = gradle.mozconfig.topobjdir
+    def generateJniLibs = tasks.register("generateJniLibs", GenerateJniLibsTask) { task ->
+        if (isFatAar) {
+            // Must match the appservices output prefix in `python/mozbuild/mozbuild/action/fat_aar.py`.
+            task.outputDir.set(file("${topobjdir}/dist/fat-aar/output/appservices/jni"))
+            task.nssLibsSourceDir.set(file("${topobjdir}/dist/fat-aar/output/geckoview/jni"))
+        } else {
+            // Must match the destdir in `mobile/android/installer/package-manifest.in`.
+            task.outputDir.set(file("${topobjdir}/dist/geckoview/appservices/lib"))
+            task.nssLibsSourceDir.set(file("${topobjdir}/dist/geckoview/lib"))
+        }
+
+        // Depending directly on a task declared in the root Gradle project
+        // seems to not be sufficiently lazy: `tasks.named(...)` is invoked
+        // during configuration of this project, which is too early and fails.
+        //
+        // But this is sufficiently lazy to be present when needed during
+        // configuration of this project, while still depending on a shared task
+        // in the root Gradle project.
+        if (findProject(":geckoview") != null) {
+            task.dependsOn(":machStagePackage")
+        }
     }
 
-    def packageLibsForTest = tasks.register("packageLibsForTest", Jar) {
-        archiveBaseName = "full-megazord-libsForTests"
+    androidComponents {
+        onVariants(selector().all()) { variant ->
+            variant.sources.jniLibs?.addGeneratedSourceDirectory(
+                generateJniLibs,
+                { task -> task.outputDir }
+            )
+        }
+    }
+}
 
-        from extractLibJniDispatch
+// Extract JNI dispatch libraries from the JAR into a directory, so that we can then package them
+// into our own megazord-desktopLibraries JAR.
+// Resolve the JNA JAR at configuration time so `--download-all-gradle-dependencies`
+// fetches it into the offline repository; a lazy resolution inside the task action
+// isn't reached during the dry-run dependency fetch.
+def jnaLibJniDispatch = zipTree(configurations.jna.singleFile).matching {
+    include "**/libjnidispatch.*"
+}
+
+def extractLibJniDispatch = tasks.register("extractLibJniDispatch", Copy) {
+    from jnaLibJniDispatch
+    into layout.buildDirectory.dir("libjnidispatch").get()
+}
+
+def packageLibsForTest = tasks.register("packageLibsForTest", Jar) {
+    archiveBaseName = "full-megazord-libsForTests"
+
+    from extractLibJniDispatch
+    if (!gradle.hasProperty("mozconfig")) {
         from layout.buildDirectory.dir("rustJniLibs/desktop")
         dependsOn tasks["cargoBuild${rootProject.ext.nativeRustTarget.capitalize()}"]
     }
 
+    if (gradle.hasProperty("mozconfig")) {
+        if (gradle.mozconfig.substs.MOZ_ANDROID_FAT_AAR_DESKTOP_ARCHITECTURES) {
+            from "${gradle.mozconfig.topobjdir}/dist/fat-aar/output/desktop/resources"
+        } else {
+            from "${gradle.mozconfig.topobjdir}/dist/host/bin/appservices/resources"
+        }
+    }
+}
+
+artifacts {
+    // Connect task output to configurations
+    libsForTests(packageLibsForTest)
+}
+
+if (!gradle.hasProperty("mozconfig")) {
     def copyMegazordNative = tasks.register("copyMegazordNative", Copy) {
         from layout.buildDirectory.dir("rustJniLibs/desktop")
         into layout.buildDirectory.dir("megazordNative")
     }
 
     artifacts {
-        // Connect task output to configurations
-        libsForTests(packageLibsForTest)
         megazordNative(copyMegazordNative)
     }
 
@@ -147,51 +231,58 @@ if (!gradle.hasProperty("mozconfig")) {
 apply from: "$publishDir/publish.gradle"
 ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
 
-if (!gradle.hasProperty("mozconfig")) {
-    afterEvaluate {
-        publishing {
-            publications {
-                // Publish a second package named `full-megazord-libsForTests` to Maven with the
-                // `libsForTests` output.  This contains the same content as our `libsForTests`
-                // configuration. Publishing it allows the android-components code to depend on it.
-                libsForTests(MavenPublication) {
-                    artifact tasks['packageLibsForTest']
+afterEvaluate {
+    def libUrl="https://github.com/mozilla/application-services"
+    def libVcsUrl="https://github.com/mozilla/application-services.git"
+
+    def libLicense="MPL-2.0"
+    def libLicenseUrl="https://www.mozilla.org/en-US/MPL/2.0/"
+
+    publishing {
+        publications {
+            // Publish a second package named `full-megazord-libsForTests` to Maven with the
+            // `libsForTests` output.  This contains the same content as our `libsForTests`
+            // configuration. Publishing it allows the android-components code to depend on it.
+            libsForTests(MavenPublication) {
+                artifact tasks['packageLibsForTest']
+                if (!gradle.hasProperty("mozconfig")) {
                     artifact file("${projectDir}/../DEPENDENCIES.md"), {
                         extension "LICENSES.md"
                     }
-                    pom {
-                        groupId = rootProject.config.componentsGroupId
-                        artifactId = "${project.ext.artifactId}-libsForTests"
-                        description = project.ext.description
-                        // For mavenLocal publishing workflow, increment the version number every publish.
-                        version = rootProject.config.componentsVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
-                        packaging = "jar"
+                }
 
-                        licenses {
-                            license {
-                                name = libLicense
-                                url = libLicenseUrl
-                            }
-                        }
+                pom {
+                    groupId = "org.mozilla.appservices"
+                    artifactId = "${project.ext.artifactId}-libsForTests"
+                    description = project.ext.description
+                    // For mavenLocal publishing workflow, increment the version number every publish.
+                    version = rootProject.config.componentsVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
+                    packaging = "jar"
 
-                        developers {
-                            developer {
-                                name = 'Sync Team'
-                                email = 'sync-team@mozilla.com'
-                            }
-                        }
-
-                        scm {
-                            connection = libVcsUrl
-                            developerConnection = libVcsUrl
-                            url = libUrl
+                    licenses {
+                        license {
+                            name = libLicense
+                            url = libLicenseUrl
                         }
                     }
 
-                    // This is never the publication we want to use when publishing a
-                    // parent project with us as a child `project()` dependency.
-                    alias = true
+                    developers {
+                        developer {
+                            name = 'Sync Team'
+                            email = 'sync-team@mozilla.com'
+                        }
+                    }
+
+                    scm {
+                        connection = libVcsUrl
+                        developerConnection = libVcsUrl
+                        url = libUrl
+                    }
                 }
+
+                // This is never the publication we want to use when publishing a
+                // parent project with us as a child `project()` dependency.
+                alias = true
             }
         }
     }

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -144,8 +144,8 @@ if (!gradle.hasProperty("mozconfig")) {
     }
 }
 
-apply from: "$appServicesRootDir/publish.gradle"
-ext.configurePublish()
+apply from: "$publishDir/publish.gradle"
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
 
 if (!gradle.hasProperty("mozconfig")) {
     afterEvaluate {

--- a/publish.gradle
+++ b/publish.gradle
@@ -11,10 +11,10 @@ def libProjectName = properties.libProjectName
 def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
-ext.configurePublish = {
-    def theGroupId = rootProject.config.componentsGroupId
-    def theArtifactId = project.ext.artifactId
-    def theDescription = project.ext.description
+ext.configurePublish = { groupId = null, artifactId = null, description = null ->
+    def theGroupId = groupId ?: rootProject.config.componentsGroupId
+    def theArtifactId = artifactId ?: project.ext.artifactId
+    def theDescription = description ?: project.ext.description
 
     // This is a little cludgey, but it seems unlikely to cause a problem, and
     // we are already doing it inside taskcluster.

--- a/settings.gradle
+++ b/settings.gradle
@@ -76,9 +76,11 @@ def setupProject(name, projectProps, appServicesRootDir) {
             // Expose the rest of the project properties, mostly for validation reasons.
             project.ext.configProps = projectProps
             project.ext.appServicesRootDir = appServicesRootDir
+            project.ext.publishDir = appServicesRootDir
 
             if (gradle.hasProperty("mozconfig")) {
-                project.buildDir = "${gradle.mozconfig.topobjdir}/gradle/build/app-services/android/$name"
+                project.buildDir = "${gradle.mozconfig.topobjdir}/gradle/build/application-services/android/$name"
+                project.ext.publishDir = "${gradle.mozconfig.topsrcdir}/mobile/android/android-components"
             }
         }
     }
@@ -88,6 +90,19 @@ def yaml = new Yaml()
 def buildconfig = yaml.load(new File(appServicesRootDir, '.buildconfig-android.yml').newInputStream())
 buildconfig.projects.each { project ->
     setupProject(project.key, project.value, appServicesRootDir)
+}
+
+if (gradle.root.hasProperty("mozconfig")) {
+    // The mozilla-central android-components/fenix "second pass" build resolves
+    // these components as Maven AARs from target.maven.zip, so the geckoview
+    // archive build must publish every app-services component, not just the
+    // megazord. Aggregate their publish tasks behind a single task.
+    def appServicesPublishTasks = buildconfig.projects.keySet().collect { ":${it}:publish" }
+    gradle.rootProject { rootProject ->
+        rootProject.tasks.register("publishAppServicesAndroid") { task ->
+            task.dependsOn(appServicesPublishTasks)
+        }
+    }
 }
 
 Properties localProperties = new Properties();

--- a/tools/start-bindings/templates/build.gradle
+++ b/tools/start-bindings/templates/build.gradle
@@ -1,5 +1,5 @@
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
-apply from: "$appServicesRootDir/publish.gradle"
+apply from: "$publishDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.{{ kotlin_module_name }}'
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("{{ crate_name }}")
 ext.dependsOnTheMegazord()
-ext.configurePublish()
+ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)


### PR DESCRIPTION
This necessary for the `application-services` monorepo work in Firefox. Full stack on Phabricator here: https://phabricator.services.mozilla.com/D313318

