### PR TITLE
Bug 2058816 - updating get_base_url and get_url in remote_settings to append v2

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -762,7 +762,7 @@ struct RemoteSettingsEndpoints {
 impl RemoteSettingsEndpoints {
     /// Construct a new RemoteSettingsEndpoints
     ///
-    /// `base_url` should have the form `https://[domain]/v1` (no trailing slash).
+    /// `base_url` should have the form `https://[domain]/v2` (no trailing slash).
     fn new(base_url: &BaseUrl, bucket_name: &str, collection_name: &str) -> Self {
         let mut root_url = base_url.clone();
         // Push the empty string to add the trailing slash.
@@ -944,18 +944,18 @@ mod test_new_client {
     #[test]
     fn test_endpoints() {
         let endpoints = RemoteSettingsEndpoints::new(
-            &BaseUrl::parse("http://rs.example.com/v1").unwrap(),
+            &BaseUrl::parse("http://rs.example.com/v2").unwrap(),
             "main",
             "test-collection",
         );
-        assert_eq!(endpoints.root_url.to_string(), "http://rs.example.com/v1/");
+        assert_eq!(endpoints.root_url.to_string(), "http://rs.example.com/v2/");
         assert_eq!(
             endpoints.collection_url.to_string(),
-            "http://rs.example.com/v1/buckets/main/collections/test-collection",
+            "http://rs.example.com/v2/buckets/main/collections/test-collection",
         );
         assert_eq!(
             endpoints.changeset_url.to_string(),
-            "http://rs.example.com/v1/buckets/main/collections/test-collection/changeset",
+            "http://rs.example.com/v2/buckets/main/collections/test-collection/changeset",
         );
     }
 }
@@ -986,7 +986,7 @@ mod jexl_tests {
             metadata: CollectionMetadata::default(),
         };
         api_client.expect_collection_url().returning(|| {
-            "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
+            "http://rs.example.com/v2/buckets/main/collections/test-collection".into()
         });
         api_client.expect_fetch_changeset().returning({
             let changeset = changeset.clone();
@@ -1004,7 +1004,7 @@ mod jexl_tests {
 
         let mut storage = Storage::new(":memory:".into());
         let _ = storage.insert_collection_content(
-            "http://rs.example.com/v1/buckets/main/collections/test-collection",
+            "http://rs.example.com/v2/buckets/main/collections/test-collection",
             &records,
             42,
             CollectionMetadata::default(),
@@ -1044,7 +1044,7 @@ mod jexl_tests {
             metadata: CollectionMetadata::default(),
         };
         api_client.expect_collection_url().returning(|| {
-            "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
+            "http://rs.example.com/v2/buckets/main/collections/test-collection".into()
         });
         api_client.expect_fetch_changeset().returning({
             let changeset = changeset.clone();
@@ -1062,7 +1062,7 @@ mod jexl_tests {
 
         let mut storage = Storage::new(":memory:".into());
         let _ = storage.insert_collection_content(
-            "http://rs.example.com/v1/buckets/main/collections/test-collection",
+            "http://rs.example.com/v2/buckets/main/collections/test-collection",
             &records,
             42,
             CollectionMetadata::default(),
@@ -1102,7 +1102,7 @@ mod jexl_tests {
             metadata: CollectionMetadata::default(),
         };
         api_client.expect_collection_url().returning(|| {
-            "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
+            "http://rs.example.com/v2/buckets/main/collections/test-collection".into()
         });
         api_client.expect_fetch_changeset().returning({
             let changeset = changeset.clone();
@@ -1120,7 +1120,7 @@ mod jexl_tests {
 
         let mut storage = Storage::new(":memory:".into());
         let _ = storage.insert_collection_content(
-            "http://rs.example.com/v1/buckets/main/collections/test-collection",
+            "http://rs.example.com/v2/buckets/main/collections/test-collection",
             &records,
             42,
             CollectionMetadata::default(),
@@ -1180,7 +1180,7 @@ mod jexl_tests {
                     "test-collection".to_string(),
                     None,
                 );
-            "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
+            "http://rs.example.com/v2/buckets/main/collections/test-collection".into()
         });
         api_client.expect_is_prod_server().returning(|| Ok(false));
 
@@ -1609,7 +1609,7 @@ mod test_reset_storage {
 
     #[test]
     fn test_reset_storage_deletes_records_and_attachments() {
-        let collection_url = "http://rs.example.com/v1/buckets/main/collections/test-collection";
+        let collection_url = "http://rs.example.com/v2/buckets/main/collections/test-collection";
 
         let mut api_client = MockApiClient::new();
         api_client
@@ -1675,7 +1675,7 @@ mod test_reset_storage {
 
     #[test]
     fn test_reset_storage_reverts_to_packaged_data() {
-        let collection_url = "http://rs.example.com/v1/buckets/main/collections/regions";
+        let collection_url = "http://rs.example.com/v2/buckets/main/collections/regions";
 
         let mut api_client = MockApiClient::new();
         api_client

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -47,12 +47,12 @@ impl RemoteSettingsServer {
     pub fn get_base_url(&self) -> Result<BaseUrl> {
         let base_url = BaseUrl::parse(self.raw_url())?;
         // Custom URLs are weird and require a couple tricks for backwards compatibility.
-        // Normally we append `v1/` to match how this has historically worked.  However,
+        // Normally we append `v2/` to match how this has historically worked.  However,
         // don't do this for file:// schemes which normally don't make any sense, but it's
         // what Nimbus uses to indicate they want to use the file-based client, rather than
         // a remote-settings based one.
         if base_url.url().scheme() != "file" {
-            Ok(base_url.join("v1"))
+            Ok(base_url.join("v2"))
         } else {
             Ok(base_url)
         }
@@ -96,12 +96,12 @@ impl RemoteSettingsServer {
             Self::Custom { url } => {
                 let mut url = Url::parse(url)?;
                 // Custom URLs are weird and require a couple tricks for backwards compatibility.
-                // Normally we append `v1/` to match how this has historically worked.  However,
+                // Normally we append `v2/` to match how this has historically worked.  However,
                 // don't do this for file:// schemes which normally don't make any sense, but it's
                 // what Nimbus uses to indicate they want to use the file-based client, rather than
                 // a remote-settings based one.
                 if url.scheme() != "file" {
-                    url = url.join("v1")?
+                    url = url.join("v2")?
                 }
                 url
             }

--- a/components/remote_settings/src/schema.rs
+++ b/components/remote_settings/src/schema.rs
@@ -206,7 +206,7 @@ PRAGMA user_version=0;
             "INSERT INTO records (id, collection_url, data) VALUES (?, ?, ?)",
             rusqlite::params![
                 "sponsored-suggestions-us-phone",
-                "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/quicksuggest-amp",
+                "https://firefox.settings.services.mozilla.com/v2/buckets/main/collections/quicksuggest-amp",
                 serde_json::to_vec(&record).unwrap(),
             ],
         ).unwrap();
@@ -216,7 +216,7 @@ PRAGMA user_version=0;
             "INSERT INTO attachments (id, collection_url, data) VALUES (?, ?, ?)",
             rusqlite::params![
                 "main-workspace/quicksuggest-amp/b.json",
-                "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/quicksuggest-amp",
+                "https://firefox.settings.services.mozilla.com/v2/buckets/main/collections/quicksuggest-amp",
                 b"current attachment data",
             ],
         ).unwrap();
@@ -226,7 +226,7 @@ PRAGMA user_version=0;
             "INSERT INTO attachments (id, collection_url, data) VALUES (?, ?, ?)",
             rusqlite::params![
                 "main-workspace/quicksuggest-amp/a.json",
-                "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/quicksuggest-amp",
+                "https://firefox.settings.services.mozilla.com/v2/buckets/main/collections/quicksuggest-amp",
                 b"orphaned attachment data that should be cleaned up",
             ],
         ).unwrap();

--- a/components/remote_settings/src/service.rs
+++ b/components/remote_settings/src/service.rs
@@ -350,7 +350,7 @@ mod test {
     }
 
     fn mock_monitor_changes(collection: &str, timestamp: u64) -> mockito::Mock {
-        mock("GET", "/v1/buckets/monitor/collections/changes/changeset")
+        mock("GET", "/v2/buckets/monitor/collections/changes/changeset")
             .match_query(Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -363,7 +363,7 @@ mod test {
     fn mock_changeset(collection: &str, timestamp: u64) -> mockito::Mock {
         mock(
             "GET",
-            format!("/v1/buckets/main/collections/{collection}/changeset").as_str(),
+            format!("/v2/buckets/main/collections/{collection}/changeset").as_str(),
         )
         .match_query(Matcher::Any)
         .with_status(200)
@@ -377,7 +377,7 @@ mod test {
     fn mock_changeset_error(bucket: &str, collection: &str) -> mockito::Mock {
         mock(
             "GET",
-            format!("/v1/buckets/{bucket}/collections/{collection}/changeset").as_str(),
+            format!("/v2/buckets/{bucket}/collections/{collection}/changeset").as_str(),
         )
         .match_query(Matcher::Any)
         .with_status(500)
@@ -561,7 +561,7 @@ mod test {
         );
 
         // First sync creates a record that references the big attachment.
-        let _changes_1 = mock("GET", "/v1/buckets/monitor/collections/changes/changeset")
+        let _changes_1 = mock("GET", "/v2/buckets/monitor/collections/changes/changeset")
             .match_query(Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -577,7 +577,7 @@ mod test {
 
         let _changeset_1 = mock(
             "GET",
-            format!("/v1/buckets/main/collections/{collection}/changeset").as_str(),
+            format!("/v2/buckets/main/collections/{collection}/changeset").as_str(),
         )
         .match_query(Matcher::Any)
         .with_status(200)
@@ -606,7 +606,7 @@ mod test {
         service.sync()?;
 
         // Mock attachment discovery and download.
-        let _root = mock("GET", "/v1/")
+        let _root = mock("GET", "/v2/")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(format!(
@@ -659,7 +659,7 @@ mod test {
 
         // Second sync tombstones the record. This deletes the attachment row, and
         // post-sync maintenance should compact the database.
-        let _changes_2 = mock("GET", "/v1/buckets/monitor/collections/changes/changeset")
+        let _changes_2 = mock("GET", "/v2/buckets/monitor/collections/changes/changeset")
             .match_query(Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -675,7 +675,7 @@ mod test {
 
         let _changeset_2 = mock(
             "GET",
-            format!("/v1/buckets/main/collections/{collection}/changeset").as_str(),
+            format!("/v2/buckets/main/collections/{collection}/changeset").as_str(),
         )
         .match_query(Matcher::Any)
         .with_status(200)

--- a/components/search/src/selector.rs
+++ b/components/search/src/selector.rs
@@ -899,7 +899,7 @@ mod tests {
     fn mock_changes_endpoint() -> mockito::Mock {
         mock(
             "GET",
-            "/v1/buckets/monitor/collections/changes/changeset?_expected=0",
+            "/v2/buckets/monitor/collections/changes/changeset?_expected=0",
         )
         .with_body(response_body_changes())
         .with_status(200)
@@ -1047,7 +1047,7 @@ mod tests {
         let changes_mock = mock_changes_endpoint();
         let m = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(
             json!({
@@ -1094,7 +1094,7 @@ mod tests {
         let changes_mock = mock_changes_endpoint();
         let m1 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(response_body())
         .with_status(501)
@@ -1125,7 +1125,7 @@ mod tests {
         let changes_mock = mock_changes_endpoint();
         let m1 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(response_body())
         .with_status(200)
@@ -1135,7 +1135,7 @@ mod tests {
 
         let m2 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-overrides-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-overrides-v2/changeset?_expected=0",
         )
         .with_body(
             json!({
@@ -1180,7 +1180,7 @@ mod tests {
         let changes_mock = mock_changes_endpoint();
         let m1 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(response_body())
         .with_status(200)
@@ -1190,7 +1190,7 @@ mod tests {
 
         let m2 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-overrides-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-overrides-v2/changeset?_expected=0",
         )
         .with_body(response_body_overrides())
         .with_status(501)
@@ -1222,7 +1222,7 @@ mod tests {
         let changes_mock = mock_changes_endpoint();
         let m1 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(response_body())
         .with_status(200)
@@ -1232,7 +1232,7 @@ mod tests {
 
         let m2 = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-overrides-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-overrides-v2/changeset?_expected=0",
         )
         .with_body(response_body_overrides())
         .with_status(200)
@@ -1281,7 +1281,7 @@ mod tests {
 
         let m = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(response_body())
         .with_status(200)
@@ -1352,7 +1352,7 @@ mod tests {
         let changes_mock = mock_changes_endpoint();
         let m = mock(
             "GET",
-            "/v1/buckets/main/collections/search-config-v2/changeset?_expected=0",
+            "/v2/buckets/main/collections/search-config-v2/changeset?_expected=0",
         )
         .with_body(response_body_locales())
         .with_status(200)

--- a/components/support/nimbus-cli/src/output/server.rs
+++ b/components/support/nimbus-cli/src/output/server.rs
@@ -50,7 +50,7 @@ fn create_app(livereload: LiveReloadLayer, state: Db) -> Router {
         .route("/post", post(post_handler))
         .route("/buckets/:bucket/collections/:collection/records", get(rs))
         .route(
-            "/v1/buckets/:bucket/collections/:collection/records",
+            "/v2/buckets/:bucket/collections/:collection/records",
             get(rs),
         )
         .layer(livereload)
@@ -376,7 +376,7 @@ mod tests {
         let _ = post_payload(&payload, &format!("127.0.0.1:{port}")).await?;
 
         // Check the fake Remote Settings page
-        let s = get(port, "/v1/buckets/BUCKET/collections/COLLECTION/records").await?;
+        let s = get(port, "/v2/buckets/BUCKET/collections/COLLECTION/records").await?;
         assert_eq!(s, serde_json::to_string(&value)?);
 
         let s = get(port, "/buckets/BUCKET/collections/COLLECTION/records").await?;
@@ -392,7 +392,7 @@ mod tests {
         let (_, tx) = start_test_server(port)?;
 
         // Part 1: get from remote settings page before anything has been posted yet.
-        let s = get(port, "/v1/buckets/BUCKET/collections/COLLECTION/records").await?;
+        let s = get(port, "/v2/buckets/BUCKET/collections/COLLECTION/records").await?;
         assert_eq!(s, "null".to_string());
 
         // Part 2: Post a payload, but not with any experiments.
@@ -404,7 +404,7 @@ mod tests {
 
         // Check the fake Remote Settings page, should be empty, since an experiments payload
         // wasn't posted
-        let s = get(port, "/v1/buckets/BUCKET/collections/COLLECTION/records").await?;
+        let s = get(port, "/v2/buckets/BUCKET/collections/COLLECTION/records").await?;
         assert_eq!(s, "".to_string());
 
         let _ = tx.send(());


### PR DESCRIPTION
## Description
Correcting [bug 2058816](https://bugzilla.mozilla.org/show_bug.cgi?id=2058816) by appending `v2` in `get_url` and `get_base_url` in `remote_settings/src/config.rs`. This was missed during the v1 removal #7492 .



### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
  - Covered by #7492 
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
