### PR TITLE
[AC-152] Fixes moz ads telemetry UniFFI callback leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## ✨ What's Changed ✨
 
+### Ads-Client
+
+- Add `AdsClient::shutdown_client()`, which closes the database connection early so it happens before Firefox Desktop's late-write shutdown barrier rather than during GC. In addition, this drops all held UniFFI callbacks (held in the MozAdsTelemetryWrapper) to avoid crash on a Firefox Desktop quit.
+
 ### Autofill
 
 - Add `Store::shutdown()`, which closes the database connection early so it happens before Firefox Desktop's late-write shutdown barrier rather than during GC. Operations after shutdown return `DatabaseClosed`. ([Bug 2050036](https://bugzilla.mozilla.org/show_bug.cgi?id=2050036))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Ads-Client
 
-- Add `AdsClient::shutdown_client()`, which closes the database connection early so it happens before Firefox Desktop's late-write shutdown barrier rather than during GC. In addition, this drops all held UniFFI callbacks (held in the MozAdsTelemetryWrapper) to avoid crash on a Firefox Desktop quit.
+- Add `AdsClient::shutdown()`, which closes the database connection early so it happens before Firefox Desktop's late-write shutdown barrier rather than during GC. In addition, this drops all held UniFFI callbacks (held in the MozAdsTelemetryWrapper) to avoid crash on a Firefox Desktop quit.
 
 ### Autofill
 

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -101,11 +101,11 @@ where
     // Shutdown the db connection and drop references to telemetry callbacks.
     // Should be used only when dropping the ads client, this may be extended to drop more things.
     pub fn shutdown_client(&mut self) -> Result<(), rusqlite::Error> {
-        // Shutdown DB
-        self.client.shutdown_db()?;
-
         // Drop telemetry (within the telemetry wrapper)
         self.telemetry.shutdown();
+
+        // Shutdown DB
+        self.client.shutdown_db()?;
 
         Ok(())
     }

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -41,7 +41,7 @@ where
 {
     client: MARSClient<T>,
     context_id_provider: Box<dyn ContextIdProvider>,
-    telemetry: Option<T>,
+    telemetry: T,
 }
 
 impl<T> AdsClient<T>
@@ -90,7 +90,7 @@ where
         Self {
             client,
             context_id_provider,
-            telemetry: Some(telemetry.clone()),
+            telemetry: telemetry.clone(),
         }
     }
 
@@ -104,9 +104,8 @@ where
         // Shutdown DB
         self.client.shutdown_db()?;
 
-        // Drop telemetry recursively
-        self.telemetry = None;
-        self.client.drop_telemetry();
+        // Drop telemetry (within the telemetry wrapper)
+        self.telemetry.shutdown();
 
         Ok(())
     }
@@ -125,14 +124,10 @@ where
         self.client
             .record_click(click_url, ohttp)
             .inspect_err(|e| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(e);
-                }
+                self.telemetry.record(e);
             })
             .inspect(|_| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(&ClientOperationEvent::RecordClick);
-                }
+                self.telemetry.record(&ClientOperationEvent::RecordClick);
             })
     }
 
@@ -173,14 +168,11 @@ where
         self.client
             .record_impression(impression_url, ohttp)
             .inspect_err(|e| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(e);
-                }
+                self.telemetry.record(e);
             })
             .inspect(|_| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(&ClientOperationEvent::RecordImpression);
-                }
+                self.telemetry
+                    .record(&ClientOperationEvent::RecordImpression);
             })
     }
 
@@ -193,14 +185,10 @@ where
         self.client
             .report_ad(report_url, reason, ohttp)
             .inspect_err(|e| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(e);
-                }
+                self.telemetry.record(e);
             })
             .inspect(|_| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(&ClientOperationEvent::ReportAd);
-                }
+                self.telemetry.record(&ClientOperationEvent::ReportAd);
             })
     }
 
@@ -214,13 +202,9 @@ where
         let response = self
             .request_ads::<AdImage>(ad_placement_requests, flags, options, ohttp)
             .inspect_err(|e| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(e);
-                }
+                self.telemetry.record(e);
             })?;
-        if let Some(telemetry) = &self.telemetry {
-            telemetry.record(&ClientOperationEvent::RequestAds);
-        }
+        self.telemetry.record(&ClientOperationEvent::RequestAds);
         Ok(response.take_first())
     }
 
@@ -234,14 +218,10 @@ where
         let result = self.request_ads::<AdSpoc>(ad_placement_requests, flags, options, ohttp);
         result
             .inspect_err(|e| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(e);
-                }
+                self.telemetry.record(e);
             })
             .map(|response| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(&ClientOperationEvent::RequestAds);
-                }
+                self.telemetry.record(&ClientOperationEvent::RequestAds);
                 response.data
             })
     }
