### PR TITLE
Remote settings fetch breadcrumbs

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::config::BaseUrl;
-use crate::error::{debug, trace, Error, Result};
+use crate::error::{breadcrumb, debug, trace, Error, Result};
 use crate::jexl_filter::JexlFilter;
 #[cfg(feature = "signatures")]
 use crate::signatures;
@@ -647,7 +647,7 @@ impl ViaductApiClient {
     }
 
     fn make_request(&mut self, url: Url) -> Result<Response> {
-        trace!("make_request: {url}");
+        breadcrumb!("make_request: {url}");
         self.remote_state.ensure_no_backoff()?;
 
         let req = Request::get(url);

--- a/components/remote_settings/src/error.rs
+++ b/components/remote_settings/src/error.rs
@@ -4,7 +4,7 @@
 
 use error_support::{ErrorHandling, GetErrorHandling};
 // reexport logging helpers.
-pub use error_support::{debug, error, info, trace, warn};
+pub use error_support::{breadcrumb, debug, error, info, trace, warn};
 
 pub type ApiResult<T> = std::result::Result<T, RemoteSettingsError>;
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Changed the `trace!` into a `breadcrumb!`.  This way when we see errors we can know which URL it was from.  I noticed a few in the last week and knowing the URL would have been very helpful.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
