### PR TITLE
Fix `groupId` dropping the `.nightly` suffix

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -115,6 +115,15 @@ dependencies {
     androidTestImplementation libs.androidx.test.runner
 }
 
+// Pick the publish group id by build context. In m-c, `config` belongs to
+// android-components (`config.componentsGroupId` is `org.mozilla.components`),
+// so we hardcode `org.mozilla.appservices`. Standalone app-services uses
+// `config.componentsGroupId`, which is the only place that appends the
+// `.nightly` suffix nightly builds publish under.
+ext.appServicesGroupId = gradle.root.hasProperty("mozconfig")
+    ? "org.mozilla.appservices"
+    : rootProject.config.componentsGroupId
+
 // Shared logic for projects that depend on libmegazord
 //
 // This ensures that libmegazord will be in the library path so that it can be loaded.  It also adds

--- a/components/ads-client/android/build.gradle
+++ b/components/ads-client/android/build.gradle
@@ -45,4 +45,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("ads_client")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -16,4 +16,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("autofill")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("crashtest")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -47,4 +47,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("fxa_client")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/init_rust_components/android/build.gradle
+++ b/components/init_rust_components/android/build.gradle
@@ -15,4 +15,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("init_rust_components")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -58,4 +58,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("logins")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/merino/android/build.gradle
+++ b/components/merino/android/build.gradle
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("merino")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -54,4 +54,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("nimbus")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -52,4 +52,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("places")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("push")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/relay/android/build.gradle
+++ b/components/relay/android/build.gradle
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("relay")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 ext.configureUniFFIBindgen("remote_settings")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)
 
 dependencies {
     if (gradle.hasProperty("mozconfig")) {

--- a/components/search/android/build.gradle
+++ b/components/search/android/build.gradle
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("search")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/suggest/android/build.gradle
+++ b/components/suggest/android/build.gradle
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("suggest")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -54,4 +54,4 @@ android {
 
 ext.configureUniFFIBindgen("error_support")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/support/rust-log-forwarder/android/build.gradle
+++ b/components/support/rust-log-forwarder/android/build.gradle
@@ -11,4 +11,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("rust_log_forwarder")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/support/tracing/android/build.gradle
+++ b/components/support/tracing/android/build.gradle
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("tracing_support")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("sync15")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -55,4 +55,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("sync_manager")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -14,4 +14,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("tabs")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -16,4 +16,4 @@ dependencies {
 
 ext.configureUniFFIBindgen("viaduct")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -228,8 +228,18 @@ if (!gradle.hasProperty("mozconfig")) {
     }
 }
 
+// Duplicated from component-common.gradle, which the megazord doesn't apply.
+// Pick the publish group id by build context. In m-c, `config` belongs to
+// android-components (`config.componentsGroupId` is `org.mozilla.components`),
+// so we hardcode `org.mozilla.appservices`. Standalone app-services uses
+// `config.componentsGroupId`, which is the only place that appends the
+// `.nightly` suffix nightly builds publish under.
+ext.appServicesGroupId = gradle.root.hasProperty("mozconfig")
+    ? "org.mozilla.appservices"
+    : rootProject.config.componentsGroupId
+
 apply from: "$publishDir/publish.gradle"
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)
 
 afterEvaluate {
     def libUrl="https://github.com/mozilla/application-services"
@@ -252,7 +262,7 @@ afterEvaluate {
                 }
 
                 pom {
-                    groupId = "org.mozilla.appservices"
+                    groupId = project.ext.appServicesGroupId
                     artifactId = "${project.ext.artifactId}-libsForTests"
                     description = project.ext.description
                     // For mavenLocal publishing workflow, increment the version number every publish.

--- a/publish.gradle
+++ b/publish.gradle
@@ -11,10 +11,12 @@ def libProjectName = properties.libProjectName
 def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
-ext.configurePublish = { groupId = null, artifactId = null, description = null ->
-    def theGroupId = groupId ?: rootProject.config.componentsGroupId
-    def theArtifactId = artifactId ?: project.ext.artifactId
-    def theDescription = description ?: project.ext.description
+// The `Arg` suffixes matter. Naming these `groupId`, `artifactId` or `description` shadows the
+// assignments to the publication down in `pom`, which then silently do nothing.
+ext.configurePublish = { groupIdArg = null, artifactIdArg = null, descriptionArg = null ->
+    def theGroupId = groupIdArg ?: rootProject.config.componentsGroupId
+    def theArtifactId = artifactIdArg ?: project.ext.artifactId
+    def theDescription = descriptionArg ?: project.ext.description
 
     // This is a little cludgey, but it seems unlikely to cause a problem, and
     // we are already doing it inside taskcluster.

--- a/tools/start-bindings/templates/build.gradle
+++ b/tools/start-bindings/templates/build.gradle
@@ -7,4 +7,4 @@ android {
 
 ext.configureUniFFIBindgen("{{ crate_name }}")
 ext.dependsOnTheMegazord()
-ext.configurePublish("org.mozilla.appservices", project.name, project.ext.description)
+ext.configurePublish(appServicesGroupId, project.name, project.ext.description)


### PR DESCRIPTION
PR #7508 hardcoded `"org.mozilla.appservices"`, dropping the `.nightly` suffix
on nightly builds. To fix, we add `appServicesGroupId` to resolve the proper
`groupId` based on the context (`mozilla-central` or standalone
`application-services`).

`configurePublish`'s parameters were also being shadowed in `publish.gradle`,
which this resolves too.