@@ -256,14 +236,10 @@ where
         let result = self.request_ads::<AdTile>(ad_placement_requests, flags, options, ohttp);
         result
             .inspect_err(|e| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(e);
-                }
+                self.telemetry.record(e);
             })
             .map(|response| {
-                if let Some(telemetry) = &self.telemetry {
-                    telemetry.record(&ClientOperationEvent::RequestAds);
-                }
+                self.telemetry.record(&ClientOperationEvent::RequestAds);
                 response.take_first()
             })
     }

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -302,7 +302,7 @@ mod tests {
     use std::{assert_eq, assert_ne, sync::Arc};
 
     use crate::{
-        ffi::telemetry::{MozAdsTelemetryWrapper, NoopMozAdsTelemetry},
+        ffi::telemetry::MozAdsTelemetryWrapper,
         mars::Environment,
         test_utils::{
             get_example_happy_image_response, get_example_happy_spoc_response,

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -524,7 +524,11 @@ mod tests {
 
         // test with client created from config
         let noop_telemetry = MozAdsTelemetryWrapper::noop();
-        let weak_reference = Arc::downgrade(&noop_telemetry.clone_inner_arc());
+        let weak_reference = Arc::downgrade(
+            &noop_telemetry
+                .clone_inner_arc()
+                .expect("Inner telemetry should be Some before dropping"),
+        );
         let config = AdsClientConfig {
             cache_config: None,
             context_id_provider: None,
@@ -540,7 +544,11 @@ mod tests {
 
         // test also with internal function from_mars
         let noop_telemetry = MozAdsTelemetryWrapper::noop();
-        let weak_reference = Arc::downgrade(&noop_telemetry.clone_inner_arc());
+        let weak_reference = Arc::downgrade(
+            &noop_telemetry
+                .clone_inner_arc()
+                .expect("Inner telemetry should be Some before dropping"),
+        );
         let cache = HttpCache::builder("test_shutdown_telemetry")
             .build()
             .unwrap();

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -41,7 +41,7 @@ where
 {
     client: MARSClient<T>,
     context_id_provider: Box<dyn ContextIdProvider>,
-    telemetry: T,
+    telemetry: Option<T>,
 }
 
 impl<T> AdsClient<T>
@@ -90,12 +90,25 @@ where
         Self {
             client,
             context_id_provider,
-            telemetry: telemetry.clone(),
+            telemetry: Some(telemetry.clone()),
         }
     }
 
     pub fn clear_cache(&self) -> Result<(), rusqlite::Error> {
         self.client.clear_cache()
+    }
+
+    // Shutdown the db connection and drop references to telemetry callbacks.
+    // Use only when dropping the ads client, further calls may return errors.
+    pub fn shutdown_client(&mut self) -> Result<(), rusqlite::Error> {
+        // Shutdown DB
+        self.client.shutdown_db()?;
+
+        // Drop telemetry recursively
+        self.telemetry = None;
+        self.client.drop_telemetry();
+
+        Ok(())
     }
 
     pub fn get_context_id(&self) -> context_id::ApiResult<String> {
@@ -112,10 +125,14 @@ where
         self.client
             .record_click(click_url, ohttp)
             .inspect_err(|e| {
-                self.telemetry.record(e);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(e);
+                }
             })
             .inspect(|_| {
-                self.telemetry.record(&ClientOperationEvent::RecordClick);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(&ClientOperationEvent::RecordClick);
+                }
             })
     }
 
@@ -156,11 +173,14 @@ where
         self.client
             .record_impression(impression_url, ohttp)
             .inspect_err(|e| {
-                self.telemetry.record(e);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(e);
+                }
             })
             .inspect(|_| {
-                self.telemetry
-                    .record(&ClientOperationEvent::RecordImpression);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(&ClientOperationEvent::RecordImpression);
+                }
             })
     }
 
@@ -173,10 +193,14 @@ where
         self.client
             .report_ad(report_url, reason, ohttp)
             .inspect_err(|e| {
-                self.telemetry.record(e);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(e);
+                }
             })
             .inspect(|_| {
-                self.telemetry.record(&ClientOperationEvent::ReportAd);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(&ClientOperationEvent::ReportAd);
+                }
             })
     }
 
@@ -190,9 +214,13 @@ where
         let response = self
             .request_ads::<AdImage>(ad_placement_requests, flags, options, ohttp)
             .inspect_err(|e| {
-                self.telemetry.record(e);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(e);
+                }
             })?;
-        self.telemetry.record(&ClientOperationEvent::RequestAds);
+        if let Some(telemetry) = &self.telemetry {
+            telemetry.record(&ClientOperationEvent::RequestAds);
+        }
         Ok(response.take_first())
     }
 
