### PR TITLE
Fix FxA state machine spelling

### DIFF
--- a/components/fxa-client/src/state_machine/display.rs
+++ b/components/fxa-client/src/state_machine/display.rs
@@ -6,9 +6,6 @@
 //!
 //! These are sent to Sentry, so they must not leak PII.
 //! In general this means they don't output values for inner fields.
-//!
-//! Also, they must not use the string "auth" since Sentry will filter that out.
-//! Use "ath" instead.
 
 use super::{FxaEvent, FxaState};
 use std::fmt;
@@ -18,9 +15,9 @@ impl fmt::Display for FxaState {
         let name = match self {
             Self::Uninitialized => "Uninitialized",
             Self::Disconnected => "Disconnected",
-            Self::Authenticating { .. } => "Athenticating",
+            Self::Authenticating { .. } => "Authenticating",
             Self::Connected => "Connected",
-            Self::AuthIssues => "AthIssues",
+            Self::AuthIssues => "AuthIssues",
         };
         write!(f, "{name}")
     }
@@ -30,10 +27,10 @@ impl fmt::Display for FxaEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
             Self::Initialize { .. } => "Initialize",
-            Self::BeginOAuthFlow { .. } => "BeginOAthFlow",
+            Self::BeginOAuthFlow { .. } => "BeginOAuthFlow",
             Self::BeginPairingFlow { .. } => "BeginPairingFlow",
-            Self::CompleteOAuthFlow { .. } => "CompleteOAthFlow",
-            Self::CancelOAuthFlow => "CancelOAthFlow",
+            Self::CompleteOAuthFlow { .. } => "CompleteOAuthFlow",
+            Self::CancelOAuthFlow => "CancelOAuthFlow",
             Self::CheckAuthorizationStatus => "CheckAuthorizationStatus",
             Self::WebChannelPasswordChange { .. } => "WebChannelPwdChange",
             Self::Disconnect => "Disconnect",


### PR DESCRIPTION
A while back we purposely misspelled "Auth" as "Ath" to get around the Sentry redaction rules.  Now that we're using the error ping and Grafana we don't need this anymore.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
