### PR TITLE
fix(remote-settings): SYNC-5384: Do not quote timestamps with v2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Remote Settings
 - Replacing v1 routes with v2 routes, removing added v2 routes ([#7492](https://github.com/mozilla/application-services/pull/7339))
 - Verify signature of imported data when `.get()` is called with `sync_if_empty: true` ([#7518](https://github.com/mozilla/application-services/pull/7518)) 
+- Do not quote `_since` values with the v2 API ([#7523](https://github.com/mozilla/application-services/pull/7523))
 
 # v154.0 (_2026-07-20_)
 

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -685,7 +685,7 @@ impl ApiClient for ViaductApiClient {
         url.query_pairs_mut().append_pair("_expected", "0");
         if let Some(timestamp) = timestamp {
             url.query_pairs_mut()
-                .append_pair("_since", &format!("\"{}\"", timestamp));
+                .append_pair("_since", &format!("{}", timestamp));
         }
 
         let resp = self.make_request(url)?;
@@ -959,6 +959,40 @@ mod test_new_client {
             endpoints.changeset_url.to_string(),
             "http://rs.example.com/v2/buckets/main/collections/test-collection/changeset",
         );
+    }
+}
+
+#[cfg(test)]
+mod viaduct_client_tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_uses_local_timestamp_as_unquoted_since() {
+        viaduct_dev::init_backend_dev();
+        let changeset = mockito::mock(
+            "GET",
+            "/v2/buckets/main/collections/test-collection/changeset",
+        )
+        // The mock only matches if `_since` is sent unquoted.
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("_expected".into(), "0".into()),
+            mockito::Matcher::UrlEncoded("_since".into(), "42".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"changes": [], "timestamp": 42, "metadata": {"bucket": "main", "signatures": []}}"#,
+        )
+        .create();
+
+        let mut api_client = ViaductApiClient::new(
+            BaseUrl::parse(&format!("{}/v2", mockito::server_url())).unwrap(),
+            "main",
+            "test-collection",
+        );
+        api_client.fetch_changeset(Some(42)).unwrap();
+
+        changeset.assert();
     }
 }
 


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