@@ -206,10 +234,14 @@ where
         let result = self.request_ads::<AdSpoc>(ad_placement_requests, flags, options, ohttp);
         result
             .inspect_err(|e| {
-                self.telemetry.record(e);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(e);
+                }
             })
             .map(|response| {
-                self.telemetry.record(&ClientOperationEvent::RequestAds);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(&ClientOperationEvent::RequestAds);
+                }
                 response.data
             })
     }
@@ -224,10 +256,14 @@ where
         let result = self.request_ads::<AdTile>(ad_placement_requests, flags, options, ohttp);
         result
             .inspect_err(|e| {
-                self.telemetry.record(e);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(e);
+                }
             })
             .map(|response| {
-                self.telemetry.record(&ClientOperationEvent::RequestAds);
+                if let Some(telemetry) = &self.telemetry {
+                    telemetry.record(&ClientOperationEvent::RequestAds);
+                }
                 response.take_first()
             })
     }
@@ -263,8 +299,10 @@ pub enum ClientOperationEvent {
 
 #[cfg(test)]
 mod tests {
+    use std::{assert_eq, assert_ne, sync::Arc};
+
     use crate::{
-        ffi::telemetry::MozAdsTelemetryWrapper,
+        ffi::telemetry::{MozAdsTelemetryWrapper, NoopMozAdsTelemetry},
         mars::Environment,
         test_utils::{
             get_example_happy_image_response, get_example_happy_spoc_response,
@@ -277,6 +315,7 @@ mod tests {
     fn new_with_mars_client(
         client: MARSClient<MozAdsTelemetryWrapper>,
     ) -> AdsClient<MozAdsTelemetryWrapper> {
+        let telemetry = client.get_telemetry();
         AdsClient {
             client,
             context_id_provider: Box::new(ContextIDComponent::new(
@@ -285,7 +324,7 @@ mod tests {
                 false,
                 Box::new(DefaultContextIdCallback),
             )),
-            telemetry: MozAdsTelemetryWrapper::noop(),
+            telemetry,
         }
     }
 
@@ -501,5 +540,40 @@ mod tests {
 
         m1.assert();
         m2.assert();
+    }
+
+    #[test]
+    fn test_shutdown_telemetry() {
+        viaduct_dev::init_backend_dev();
+
+        // test with client created from config
+        let noop_telemetry = MozAdsTelemetryWrapper::noop();
+        let weak_reference = Arc::downgrade(&noop_telemetry.clone_inner_arc());
+        let config = AdsClientConfig {
+            cache_config: None,
+            context_id_provider: None,
+            environment: Environment::Test,
+            telemetry: noop_telemetry,
+        };
+        let mut client = AdsClient::new(config);
+
+        // weak ref will show 0 strong references when the Arc<dyn MozAdsTelemetry> is gone.
+        assert_ne!(weak_reference.strong_count(), 0);
+        client.shutdown_client().unwrap();
+        assert_eq!(weak_reference.strong_count(), 0);
+
+        // test also with internal function from_mars
+        let noop_telemetry = MozAdsTelemetryWrapper::noop();
+        let weak_reference = Arc::downgrade(&noop_telemetry.clone_inner_arc());
+        let cache = HttpCache::builder("test_shutdown_telemetry")
+            .build()
+            .unwrap();
+        let mars_client = MARSClient::new(Environment::Test, Some(cache), noop_telemetry);
+        let mut client = new_with_mars_client(mars_client);
+
+        // weak ref will show 0 strong references when the Arc<dyn MozAdsTelemetry> is gone.
+        assert_ne!(weak_reference.strong_count(), 0);
+        client.shutdown_client().unwrap();
+        assert_eq!(weak_reference.strong_count(), 0);
     }
 }

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -99,7 +99,7 @@ where
     }
 
     // Shutdown the db connection and drop references to telemetry callbacks.
-    // Use only when dropping the ads client, further calls may return errors.
+    // Should be used only when dropping the ads client, this may be extended to drop more things.
     pub fn shutdown_client(&mut self) -> Result<(), rusqlite::Error> {
         // Shutdown DB
         self.client.shutdown_db()?;

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -59,8 +59,8 @@ impl MozAdsTelemetryWrapper {
 
 impl Telemetry for MozAdsTelemetryWrapper {
     fn shutdown(&self) {
-        // let mut inner = self.inner.lock();
-        // *inner = Arc::new(NoopMozAdsTelemetry);
+        let mut inner = self.inner.lock();
+        *inner = Arc::new(NoopMozAdsTelemetry);
     }
 
     fn record(&self, event: &dyn Any) {

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -6,6 +6,8 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use parking_lot::Mutex;
+
 use crate::client::error::RequestAdsError;
 use crate::client::ClientOperationEvent;
 use crate::http_cache::{CacheOutcome, HttpCacheBuilderError};
@@ -33,30 +35,38 @@ impl MozAdsTelemetry for NoopMozAdsTelemetry {
 
 #[derive(Clone)]
 pub struct MozAdsTelemetryWrapper {
-    inner: Arc<dyn MozAdsTelemetry>,
+    inner: Arc<Mutex<Arc<dyn MozAdsTelemetry>>>,
 }
 
 impl MozAdsTelemetryWrapper {
     pub fn new(inner: Arc<dyn MozAdsTelemetry>) -> Self {
-        Self { inner }
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
     }
 
     pub fn noop() -> Self {
         Self {
-            inner: Arc::new(NoopMozAdsTelemetry),
+            inner: Arc::new(Mutex::new(Arc::new(NoopMozAdsTelemetry))),
         }
     }
 
     #[cfg(test)]
     pub fn clone_inner_arc(&self) -> Arc<dyn MozAdsTelemetry> {
-        self.inner.clone()
+        self.inner.lock().clone()
     }
 }
 
 impl Telemetry for MozAdsTelemetryWrapper {
+    fn shutdown(&self) {
+        let mut inner = self.inner.lock();
+        *inner = Arc::new(NoopMozAdsTelemetry);
+    }
+
     fn record(&self, event: &dyn Any) {
+        let inner = self.inner.lock();
         if let Some(cache_outcome) = event.downcast_ref::<CacheOutcome>() {
-            self.inner.record_http_cache_outcome(
+            inner.record_http_cache_outcome(
                 match cache_outcome {
                     CacheOutcome::Hit => "hit".to_string(),
                     CacheOutcome::LookupFailed(_) => "lookup_failed".to_string(),
@@ -78,7 +88,7 @@ impl Telemetry for MozAdsTelemetryWrapper {
             return;
         }
         if let Some(client_op) = event.downcast_ref::<ClientOperationEvent>() {
-            self.inner.record_client_operation_total(match client_op {
+            inner.record_client_operation_total(match client_op {
                 ClientOperationEvent::New => "new".to_string(),
                 ClientOperationEvent::RecordClick => "record_click".to_string(),
                 ClientOperationEvent::RecordImpression => "record_impression".to_string(),
@@ -88,7 +98,7 @@ impl Telemetry for MozAdsTelemetryWrapper {
             return;
         }
         if let Some(cache_builder_error) = event.downcast_ref::<HttpCacheBuilderError>() {
-            self.inner.record_build_cache_error(
+            inner.record_build_cache_error(
                 match cache_builder_error {
                     HttpCacheBuilderError::EmptyDbPath => "empty_db_path".to_string(),
                     HttpCacheBuilderError::Database(_) => "database_error".to_string(),
@@ -100,31 +110,29 @@ impl Telemetry for MozAdsTelemetryWrapper {
             return;
         }
         if let Some(record_click_error) = event.downcast_ref::<RecordClickError>() {
-            self.inner.record_client_error(
+            inner.record_client_error(
                 "record_click".to_string(),
                 format!("{}", record_click_error),
             );
             return;
         }
         if let Some(record_impression_error) = event.downcast_ref::<RecordImpressionError>() {
-            self.inner.record_client_error(
+            inner.record_client_error(
                 "record_impression".to_string(),
                 format!("{}", record_impression_error),
             );
             return;
         }
         if let Some(report_ad_error) = event.downcast_ref::<ReportAdError>() {
-            self.inner
-                .record_client_error("report_ad".to_string(), format!("{}", report_ad_error));
+            inner.record_client_error("report_ad".to_string(), format!("{}", report_ad_error));
             return;
         }
         if let Some(request_ads_error) = event.downcast_ref::<RequestAdsError>() {
-            self.inner
-                .record_client_error("request_ads".to_string(), format!("{}", request_ads_error));
+            inner.record_client_error("request_ads".to_string(), format!("{}", request_ads_error));
             return;
         }
         if let Some(json_error) = event.downcast_ref::<serde_json::Error>() {
-            self.inner.record_deserialization_error(
+            inner.record_deserialization_error(
                 "invalid_ad_item".to_string(),
                 format!("{}", json_error),
             );

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -6,7 +6,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 use crate::client::error::RequestAdsError;
 use crate::client::ClientOperationEvent;
@@ -35,38 +35,40 @@ impl MozAdsTelemetry for NoopMozAdsTelemetry {
 
 #[derive(Clone)]
 pub struct MozAdsTelemetryWrapper {
-    inner: Arc<Mutex<Arc<dyn MozAdsTelemetry>>>,
+    inner: Arc<RwLock<Option<Arc<dyn MozAdsTelemetry>>>>,
 }
 
 impl MozAdsTelemetryWrapper {
     pub fn new(inner: Arc<dyn MozAdsTelemetry>) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(inner)),
+            inner: Arc::new(RwLock::new(Some(inner))),
         }
     }
 
     pub fn noop() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(Arc::new(NoopMozAdsTelemetry))),
+            inner: Arc::new(RwLock::new(Some(Arc::new(NoopMozAdsTelemetry)))),
         }
     }
 
     #[cfg(test)]
-    pub fn clone_inner_arc(&self) -> Arc<dyn MozAdsTelemetry> {
-        self.inner.lock().clone()
+    pub fn clone_inner_arc(&self) -> Option<Arc<dyn MozAdsTelemetry>> {
+        self.inner.read().clone()
     }
 }
 
 impl Telemetry for MozAdsTelemetryWrapper {
     // MozAdsTelemetry has hanging uniffi callbacks which need to be explicitly dropped before closing.
-    // This replaces it with a `NoopMozAdsTelemetry` call, meaning future calls will be noops.
+    // This replaces it with a `None` internally, meaning future calls will be noops.
     fn shutdown(&self) {
-        let mut inner = self.inner.lock();
-        *inner = Arc::new(NoopMozAdsTelemetry);
+        let _dropped = self.inner.write().take();
     }
 
     fn record(&self, event: &dyn Any) {
-        let inner = self.inner.lock();
+        let Some(inner) = self.inner.read().clone() else {
+            return;
+        };
+
         if let Some(cache_outcome) = event.downcast_ref::<CacheOutcome>() {
             inner.record_http_cache_outcome(
                 match cache_outcome {

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -46,6 +46,11 @@ impl MozAdsTelemetryWrapper {
             inner: Arc::new(NoopMozAdsTelemetry),
         }
     }
+
+    #[cfg(test)]
+    pub fn clone_inner_arc(&self) -> Arc<dyn MozAdsTelemetry> {
+        self.inner.clone()
+    }
 }
 
 impl Telemetry for MozAdsTelemetryWrapper {

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -59,8 +59,8 @@ impl MozAdsTelemetryWrapper {
 
 impl Telemetry for MozAdsTelemetryWrapper {
     fn shutdown(&self) {
-        let mut inner = self.inner.lock();
-        *inner = Arc::new(NoopMozAdsTelemetry);
+        // let mut inner = self.inner.lock();
+        // *inner = Arc::new(NoopMozAdsTelemetry);
     }
 
     fn record(&self, event: &dyn Any) {

--- a/components/ads-client/src/ffi/telemetry.rs
+++ b/components/ads-client/src/ffi/telemetry.rs
@@ -58,6 +58,8 @@ impl MozAdsTelemetryWrapper {
 }
 
 impl Telemetry for MozAdsTelemetryWrapper {
+    // MozAdsTelemetry has hanging uniffi callbacks which need to be explicitly dropped before closing.
+    // This replaces it with a `NoopMozAdsTelemetry` call, meaning future calls will be noops.
     fn shutdown(&self) {
         let mut inner = self.inner.lock();
         *inner = Arc::new(NoopMozAdsTelemetry);

--- a/components/ads-client/src/http_cache.rs
+++ b/components/ads-client/src/http_cache.rs
@@ -60,7 +60,7 @@ impl HttpCache {
         Ok(())
     }
 
-    pub fn shutdown(self) -> Result<(), rusqlite::Error> {
+    pub fn shutdown_db(self) -> Result<(), rusqlite::Error> {
         self.store.close()
     }
 

--- a/components/ads-client/src/http_cache.rs
+++ b/components/ads-client/src/http_cache.rs
@@ -60,6 +60,10 @@ impl HttpCache {
         Ok(())
     }
 
+    pub fn shutdown(self) -> Result<(), rusqlite::Error> {
+        self.store.close()
+    }
+
     pub fn invalidate_by_hash(&self, request_hash: &RequestHash) -> Result<(), rusqlite::Error> {
         self.store.invalidate_by_hash(request_hash)?;
         Ok(())

--- a/components/ads-client/src/http_cache/store.rs
+++ b/components/ads-client/src/http_cache/store.rs
@@ -40,6 +40,11 @@ impl HttpCacheStore {
         }
     }
 
+    pub fn close(self) -> Result<(), rusqlite::Error> {
+        let conn = self.conn.into_inner();
+        conn.close().map_err(|(_, err)| err)
+    }
+
     #[cfg(test)]
     pub fn new_with_test_clock(conn: Connection) -> Self {
         use crate::http_cache::clock::TestClock;

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -52,6 +52,9 @@ impl MozAdsClient {
             })
     }
 
+    // Allows the ads-client to unload some references and prepare for a safe shutdown.
+    // Other methods should not be called after this one.
+    #[uniffi::method()]
     pub fn shutdown(&self) -> AdsClientApiResult<()> {
         let mut inner = self.inner.lock();
         if let Err(err) = inner.shutdown_client() {

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -41,15 +41,6 @@ pub struct MozAdsClient {
     inner: Mutex<AdsClient<MozAdsTelemetryWrapper>>,
 }
 
-impl Drop for MozAdsClient {
-    fn drop(&mut self) {
-        println!("Running 'drop' on MozAdsClient");
-        if let Err(e) = self.shutdown() {
-            eprintln!("Failed to drop: {e}");
-        }
-    }
-}
-
 #[uniffi::export]
 impl MozAdsClient {
     pub fn clear_cache(&self) -> AdsClientApiResult<()> {

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -41,6 +41,15 @@ pub struct MozAdsClient {
     inner: Mutex<AdsClient<MozAdsTelemetryWrapper>>,
 }
 
+impl Drop for MozAdsClient {
+    fn drop(&mut self) {
+        println!("Running 'drop' on MozAdsClient");
+        if let Err(e) = self.shutdown() {
+            eprintln!("Failed to drop: {e}");
+        }
+    }
+}
+
 #[uniffi::export]
 impl MozAdsClient {
     pub fn clear_cache(&self) -> AdsClientApiResult<()> {

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -12,9 +12,9 @@ use parking_lot::Mutex;
 use url::Url as AdsClientUrl;
 
 use client::AdsClient;
+use error_support::error;
 use http_cache::CachePolicy;
 use mars::ad_request::{AdPlacementRequest, AdRequestFlags};
-
 mod client;
 mod ffi;
 pub mod http_cache;
@@ -50,6 +50,15 @@ impl MozAdsClient {
             .map_err(|e| MozAdsClientApiError::Other {
                 reason: format!("Failed to clear cache: {}", e),
             })
+    }
+
+    pub fn shutdown(&self) -> AdsClientApiResult<()> {
+        let mut inner = self.inner.lock();
+        if let Err(err) = inner.shutdown_client() {
+            // Log the error, but continue with shutdown.
+            error!("Failed to shutdown the ads client: {:?}", err);
+        }
+        Ok(())
     }
 
     #[handle_error(ComponentError)]

--- a/components/ads-client/src/mars.rs
+++ b/components/ads-client/src/mars.rs
@@ -36,7 +36,7 @@ where
     T: Clone + Telemetry,
 {
     environment: Environment,
-    telemetry: T,
+    telemetry: Option<T>,
     transport: MARSTransport<T>,
 }
 
@@ -48,13 +48,22 @@ where
         let transport = MARSTransport::new(http_cache, telemetry.clone());
         Self {
             environment,
-            telemetry,
+            telemetry: Some(telemetry),
             transport,
         }
     }
 
     pub fn clear_cache(&self) -> Result<(), rusqlite::Error> {
         self.transport.clear_cache()
+    }
+
+    pub fn shutdown_db(&mut self) -> Result<(), rusqlite::Error> {
+        self.transport.shutdown_db()
+    }
+
+    pub fn drop_telemetry(&mut self) {
+        self.telemetry = None;
+        self.transport.drop_telemetry();
     }
 
     pub fn fetch_ads<A>(
@@ -79,7 +88,7 @@ where
         }
 
         let response = self.transport.send(ad_request, &cache_policy, ohttp)?;
-        let ads = AdResponse::<A>::parse(response.json()?, &self.telemetry)?;
+        let ads = AdResponse::<A>::parse(response.json()?, self.telemetry.as_ref())?;
         Ok((ads, request_hash))
     }
 
@@ -137,6 +146,11 @@ where
                 .extend(Headers::from(self.fetch_preflight()?));
         }
         self.transport.fire(request, ohttp).map_err(Into::into)
+    }
+
+    #[cfg(test)]
+    pub fn get_telemetry(&self) -> Option<T> {
+        self.telemetry.clone()
     }
 }
 

--- a/components/ads-client/src/mars.rs
+++ b/components/ads-client/src/mars.rs
@@ -36,7 +36,7 @@ where
     T: Clone + Telemetry,
 {
     environment: Environment,
-    telemetry: Option<T>,
+    telemetry: T,
     transport: MARSTransport<T>,
 }
 
@@ -48,7 +48,7 @@ where
         let transport = MARSTransport::new(http_cache, telemetry.clone());
         Self {
             environment,
-            telemetry: Some(telemetry),
+            telemetry,
             transport,
         }
     }
@@ -59,11 +59,6 @@ where
 
     pub fn shutdown_db(&mut self) -> Result<(), rusqlite::Error> {
         self.transport.shutdown_db()
-    }
-
-    pub fn drop_telemetry(&mut self) {
-        self.telemetry = None;
-        self.transport.drop_telemetry();
     }
 
     pub fn fetch_ads<A>(
@@ -88,7 +83,7 @@ where
         }
 
         let response = self.transport.send(ad_request, &cache_policy, ohttp)?;
-        let ads = AdResponse::<A>::parse(response.json()?, self.telemetry.as_ref())?;
+        let ads = AdResponse::<A>::parse(response.json()?, &self.telemetry)?;
         Ok((ads, request_hash))
     }
 
@@ -149,7 +144,7 @@ where
     }
 
     #[cfg(test)]
-    pub fn get_telemetry(&self) -> Option<T> {
+    pub fn get_telemetry(&self) -> T {
         self.telemetry.clone()
     }
 }

--- a/components/ads-client/src/mars/ad_response.rs
+++ b/components/ads-client/src/mars/ad_response.rs
@@ -18,7 +18,7 @@ pub struct AdResponse<A: AdResponseValue> {
 impl<A: AdResponseValue> AdResponse<A> {
     pub fn parse<T: Telemetry>(
         data: serde_json::Value,
-        telemetry: Option<&T>,
+        telemetry: &T,
     ) -> Result<AdResponse<A>, serde_json::Error> {
         let raw: HashMap<String, serde_json::Value> = serde_json::from_value(data)?;
         let mut result = HashMap::new();
@@ -30,9 +30,7 @@ impl<A: AdResponseValue> AdResponse<A> {
                     match serde_json::from_value::<A>(item.clone()) {
                         Ok(ad) => ads.push(ad),
                         Err(e) => {
-                            if let Some(telemetry) = telemetry {
-                                telemetry.record(&e);
-                            }
+                            telemetry.record(&e);
                         }
                     }
                 }
@@ -337,8 +335,7 @@ mod tests {
         });
 
         let parsed =
-            AdResponse::<AdImage>::parse(raw_ad_response, Some(&MozAdsTelemetryWrapper::noop()))
-                .unwrap();
+            AdResponse::<AdImage>::parse(raw_ad_response, &MozAdsTelemetryWrapper::noop()).unwrap();
 
         let expected = AdResponse {
             data: HashMap::from([(
@@ -375,8 +372,7 @@ mod tests {
         });
 
         let parsed =
-            AdResponse::<AdImage>::parse(raw_ad_response, Some(&MozAdsTelemetryWrapper::noop()))
-                .unwrap();
+            AdResponse::<AdImage>::parse(raw_ad_response, &MozAdsTelemetryWrapper::noop()).unwrap();
 
         let expected = AdResponse {
             data: HashMap::from([]),

--- a/components/ads-client/src/mars/ad_response.rs
+++ b/components/ads-client/src/mars/ad_response.rs
@@ -18,7 +18,7 @@ pub struct AdResponse<A: AdResponseValue> {
 impl<A: AdResponseValue> AdResponse<A> {
     pub fn parse<T: Telemetry>(
         data: serde_json::Value,
-        telemetry: &T,
+        telemetry: Option<&T>,
     ) -> Result<AdResponse<A>, serde_json::Error> {
         let raw: HashMap<String, serde_json::Value> = serde_json::from_value(data)?;
         let mut result = HashMap::new();
@@ -30,7 +30,9 @@ impl<A: AdResponseValue> AdResponse<A> {
                     match serde_json::from_value::<A>(item.clone()) {
                         Ok(ad) => ads.push(ad),
                         Err(e) => {
-                            telemetry.record(&e);
+                            if let Some(telemetry) = telemetry {
+                                telemetry.record(&e);
+                            }
                         }
                     }
                 }
@@ -335,7 +337,8 @@ mod tests {
         });
 
         let parsed =
-            AdResponse::<AdImage>::parse(raw_ad_response, &MozAdsTelemetryWrapper::noop()).unwrap();
+            AdResponse::<AdImage>::parse(raw_ad_response, Some(&MozAdsTelemetryWrapper::noop()))
+                .unwrap();
 
         let expected = AdResponse {
             data: HashMap::from([(
@@ -372,7 +375,8 @@ mod tests {
         });
 
         let parsed =
-            AdResponse::<AdImage>::parse(raw_ad_response, &MozAdsTelemetryWrapper::noop()).unwrap();
+            AdResponse::<AdImage>::parse(raw_ad_response, Some(&MozAdsTelemetryWrapper::noop()))
+                .unwrap();
 
         let expected = AdResponse {
             data: HashMap::from([]),

--- a/components/ads-client/src/mars/transport.rs
+++ b/components/ads-client/src/mars/transport.rs
@@ -18,15 +18,26 @@ const OHTTP_CHANNEL_ID: &str = "ads-client";
 
 pub struct MARSTransport<T: Telemetry> {
     http_cache: Option<HttpCache>,
-    telemetry: T,
+    telemetry: Option<T>,
 }
 
 impl<T: Telemetry> MARSTransport<T> {
     pub fn new(http_cache: Option<HttpCache>, telemetry: T) -> Self {
         Self {
             http_cache,
-            telemetry,
+            telemetry: Some(telemetry),
         }
+    }
+
+    pub fn shutdown_db(&mut self) -> Result<(), rusqlite::Error> {
+        if let Some(cache) = self.http_cache.take() {
+            cache.shutdown()?;
+        }
+        Ok(())
+    }
+
+    pub fn drop_telemetry(&mut self) {
+        self.telemetry = None;
     }
 
     pub fn clear_cache(&self) -> Result<(), rusqlite::Error> {
@@ -63,8 +74,10 @@ impl<T: Telemetry> MARSTransport<T> {
         let client = Self::client_for(ohttp)?;
         if let Some(cache) = &self.http_cache {
             let (response, outcomes) = cache.send_with_policy(&client, request, policy)?;
-            for outcome in &outcomes {
-                self.telemetry.record(outcome);
+            if let Some(telemetry) = &self.telemetry {
+                for outcome in &outcomes {
+                    telemetry.record(outcome);
+                }
             }
             HTTPError::check(&response)?;
             Ok(response)

--- a/components/ads-client/src/mars/transport.rs
+++ b/components/ads-client/src/mars/transport.rs
@@ -18,26 +18,22 @@ const OHTTP_CHANNEL_ID: &str = "ads-client";
 
 pub struct MARSTransport<T: Telemetry> {
     http_cache: Option<HttpCache>,
-    telemetry: Option<T>,
+    telemetry: T,
 }
 
 impl<T: Telemetry> MARSTransport<T> {
     pub fn new(http_cache: Option<HttpCache>, telemetry: T) -> Self {
         Self {
             http_cache,
-            telemetry: Some(telemetry),
+            telemetry,
         }
     }
 
     pub fn shutdown_db(&mut self) -> Result<(), rusqlite::Error> {
         if let Some(cache) = self.http_cache.take() {
-            cache.shutdown()?;
+            cache.shutdown_db()?;
         }
         Ok(())
-    }
-
-    pub fn drop_telemetry(&mut self) {
-        self.telemetry = None;
     }
 
     pub fn clear_cache(&self) -> Result<(), rusqlite::Error> {
@@ -74,10 +70,8 @@ impl<T: Telemetry> MARSTransport<T> {
         let client = Self::client_for(ohttp)?;
         if let Some(cache) = &self.http_cache {
             let (response, outcomes) = cache.send_with_policy(&client, request, policy)?;
-            if let Some(telemetry) = &self.telemetry {
-                for outcome in &outcomes {
-                    telemetry.record(outcome);
-                }
+            for outcome in &outcomes {
+                self.telemetry.record(outcome);
             }
             HTTPError::check(&response)?;
             Ok(response)

--- a/components/ads-client/src/telemetry.rs
+++ b/components/ads-client/src/telemetry.rs
@@ -8,7 +8,7 @@ use std::any::Any;
 pub trait Telemetry {
     fn record(&self, event: &dyn Any);
 
-    // Shuts down the telemetry wrapper by replacing it with a noop.
-    // Future telemetry records will not record anything.
+    // Shuts down any telemetry structures. This should be called before dropping the struct implementing this trait.
+    // Future calls to `record` will not record anything.
     fn shutdown(&self);
 }

--- a/components/ads-client/src/telemetry.rs
+++ b/components/ads-client/src/telemetry.rs
@@ -7,4 +7,8 @@ use std::any::Any;
 
 pub trait Telemetry {
     fn record(&self, event: &dyn Any);
+
+    // Shuts down the telemetry wrapper by replacing it with a noop.
+    // Future telemetry records will not record anything.
+    fn shutdown(&self);
 }


### PR DESCRIPTION
This provides the `shutdown` function for addressing the crash on early ads-client -> HNT builds. When quit, we get:

```
console.error: "UniFFI Callback interface error during xpcom-shutdown: Error: UniFFI interface MozAdsTelemetry has 1 registered callbacks at xpcom-shutdown.
```

This requires a surface to deload several hanging parts of ads-client, specifically:
- any open sqlite connections (matching some other patterns elsewhere in application-services)
- any references hanging uniffi callbacks
We provide such a function here, for use in upcoming future m-c PR to use on shutdown.

#### Notes

- I'm not sure if there's a good way to do a test here that would also catch any future callbacks added. 
- We can reduce LoC here by putting a mutex inside the `MozAdsTelemetryWrapper`, or alternatively creating a new trait like `TryTelemetry` below that _optionally_ record, that gives a new method to `Option<dyn Telemetry>`, and swapping all calls to use `TryTelemetry` instead.  I prefer the explicit usage as shown in the PR, with `if let Some(xxx)` but not tied to it if we prefer one of these.

```
pub trait TryTelemetry {
    fn try_record(&self, event: &dyn Any);
}

impl<T: Telemetry> TryTelemetry for Option<T> {
   ...
}
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
