### PR TITLE
E type alias in state machine transition code

### DIFF
--- a/components/fxa-client/src/state_machine/transitions.rs
+++ b/components/fxa-client/src/state_machine/transitions.rs
@@ -17,27 +17,26 @@ pub fn transition(
     from: FxaState,
     event: FxaEvent,
 ) -> std::result::Result<FxaState, StateMachineErr> {
+    use FxaEvent as E;
     use FxaState as S;
 
     match (from, event) {
         // ── From Uninitialized ──────────────────────────────────────────
-        (S::Uninitialized, FxaEvent::Initialize { device_config }) => {
-            match account.get_auth_state() {
-                FxaRustAuthState::Disconnected => Ok(S::Disconnected),
-                FxaRustAuthState::AuthIssues => Ok(S::AuthIssues),
-                FxaRustAuthState::Connected => {
-                    match account.finish_initialize(&device_config.capabilities) {
-                        Ok(()) => Ok(S::Connected),
-                        Err(cause) => Err(StateMachineErr::new(cause, S::AuthIssues)),
-                    }
+        (S::Uninitialized, E::Initialize { device_config }) => match account.get_auth_state() {
+            FxaRustAuthState::Disconnected => Ok(S::Disconnected),
+            FxaRustAuthState::AuthIssues => Ok(S::AuthIssues),
+            FxaRustAuthState::Connected => {
+                match account.finish_initialize(&device_config.capabilities) {
+                    Ok(()) => Ok(S::Connected),
+                    Err(cause) => Err(StateMachineErr::new(cause, S::AuthIssues)),
                 }
             }
-        }
+        },
 
         // ── From Disconnected ───────────────────────────────────────────
         (
             S::Disconnected,
-            FxaEvent::BeginOAuthFlow {
+            E::BeginOAuthFlow {
                 service,
                 scopes,
                 entrypoint,
@@ -54,7 +53,7 @@ pub fn transition(
         }
         (
             S::Disconnected,
-            FxaEvent::BeginPairingFlow {
+            E::BeginPairingFlow {
                 pairing_url,
                 service,
                 scopes,
@@ -72,7 +71,7 @@ pub fn transition(
         }
 
         // ── From Authenticating ─────────────────────────────────────────
-        (S::Authenticating { initial_state, .. }, FxaEvent::CompleteOAuthFlow { code, state }) => {
+        (S::Authenticating { initial_state, .. }, E::CompleteOAuthFlow { code, state }) => {
             account
                 .complete_oauth_flow(&code, &state)
                 .to_state_machine_err(|| initial_state.into())?;
@@ -87,16 +86,14 @@ pub fn transition(
 
             Ok(S::Connected)
         }
-        (S::Authenticating { initial_state, .. }, FxaEvent::CancelOAuthFlow) => {
-            Ok(initial_state.into())
-        }
-        (S::Authenticating { .. }, FxaEvent::Disconnect) => {
+        (S::Authenticating { initial_state, .. }, E::CancelOAuthFlow) => Ok(initial_state.into()),
+        (S::Authenticating { .. }, E::Disconnect) => {
             account.disconnect();
             Ok(S::Disconnected)
         }
         (
             S::Authenticating { initial_state, .. },
-            FxaEvent::BeginOAuthFlow {
+            E::BeginOAuthFlow {
                 service,
                 scopes,
                 entrypoint,
@@ -113,7 +110,7 @@ pub fn transition(
         }
         (
             S::Authenticating { initial_state, .. },
-            FxaEvent::BeginPairingFlow {
+            E::BeginPairingFlow {
                 pairing_url,
                 service,
                 scopes,
@@ -131,23 +128,23 @@ pub fn transition(
         }
         // A WebChannel password change while an OAuth flow is in progress
         // is a no-op; let the flow finish. Should be rare in practice.
-        (s @ S::Authenticating { .. }, FxaEvent::WebChannelPasswordChange { .. }) => {
+        (s @ S::Authenticating { .. }, E::WebChannelPasswordChange { .. }) => {
             crate::warn!("WebChannel password change received while Authenticating; ignoring");
             Ok(s)
         }
 
         // ── From Connected ──────────────────────────────────────────────
-        (S::Connected, FxaEvent::Disconnect) => {
+        (S::Connected, E::Disconnect) => {
             account.disconnect();
             Ok(S::Disconnected)
         }
-        (S::Connected, FxaEvent::CheckAuthorizationStatus) => {
+        (S::Connected, E::CheckAuthorizationStatus) => {
             let active = account
                 .check_authorization_status()
                 .to_state_machine_err(|| S::AuthIssues)?;
             Ok(if active { S::Connected } else { S::AuthIssues })
         }
-        (S::Connected, FxaEvent::CallGetProfile) => {
+        (S::Connected, E::CallGetProfile) => {
             account
                 .get_profile()
                 .to_state_machine_err(|| S::AuthIssues)?;
@@ -155,7 +152,7 @@ pub fn transition(
         }
         (
             S::Connected,
-            FxaEvent::BeginOAuthFlow {
+            E::BeginOAuthFlow {
                 service,
                 scopes,
                 entrypoint,
@@ -173,7 +170,7 @@ pub fn transition(
                 initial_state: FxaRustAuthState::Connected,
             })
         }
-        (S::Connected, FxaEvent::WebChannelPasswordChange { json_payload }) => {
+        (S::Connected, E::WebChannelPasswordChange { json_payload }) => {
             // The inner call swaps the session token for a new refresh token and re-registers
             // the device record (push subscription, commands, etc) against the new token.
             account
@@ -185,7 +182,7 @@ pub fn transition(
         // ── From AuthIssues ─────────────────────────────────────────────
         (
             S::AuthIssues,
-            FxaEvent::BeginOAuthFlow {
+            E::BeginOAuthFlow {
                 service,
                 scopes,
                 entrypoint,
@@ -200,11 +197,11 @@ pub fn transition(
                 initial_state: FxaRustAuthState::AuthIssues,
             })
         }
-        (S::AuthIssues, FxaEvent::Disconnect) => {
+        (S::AuthIssues, E::Disconnect) => {
             account.disconnect();
             Ok(S::Disconnected)
         }
-        (S::AuthIssues, FxaEvent::WebChannelPasswordChange { json_payload }) => {
+        (S::AuthIssues, E::WebChannelPasswordChange { json_payload }) => {
             // A concurrent sync/401 may have pushed us here before the webchannel ran. The new
             // session token recovers us; device re-registration will be handled inside the inner call.
             account
@@ -212,7 +209,7 @@ pub fn transition(
                 .to_state_machine_err(|| S::AuthIssues)?;
             Ok(S::Connected)
         }
-        (S::AuthIssues, FxaEvent::CheckAuthorizationStatus) => {
+        (S::AuthIssues, E::CheckAuthorizationStatus) => {
             let active = account
                 .check_authorization_status()
                 .to_state_machine_err(|| S::AuthIssues)?;
@@ -220,7 +217,7 @@ pub fn transition(
         }
 
         // ── Other transitions  ─────────────────────────────────
-        (from_state, FxaEvent::CheckAuthorizationStatus) => {
+        (from_state, E::CheckAuthorizationStatus) => {
             // Ignore `CheckAuthorizationStatus` from other states.
             // We want the app to be able to send this event whenever they want,
             // without generating an error.


### PR DESCRIPTION
I like the symmetry with `S` for `FxaState`.

This is just a matter of taste, if you don't like it we can just close this one.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
