### PR TITLE
Bug 2055621 - viaduct: only link to sqlite when the ohttp feature is enabled.

### DIFF
--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -30,8 +30,8 @@ ohttp = { version = "0.7.2", features = ["client", "server", "app-svc", "externa
 #
 # Without this, builds will often succeed because other crates will bring in `rusqlite`, however
 # some combinations will fail.  `cargo -p ads-client -p context_id` is one example (2026/06/25).
-rusqlite = { version = "0.37.0", features = [ "bundled" ] }
+rusqlite = { version = "0.37.0", features = [ "bundled" ], optional = true }
 
 [features]
 default = []
-ohttp = ["dep:bhttp", "dep:ohttp"]
+ohttp = ["dep:bhttp", "dep:ohttp", "dep:rusqlite"]

--- a/components/viaduct/src/lib.rs
+++ b/components/viaduct/src/lib.rs
@@ -7,6 +7,7 @@
 
 // Force linking to `rusqlite` even though we don't use it directly.
 // See `Cargo.toml` for why this is needed.
+#[cfg(feature = "ohttp")]
 #[allow(unused_extern_crates)]
 extern crate rusqlite;
 


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=2055621

[Bug 2049856](https://bugzilla.mozilla.org/show_bug.cgi?id=2049856) added a dependency from viaduct to rusqlite, which broke the nimbus-fml toolchain build on the Firefox CI because it doesn't have the x86_64-linux-musl-gcc compiler.

viaduct doesn't actually need to link to sqlite outside the ohttp feature, so properly encode that in its Cargo.toml.

Because nimbus-fml doesn't enable viaduct's ohttp feature, it won't try to link to sqlite anymore.

Try run: https://treeherder.mozilla.org/jobs?repo=try&revision=ad6338a9be84fca240cc2b70b9bf1fbbb60ecda8
This change would break users that depend on viaduct without the ohttp feature and otherwise depend on ohttp with its external-sqlite feature but do not depend on rusqlite by any other means. I believe that's acceptable and doesn't need a changelog entry.

Change suggested by :glandium in https://phabricator.services.mozilla.com/D316132

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
