### PR TITLE
tabs: don't log the entire tabs payload at trace level.

### DIFF
--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -212,7 +212,7 @@ impl SyncEngine for TabsEngine {
         };
         super::prepare_for_upload(&mut record);
 
-        trace!("outgoing {:?}", record);
+        trace!("outgoing {record}");
         let envelope = OutgoingEnvelope {
             id: local_id.as_str().into(),
             ttl: Some(TABS_CLIENT_TTL),

--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -143,6 +143,22 @@ pub struct TabsRecord {
     pub windows: HashMap<String, TabsRecordWindow>,
 }
 
+// Intended so logging is concise and doesn't leak tab titles, urls, etc.
+// Like `Debug`, but counts the vecs instead of recursing them.
+impl std::fmt::Display for TabsRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TabsRecord {{ id: {}, client_name: {}, tabs: {}, tab_groups: {}, windows: {} }}",
+            self.id,
+            self.client_name,
+            self.tabs.len(),
+            self.tab_groups.len(),
+            self.windows.len()
+        )
+    }
+}
+
 #[cfg(test)]
 pub mod test {
     use super::*;


### PR DESCRIPTION
It makes desktop logs really noisy for no reason.

The payload is often very long, is pii, and has no value to us.
