### PR TITLE
[AC-154] creates temporary ads client structure `AdsStore`

### DIFF
--- a/components/ads-client/src/ads_store.rs
+++ b/components/ads-client/src/ads_store.rs
@@ -1,5 +1,8 @@
 use crate::mars::ad_response::{AdImage, AdSpoc, AdTile};
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 // TODO: This is an intentionally naive in-memory cache implementation of the ads cache.
 // It functions as a skeleton to store ads fetched in the background, and has a naive expiration mechanism.
@@ -8,9 +11,11 @@ const DEFAULT_TTL: Duration = Duration::from_secs(300);
 
 #[derive(Debug)]
 pub struct AdsStore {
-    image_ads: HashMap<String, (u64, AdImage)>,
-    spoc_ads: HashMap<String, (u64, Vec<AdSpoc>)>,
-    tile_ads: HashMap<String, (u64, AdTile)>,
+    ttl: Duration,
+
+    image_ads: HashMap<String, CacheEntry<AdImage>>,
+    spoc_ads: HashMap<String, CacheEntry<Vec<AdSpoc>>>,
+    tile_ads: HashMap<String, CacheEntry<AdTile>>,
 }
 
 impl Default for AdsStore {
@@ -21,26 +26,31 @@ impl Default for AdsStore {
 
 impl AdsStore {
     pub fn new() -> Self {
+        AdsStore::new_with_ttl(DEFAULT_TTL)
+    }
+
+    pub fn new_with_ttl(ttl: Duration) -> Self {
         AdsStore {
+            ttl,
             image_ads: HashMap::new(),
             spoc_ads: HashMap::new(),
             tile_ads: HashMap::new(),
         }
     }
 
-    pub fn cache_ads<T: AdsStorable>(
+    pub fn store_ads<T: AdsStorable>(
         &mut self,
         ads: HashMap<String, T::StorageType>,
-        timestamp: u64,
+        timestamp: Instant,
     ) {
-        T::cache_ads(ads, self, timestamp);
+        T::store_ads(ads, self, timestamp);
     }
 
-    pub fn get_cached_ads<'a, T: AdsStorable>(
+    pub fn get_stored_ads<'a, T: AdsStorable>(
         &'a self,
         placement: &str,
     ) -> Option<&'a T::StorageType> {
-        T::fetch_cached_ads(self, placement)
+        T::fetch_stored_ads(self, placement)
     }
 }
 
@@ -48,53 +58,201 @@ pub trait AdsStorable: Sized {
     // The ad(s) to store (eg: this may be a single ad, or an array of ads)
     type StorageType;
 
-    fn cache_ads(ads: HashMap<String, Self::StorageType>, ads_cache: &mut AdsStore, timestamp: u64);
-    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Self::StorageType>;
+    fn store_ads(
+        ads: HashMap<String, Self::StorageType>,
+        ads_cache: &mut AdsStore,
+        timestamp: Instant,
+    );
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Self::StorageType>;
 }
 
 impl AdsStorable for AdImage {
     type StorageType = AdImage;
-    fn cache_ads(ads: HashMap<String, AdImage>, ads_cache: &mut AdsStore, timestamp: u64) {
+    fn store_ads(ads: HashMap<String, AdImage>, ads_cache: &mut AdsStore, timestamp: Instant) {
+        ads_cache.image_ads.extend(
+            ads.into_iter()
+                .map(|(key, ad)| (key, CacheEntry::new(ad, timestamp))),
+        );
         ads_cache
             .image_ads
-            .extend(ads.into_iter().map(|(key, ad)| (key, (timestamp, ad))));
-        ads_cache
-            .image_ads
-            .retain(|_, (x, _)| *x - timestamp < DEFAULT_TTL.as_secs());
+            .retain(|_, x| !x.is_expired(ads_cache.ttl));
+    }
 
-            }
-
-    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdImage> {
-        ads_cache.image_ads.get(id).map(|(_, ads)| ads)
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdImage> {
+        ads_cache.image_ads.get(id).map(|ads| ads.get_value())
     }
 }
 
 impl AdsStorable for AdSpoc {
     type StorageType = Vec<AdSpoc>;
-    fn cache_ads(ads: HashMap<String, Vec<AdSpoc>>, ads_cache: &mut AdsStore, timestamp: u64) {
+    fn store_ads(ads: HashMap<String, Vec<AdSpoc>>, ads_cache: &mut AdsStore, timestamp: Instant) {
+        ads_cache.spoc_ads.extend(
+            ads.into_iter()
+                .map(|(key, ad)| (key, CacheEntry::new(ad, timestamp))),
+        );
         ads_cache
             .spoc_ads
-            .extend(ads.into_iter().map(|(key, ad)| (key, (timestamp, ad))));
-        ads_cache
-            .spoc_ads
-            .retain(|_, (x, _)| *x - timestamp < DEFAULT_TTL.as_secs());
+            .retain(|_, x| !x.is_expired(ads_cache.ttl));
     }
-    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Vec<AdSpoc>> {
-        ads_cache.spoc_ads.get(id).map(|(_, ads)| ads)
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Vec<AdSpoc>> {
+        ads_cache.spoc_ads.get(id).map(|ads| ads.get_value())
     }
 }
 
 impl AdsStorable for AdTile {
     type StorageType = AdTile;
-    fn cache_ads(ads: HashMap<String, AdTile>, ads_cache: &mut AdsStore, timestamp: u64) {
+    fn store_ads(ads: HashMap<String, AdTile>, ads_cache: &mut AdsStore, timestamp: Instant) {
+        ads_cache.tile_ads.extend(
+            ads.into_iter()
+                .map(|(key, ad)| (key, CacheEntry::new(ad, timestamp))),
+        );
         ads_cache
             .tile_ads
-            .extend(ads.into_iter().map(|(key, ad)| (key, (timestamp, ad))));
-        ads_cache
-            .tile_ads
-            .retain(|_, (x, _)| *x - timestamp < DEFAULT_TTL.as_secs());
+            .retain(|_, x| !x.is_expired(ads_cache.ttl));
     }
-    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdTile> {
-        ads_cache.tile_ads.get(id).map(|(_, ads)| ads)
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdTile> {
+        ads_cache.tile_ads.get(id).map(|ads| ads.get_value())
+    }
+}
+
+#[derive(Debug)]
+struct CacheEntry<T> {
+    inserted_at: Instant,
+    value: T,
+}
+
+impl<T> CacheEntry<T> {
+    fn new(value: T, instant: Instant) -> CacheEntry<T> {
+        CacheEntry {
+            inserted_at: instant,
+            value,
+        }
+    }
+
+    fn is_expired(&self, ttl: Duration) -> bool {
+        self.inserted_at.elapsed() >= ttl
+    }
+
+    fn get_value(&self) -> &T {
+        &self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        time::{Duration, Instant},
+    };
+
+    use crate::{
+        ads_store::AdsStore,
+        mars::ad_response::{AdImage, AdSpoc, AdTile},
+        test_utils,
+    };
+
+    #[test]
+    fn test_store_image_ad() {
+        let five_min_ago = Instant::now()
+            .checked_sub(Duration::from_mins(5))
+            .expect("Could not create `Instant` for 5 minutes ago");
+        let one_min_ago = Instant::now()
+            .checked_sub(Duration::from_mins(1))
+            .expect("Could not create `Instant` for 1 minute ago");
+        let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
+
+        let demo_ads = test_utils::get_example_happy_image_response().data;
+        let first_key = demo_ads
+            .iter()
+            .next()
+            .expect("No test data in `get_example_happy_image_response`")
+            .0;
+        // TODO: Remove this bit.
+        let demo_ads: HashMap<String, AdImage> = demo_ads
+            .clone()
+            .into_iter()
+            .filter_map(|(k, v)| Some((k, v.into_iter().next()?)))
+            .collect();
+
+        ads_store.store_ads::<AdImage>(demo_ads.clone(), five_min_ago);
+        assert!(
+            ads_store.get_stored_ads::<AdImage>(first_key).is_none(),
+            "Old data past TTL date must not be returned."
+        );
+
+        ads_store.store_ads::<AdImage>(demo_ads, one_min_ago);
+        assert!(
+            ads_store.get_stored_ads::<AdImage>(first_key).is_some(),
+            "Could not fetch fresh ad from ads store."
+        );
+    }
+
+    #[test]
+    fn test_store_spocs_ad() {
+        let five_min_ago = Instant::now()
+            .checked_sub(Duration::from_mins(5))
+            .expect("Could not create `Instant` for 5 minutes ago");
+        let one_min_ago = Instant::now()
+            .checked_sub(Duration::from_mins(1))
+            .expect("Could not create `Instant` for 1 minute ago");
+        let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
+
+        let demo_ads = test_utils::get_example_happy_spoc_response().data;
+        let first_key = demo_ads
+            .iter()
+            .next()
+            .expect("No test data in `get_example_happy_spoc_response`")
+            .0;
+        // TODO: Remove this bit.
+        // let demo_ads: HashMap<String, Vec<AdSpoc>>  = demo_ads.clone().into_iter().filter_map(|(k,v)| Some((k, v.into_iter().next()?))).collect();
+
+        ads_store.store_ads::<AdSpoc>(demo_ads.clone(), five_min_ago);
+        assert!(
+            ads_store.get_stored_ads::<AdSpoc>(first_key).is_none(),
+            "Old data past TTL date must not be returned."
+        );
+
+        ads_store.store_ads::<AdSpoc>(demo_ads.clone(), one_min_ago);
+        assert!(
+            ads_store.get_stored_ads::<AdSpoc>(first_key).is_some(),
+            "Could not fetch fresh ad from ads store."
+        );
+    }
+
+    #[test]
+
+    fn test_store_tiles_ad() {
+        let five_min_ago = Instant::now()
+            .checked_sub(Duration::from_mins(5))
+            .expect("Could not create `Instant` for 5 minutes ago");
+        let one_min_ago = Instant::now()
+            .checked_sub(Duration::from_mins(1))
+            .expect("Could not create `Instant` for 1 minute ago");
+        let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
+
+        let demo_ads = test_utils::get_example_happy_uatile_response().data;
+        let first_key = demo_ads
+            .iter()
+            .next()
+            .expect("No test data in `get_example_happy_uatile_response`")
+            .0;
+        // TODO: Remove this bit.
+        let demo_ads: HashMap<String, AdTile> = demo_ads
+            .clone()
+            .into_iter()
+            .filter_map(|(k, v)| Some((k, v.into_iter().next()?)))
+            .collect();
+
+        ads_store.store_ads::<AdTile>(demo_ads.clone(), five_min_ago);
+        assert!(
+            ads_store.get_stored_ads::<AdTile>(first_key).is_none(),
+            "Old data past TTL date must not be returned."
+        );
+
+        ads_store.store_ads::<AdTile>(demo_ads, one_min_ago);
+        assert!(
+            ads_store.get_stored_ads::<AdTile>(first_key).is_some(),
+            "Could not fetch fresh ad from ads store."
+        );
     }
 }

--- a/components/ads-client/src/ads_store.rs
+++ b/components/ads-client/src/ads_store.rs
@@ -186,13 +186,13 @@ mod tests {
 
         ads_store.store_ads::<AdImage>(demo_ads.clone(), five_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdImage>(&first_key).is_none(),
+            ads_store.get_stored_ads::<AdImage>(first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
         ads_store.store_ads::<AdImage>(demo_ads.clone(), one_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdImage>(&first_key).is_some(),
+            ads_store.get_stored_ads::<AdImage>(first_key).is_some(),
             "Could not fetch fresh ad from ads store."
         );
     }
@@ -212,7 +212,7 @@ mod tests {
         let demo_ads: HashMap<PlacementId, Vec<AdSpoc>> = demo_ads
             .clone()
             .into_iter()
-            .filter_map(|(k, v)| Some((PlacementId(k), v)))
+            .map(|(k, v)| (PlacementId(k), v))
             .collect();
         let first_key = demo_ads
             .iter()
@@ -222,13 +222,13 @@ mod tests {
 
         ads_store.store_ads::<AdSpoc>(demo_ads.clone(), five_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdSpoc>(&first_key).is_none(),
+            ads_store.get_stored_ads::<AdSpoc>(first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
         ads_store.store_ads::<AdSpoc>(demo_ads.clone(), one_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdSpoc>(&first_key).is_some(),
+            ads_store.get_stored_ads::<AdSpoc>(first_key).is_some(),
             "Could not fetch fresh ad from ads store."
         );
     }
@@ -259,13 +259,13 @@ mod tests {
 
         ads_store.store_ads::<AdTile>(demo_ads.clone(), five_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdTile>(&first_key).is_none(),
+            ads_store.get_stored_ads::<AdTile>(first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
         ads_store.store_ads::<AdTile>(demo_ads.clone(), one_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdTile>(&first_key).is_some(),
+            ads_store.get_stored_ads::<AdTile>(first_key).is_some(),
             "Could not fetch fresh ad from ads store."
         );
     }

--- a/components/ads-client/src/ads_store.rs
+++ b/components/ads-client/src/ads_store.rs
@@ -208,7 +208,6 @@ mod tests {
         let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
 
         let demo_ads = test_utils::get_example_happy_spoc_response().data;
-        // TODO: Remove this bit.
         let demo_ads: HashMap<PlacementId, Vec<AdSpoc>> = demo_ads
             .clone()
             .into_iter()
@@ -245,7 +244,6 @@ mod tests {
         let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
 
         let demo_ads = test_utils::get_example_happy_uatile_response().data;
-        // TODO: Remove this bit.
         let demo_ads: HashMap<PlacementId, AdTile> = demo_ads
             .clone()
             .into_iter()

--- a/components/ads-client/src/ads_store.rs
+++ b/components/ads-client/src/ads_store.rs
@@ -4,19 +4,23 @@ use std::{
     time::{Duration, Instant},
 };
 
+const DEFAULT_TTL: Duration = Duration::from_secs(300);
+
 // TODO: This is an intentionally naive in-memory cache implementation of the ads cache.
 // It functions as a skeleton to store ads fetched in the background, and has a naive expiration mechanism.
 // The subsequent vertical slice will replace this in its entirety with the http_cache sqlite database instead, with TTLs, persistent storage, etc.
-const DEFAULT_TTL: Duration = Duration::from_secs(300);
-
 #[derive(Debug)]
 pub struct AdsStore {
     ttl: Duration,
 
-    image_ads: HashMap<String, CacheEntry<AdImage>>,
-    spoc_ads: HashMap<String, CacheEntry<Vec<AdSpoc>>>,
-    tile_ads: HashMap<String, CacheEntry<AdTile>>,
+    image_ads: HashMap<PlacementId, CacheEntry<AdImage>>,
+    spoc_ads: HashMap<PlacementId, CacheEntry<Vec<AdSpoc>>>,
+    tile_ads: HashMap<PlacementId, CacheEntry<AdTile>>,
 }
+
+/// Identification of placement sent and returned from MARS (eg: `mock_spoc_1`)
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+pub struct PlacementId(String);
 
 impl Default for AdsStore {
     fn default() -> Self {
@@ -40,7 +44,7 @@ impl AdsStore {
 
     pub fn store_ads<T: AdsStorable>(
         &mut self,
-        ads: HashMap<String, T::StorageType>,
+        ads: HashMap<PlacementId, T::StorageType>,
         timestamp: Instant,
     ) {
         T::store_ads(ads, self, timestamp);
@@ -48,7 +52,7 @@ impl AdsStore {
 
     pub fn get_stored_ads<'a, T: AdsStorable>(
         &'a self,
-        placement: &str,
+        placement: &PlacementId,
     ) -> Option<&'a T::StorageType> {
         T::fetch_stored_ads(self, placement)
     }
@@ -59,16 +63,19 @@ pub trait AdsStorable: Sized {
     type StorageType;
 
     fn store_ads(
-        ads: HashMap<String, Self::StorageType>,
+        ads: HashMap<PlacementId, Self::StorageType>,
         ads_cache: &mut AdsStore,
         timestamp: Instant,
     );
-    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Self::StorageType>;
+    fn fetch_stored_ads<'a>(
+        ads_cache: &'a AdsStore,
+        id: &PlacementId,
+    ) -> Option<&'a Self::StorageType>;
 }
 
 impl AdsStorable for AdImage {
     type StorageType = AdImage;
-    fn store_ads(ads: HashMap<String, AdImage>, ads_cache: &mut AdsStore, timestamp: Instant) {
+    fn store_ads(ads: HashMap<PlacementId, AdImage>, ads_cache: &mut AdsStore, timestamp: Instant) {
         ads_cache.image_ads.extend(
             ads.into_iter()
                 .map(|(key, ad)| (key, CacheEntry::new(ad, timestamp))),
@@ -78,14 +85,18 @@ impl AdsStorable for AdImage {
             .retain(|_, x| !x.is_expired(ads_cache.ttl));
     }
 
-    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdImage> {
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &PlacementId) -> Option<&'a AdImage> {
         ads_cache.image_ads.get(id).map(|ads| ads.get_value())
     }
 }
 
 impl AdsStorable for AdSpoc {
     type StorageType = Vec<AdSpoc>;
-    fn store_ads(ads: HashMap<String, Vec<AdSpoc>>, ads_cache: &mut AdsStore, timestamp: Instant) {
+    fn store_ads(
+        ads: HashMap<PlacementId, Vec<AdSpoc>>,
+        ads_cache: &mut AdsStore,
+        timestamp: Instant,
+    ) {
         ads_cache.spoc_ads.extend(
             ads.into_iter()
                 .map(|(key, ad)| (key, CacheEntry::new(ad, timestamp))),
@@ -94,14 +105,14 @@ impl AdsStorable for AdSpoc {
             .spoc_ads
             .retain(|_, x| !x.is_expired(ads_cache.ttl));
     }
-    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Vec<AdSpoc>> {
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &PlacementId) -> Option<&'a Vec<AdSpoc>> {
         ads_cache.spoc_ads.get(id).map(|ads| ads.get_value())
     }
 }
 
 impl AdsStorable for AdTile {
     type StorageType = AdTile;
-    fn store_ads(ads: HashMap<String, AdTile>, ads_cache: &mut AdsStore, timestamp: Instant) {
+    fn store_ads(ads: HashMap<PlacementId, AdTile>, ads_cache: &mut AdsStore, timestamp: Instant) {
         ads_cache.tile_ads.extend(
             ads.into_iter()
                 .map(|(key, ad)| (key, CacheEntry::new(ad, timestamp))),
@@ -110,7 +121,7 @@ impl AdsStorable for AdTile {
             .tile_ads
             .retain(|_, x| !x.is_expired(ads_cache.ttl));
     }
-    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdTile> {
+    fn fetch_stored_ads<'a>(ads_cache: &'a AdsStore, id: &PlacementId) -> Option<&'a AdTile> {
         ads_cache.tile_ads.get(id).map(|ads| ads.get_value())
     }
 }
@@ -146,7 +157,7 @@ mod tests {
     };
 
     use crate::{
-        ads_store::AdsStore,
+        ads_store::{AdsStore, PlacementId},
         mars::ad_response::{AdImage, AdSpoc, AdTile},
         test_utils,
     };
@@ -162,27 +173,26 @@ mod tests {
         let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
 
         let demo_ads = test_utils::get_example_happy_image_response().data;
+        let demo_ads: HashMap<PlacementId, AdImage> = demo_ads
+            .clone()
+            .into_iter()
+            .filter_map(|(k, v)| Some((PlacementId(k), v.into_iter().next()?)))
+            .collect();
         let first_key = demo_ads
             .iter()
             .next()
             .expect("No test data in `get_example_happy_image_response`")
             .0;
-        // TODO: Remove this bit.
-        let demo_ads: HashMap<String, AdImage> = demo_ads
-            .clone()
-            .into_iter()
-            .filter_map(|(k, v)| Some((k, v.into_iter().next()?)))
-            .collect();
 
         ads_store.store_ads::<AdImage>(demo_ads.clone(), five_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdImage>(first_key).is_none(),
+            ads_store.get_stored_ads::<AdImage>(&first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
-        ads_store.store_ads::<AdImage>(demo_ads, one_min_ago);
+        ads_store.store_ads::<AdImage>(demo_ads.clone(), one_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdImage>(first_key).is_some(),
+            ads_store.get_stored_ads::<AdImage>(&first_key).is_some(),
             "Could not fetch fresh ad from ads store."
         );
     }
@@ -198,23 +208,27 @@ mod tests {
         let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
 
         let demo_ads = test_utils::get_example_happy_spoc_response().data;
+        // TODO: Remove this bit.
+        let demo_ads: HashMap<PlacementId, Vec<AdSpoc>> = demo_ads
+            .clone()
+            .into_iter()
+            .filter_map(|(k, v)| Some((PlacementId(k), v)))
+            .collect();
         let first_key = demo_ads
             .iter()
             .next()
             .expect("No test data in `get_example_happy_spoc_response`")
             .0;
-        // TODO: Remove this bit.
-        // let demo_ads: HashMap<String, Vec<AdSpoc>>  = demo_ads.clone().into_iter().filter_map(|(k,v)| Some((k, v.into_iter().next()?))).collect();
 
         ads_store.store_ads::<AdSpoc>(demo_ads.clone(), five_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdSpoc>(first_key).is_none(),
+            ads_store.get_stored_ads::<AdSpoc>(&first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
         ads_store.store_ads::<AdSpoc>(demo_ads.clone(), one_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdSpoc>(first_key).is_some(),
+            ads_store.get_stored_ads::<AdSpoc>(&first_key).is_some(),
             "Could not fetch fresh ad from ads store."
         );
     }
@@ -231,27 +245,27 @@ mod tests {
         let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
 
         let demo_ads = test_utils::get_example_happy_uatile_response().data;
+        // TODO: Remove this bit.
+        let demo_ads: HashMap<PlacementId, AdTile> = demo_ads
+            .clone()
+            .into_iter()
+            .filter_map(|(k, v)| Some((PlacementId(k), v.into_iter().next()?)))
+            .collect();
         let first_key = demo_ads
             .iter()
             .next()
             .expect("No test data in `get_example_happy_uatile_response`")
             .0;
-        // TODO: Remove this bit.
-        let demo_ads: HashMap<String, AdTile> = demo_ads
-            .clone()
-            .into_iter()
-            .filter_map(|(k, v)| Some((k, v.into_iter().next()?)))
-            .collect();
 
         ads_store.store_ads::<AdTile>(demo_ads.clone(), five_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdTile>(first_key).is_none(),
+            ads_store.get_stored_ads::<AdTile>(&first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
-        ads_store.store_ads::<AdTile>(demo_ads, one_min_ago);
+        ads_store.store_ads::<AdTile>(demo_ads.clone(), one_min_ago);
         assert!(
-            ads_store.get_stored_ads::<AdTile>(first_key).is_some(),
+            ads_store.get_stored_ads::<AdTile>(&first_key).is_some(),
             "Could not fetch fresh ad from ads store."
         );
     }

--- a/components/ads-client/src/ads_store.rs
+++ b/components/ads-client/src/ads_store.rs
@@ -1,0 +1,100 @@
+use crate::mars::ad_response::{AdImage, AdSpoc, AdTile};
+use std::{collections::HashMap, time::Duration};
+
+// TODO: This is an intentionally naive in-memory cache implementation of the ads cache.
+// It functions as a skeleton to store ads fetched in the background, and has a naive expiration mechanism.
+// The subsequent vertical slice will replace this in its entirety with the http_cache sqlite database instead, with TTLs, persistent storage, etc.
+const DEFAULT_TTL: Duration = Duration::from_secs(300);
+
+#[derive(Debug)]
+pub struct AdsStore {
+    image_ads: HashMap<String, (u64, AdImage)>,
+    spoc_ads: HashMap<String, (u64, Vec<AdSpoc>)>,
+    tile_ads: HashMap<String, (u64, AdTile)>,
+}
+
+impl Default for AdsStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AdsStore {
+    pub fn new() -> Self {
+        AdsStore {
+            image_ads: HashMap::new(),
+            spoc_ads: HashMap::new(),
+            tile_ads: HashMap::new(),
+        }
+    }
+
+    pub fn cache_ads<T: AdsStorable>(
+        &mut self,
+        ads: HashMap<String, T::StorageType>,
+        timestamp: u64,
+    ) {
+        T::cache_ads(ads, self, timestamp);
+    }
+
+    pub fn get_cached_ads<'a, T: AdsStorable>(
+        &'a self,
+        placement: &str,
+    ) -> Option<&'a T::StorageType> {
+        T::fetch_cached_ads(self, placement)
+    }
+}
+
+pub trait AdsStorable: Sized {
+    // The ad(s) to store (eg: this may be a single ad, or an array of ads)
+    type StorageType;
+
+    fn cache_ads(ads: HashMap<String, Self::StorageType>, ads_cache: &mut AdsStore, timestamp: u64);
+    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Self::StorageType>;
+}
+
+impl AdsStorable for AdImage {
+    type StorageType = AdImage;
+    fn cache_ads(ads: HashMap<String, AdImage>, ads_cache: &mut AdsStore, timestamp: u64) {
+        ads_cache
+            .image_ads
+            .extend(ads.into_iter().map(|(key, ad)| (key, (timestamp, ad))));
+        ads_cache
+            .image_ads
+            .retain(|_, (x, _)| *x - timestamp < DEFAULT_TTL.as_secs());
+
+            }
+
+    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdImage> {
+        ads_cache.image_ads.get(id).map(|(_, ads)| ads)
+    }
+}
+
+impl AdsStorable for AdSpoc {
+    type StorageType = Vec<AdSpoc>;
+    fn cache_ads(ads: HashMap<String, Vec<AdSpoc>>, ads_cache: &mut AdsStore, timestamp: u64) {
+        ads_cache
+            .spoc_ads
+            .extend(ads.into_iter().map(|(key, ad)| (key, (timestamp, ad))));
+        ads_cache
+            .spoc_ads
+            .retain(|_, (x, _)| *x - timestamp < DEFAULT_TTL.as_secs());
+    }
+    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a Vec<AdSpoc>> {
+        ads_cache.spoc_ads.get(id).map(|(_, ads)| ads)
+    }
+}
+
+impl AdsStorable for AdTile {
+    type StorageType = AdTile;
+    fn cache_ads(ads: HashMap<String, AdTile>, ads_cache: &mut AdsStore, timestamp: u64) {
+        ads_cache
+            .tile_ads
+            .extend(ads.into_iter().map(|(key, ad)| (key, (timestamp, ad))));
+        ads_cache
+            .tile_ads
+            .retain(|_, (x, _)| *x - timestamp < DEFAULT_TTL.as_secs());
+    }
+    fn fetch_cached_ads<'a>(ads_cache: &'a AdsStore, id: &str) -> Option<&'a AdTile> {
+        ads_cache.tile_ads.get(id).map(|(_, ads)| ads)
+    }
+}

--- a/components/ads-client/src/ads_store.rs
+++ b/components/ads-client/src/ads_store.rs
@@ -164,13 +164,13 @@ mod tests {
 
     #[test]
     fn test_store_image_ad() {
-        let five_min_ago = Instant::now()
-            .checked_sub(Duration::from_mins(5))
-            .expect("Could not create `Instant` for 5 minutes ago");
         let one_min_ago = Instant::now()
-            .checked_sub(Duration::from_mins(1))
+            .checked_sub(Duration::from_secs(60))
+            .expect("Could not create `Instant` for 5 minutes ago");
+        let five_sec_ago = Instant::now()
+            .checked_sub(Duration::from_secs(5))
             .expect("Could not create `Instant` for 1 minute ago");
-        let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
+        let mut ads_store = AdsStore::new_with_ttl(Duration::from_secs(30));
 
         let demo_ads = test_utils::get_example_happy_image_response().data;
         let demo_ads: HashMap<PlacementId, AdImage> = demo_ads
@@ -184,13 +184,13 @@ mod tests {
             .expect("No test data in `get_example_happy_image_response`")
             .0;
 
-        ads_store.store_ads::<AdImage>(demo_ads.clone(), five_min_ago);
+        ads_store.store_ads::<AdImage>(demo_ads.clone(), one_min_ago);
         assert!(
             ads_store.get_stored_ads::<AdImage>(first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
-        ads_store.store_ads::<AdImage>(demo_ads.clone(), one_min_ago);
+        ads_store.store_ads::<AdImage>(demo_ads.clone(), five_sec_ago);
         assert!(
             ads_store.get_stored_ads::<AdImage>(first_key).is_some(),
             "Could not fetch fresh ad from ads store."
@@ -199,13 +199,13 @@ mod tests {
 
     #[test]
     fn test_store_spocs_ad() {
-        let five_min_ago = Instant::now()
-            .checked_sub(Duration::from_mins(5))
-            .expect("Could not create `Instant` for 5 minutes ago");
         let one_min_ago = Instant::now()
-            .checked_sub(Duration::from_mins(1))
+            .checked_sub(Duration::from_secs(60))
+            .expect("Could not create `Instant` for 5 minutes ago");
+        let five_sec_ago = Instant::now()
+            .checked_sub(Duration::from_secs(5))
             .expect("Could not create `Instant` for 1 minute ago");
-        let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
+        let mut ads_store = AdsStore::new_with_ttl(Duration::from_secs(30));
 
         let demo_ads = test_utils::get_example_happy_spoc_response().data;
         let demo_ads: HashMap<PlacementId, Vec<AdSpoc>> = demo_ads
@@ -219,13 +219,13 @@ mod tests {
             .expect("No test data in `get_example_happy_spoc_response`")
             .0;
 
-        ads_store.store_ads::<AdSpoc>(demo_ads.clone(), five_min_ago);
+        ads_store.store_ads::<AdSpoc>(demo_ads.clone(), one_min_ago);
         assert!(
             ads_store.get_stored_ads::<AdSpoc>(first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
-        ads_store.store_ads::<AdSpoc>(demo_ads.clone(), one_min_ago);
+        ads_store.store_ads::<AdSpoc>(demo_ads.clone(), five_sec_ago);
         assert!(
             ads_store.get_stored_ads::<AdSpoc>(first_key).is_some(),
             "Could not fetch fresh ad from ads store."
@@ -235,13 +235,13 @@ mod tests {
     #[test]
 
     fn test_store_tiles_ad() {
-        let five_min_ago = Instant::now()
-            .checked_sub(Duration::from_mins(5))
-            .expect("Could not create `Instant` for 5 minutes ago");
         let one_min_ago = Instant::now()
-            .checked_sub(Duration::from_mins(1))
+            .checked_sub(Duration::from_secs(60))
+            .expect("Could not create `Instant` for 5 minutes ago");
+        let five_sec_ago = Instant::now()
+            .checked_sub(Duration::from_secs(5))
             .expect("Could not create `Instant` for 1 minute ago");
-        let mut ads_store = AdsStore::new_with_ttl(Duration::from_mins(3));
+        let mut ads_store = AdsStore::new_with_ttl(Duration::from_secs(30));
 
         let demo_ads = test_utils::get_example_happy_uatile_response().data;
         let demo_ads: HashMap<PlacementId, AdTile> = demo_ads
@@ -255,13 +255,13 @@ mod tests {
             .expect("No test data in `get_example_happy_uatile_response`")
             .0;
 
-        ads_store.store_ads::<AdTile>(demo_ads.clone(), five_min_ago);
+        ads_store.store_ads::<AdTile>(demo_ads.clone(), one_min_ago);
         assert!(
             ads_store.get_stored_ads::<AdTile>(first_key).is_none(),
             "Old data past TTL date must not be returned."
         );
 
-        ads_store.store_ads::<AdTile>(demo_ads.clone(), one_min_ago);
+        ads_store.store_ads::<AdTile>(demo_ads.clone(), five_sec_ago);
         assert!(
             ads_store.get_stored_ads::<AdTile>(first_key).is_some(),
             "Could not fetch fresh ad from ads store."

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -113,15 +113,16 @@ where
         Ok(())
     }
 
-    pub fn cache_ads<A: AdsStorable>(&mut self, ads: HashMap<String, A::StorageType>) {
-        let now = chrono::Utc::now().timestamp().unsigned_abs();
-        self.ads_store.cache_ads::<A>(ads, now);
+    #[allow(dead_code)]
+    pub fn store_ads<A: AdsStorable>(&mut self, ads: HashMap<String, A::StorageType>) {
+        let now = std::time::Instant::now();
+        self.ads_store.store_ads::<A>(ads, now);
     }
 
-    pub fn get_cached_ads<A: AdsStorable>(&self, placement_id: &str) -> Option<&A::StorageType> {
-        self.ads_store.get_cached_ads::<A>(placement_id)
+    #[allow(dead_code)]
+    pub fn get_stored_ads<A: AdsStorable>(&self, placement_id: &str) -> Option<&A::StorageType> {
+        self.ads_store.get_stored_ads::<A>(placement_id)
     }
-
 
     pub fn get_context_id(&self) -> context_id::ApiResult<String> {
         self.context_id_provider.context_id()

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::ads_store::{AdsStorable, AdsStore};
+use crate::ads_store::{AdsStorable, AdsStore, PlacementId};
 use crate::http_cache::{ByteSize, CachePolicy, HttpCache};
 use crate::mars::ad_request::{AdPlacementRequest, AdRequestFlags};
 use crate::mars::ad_response::{AdImage, AdResponse, AdResponseValue, AdSpoc, AdTile};
@@ -114,13 +114,16 @@ where
     }
 
     #[allow(dead_code)]
-    pub fn store_ads<A: AdsStorable>(&mut self, ads: HashMap<String, A::StorageType>) {
+    pub fn store_ads<A: AdsStorable>(&mut self, ads: HashMap<PlacementId, A::StorageType>) {
         let now = std::time::Instant::now();
         self.ads_store.store_ads::<A>(ads, now);
     }
 
     #[allow(dead_code)]
-    pub fn get_stored_ads<A: AdsStorable>(&self, placement_id: &str) -> Option<&A::StorageType> {
+    pub fn get_stored_ads<A: AdsStorable>(
+        &self,
+        placement_id: &PlacementId,
+    ) -> Option<&A::StorageType> {
         self.ads_store.get_stored_ads::<A>(placement_id)
     }
 

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use crate::ads_store::{AdsStorable, AdsStore};
 use crate::http_cache::{ByteSize, CachePolicy, HttpCache};
 use crate::mars::ad_request::{AdPlacementRequest, AdRequestFlags};
 use crate::mars::ad_response::{AdImage, AdResponse, AdResponseValue, AdSpoc, AdTile};
@@ -42,6 +43,7 @@ where
     client: MARSClient<T>,
     context_id_provider: Box<dyn ContextIdProvider>,
     telemetry: T,
+    ads_store: AdsStore,
 }
 
 impl<T> AdsClient<T>
@@ -91,6 +93,7 @@ where
             client,
             context_id_provider,
             telemetry: telemetry.clone(),
+            ads_store: AdsStore::new(),
         }
     }
 
@@ -109,6 +112,16 @@ where
 
         Ok(())
     }
+
+    pub fn cache_ads<A: AdsStorable>(&mut self, ads: HashMap<String, A::StorageType>) {
+        let now = chrono::Utc::now().timestamp().unsigned_abs();
+        self.ads_store.cache_ads::<A>(ads, now);
+    }
+
+    pub fn get_cached_ads<A: AdsStorable>(&self, placement_id: &str) -> Option<&A::StorageType> {
+        self.ads_store.get_cached_ads::<A>(placement_id)
+    }
+
 
     pub fn get_context_id(&self) -> context_id::ApiResult<String> {
         self.context_id_provider.context_id()
@@ -301,6 +314,7 @@ mod tests {
                 Box::new(DefaultContextIdCallback),
             )),
             telemetry,
+            ads_store: AdsStore::new(),
         }
     }
 

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -15,6 +15,8 @@ use client::AdsClient;
 use error_support::error;
 use http_cache::CachePolicy;
 use mars::ad_request::{AdPlacementRequest, AdRequestFlags};
+
+pub mod ads_store;
 mod client;
 mod ffi;
 pub mod http_cache;


### PR DESCRIPTION
As discussed in [this PR](https://github.com/mozilla/application-services/pull/7531), this splits out the _temporary_ ads store out of the PR to reduce its complexity.

This is a temporary structure to be used for the first vertical slice of the fire-and-forget refactoring for ads-client. It will be modified in a later PR to use sqlite (durable) instead.

It is currently unused.

I don't think this needs a changelog entry, but the greater fire-and-forget mechanism will include one.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
