### PR TITLE
test(ads-client): assert shutdown is idempotent

### DIFF
--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -560,4 +560,30 @@ mod tests {
         client.shutdown_client().unwrap();
         assert_eq!(weak_reference.strong_count(), 0);
     }
+
+    #[test]
+    fn test_shutdown_is_idempotent() {
+        viaduct_dev::init_backend_dev();
+
+        let noop_telemetry = MozAdsTelemetryWrapper::noop();
+        let weak_reference = Arc::downgrade(
+            &noop_telemetry
+                .clone_inner_arc()
+                .expect("Inner telemetry should be Some before dropping"),
+        );
+        // A real cache so the second shutdown exercises the db close path.
+        let cache = HttpCache::builder("test_shutdown_is_idempotent")
+            .build()
+            .unwrap();
+        let mars_client = MARSClient::new(Environment::Test, Some(cache), noop_telemetry);
+        let mut client = new_with_mars_client(mars_client);
+
+        client.shutdown_client().unwrap();
+        assert_eq!(weak_reference.strong_count(), 0);
+
+        // Repeated shutdowns must not error or re-close an already closed connection.
+        client.shutdown_client().unwrap();
+        client.shutdown_client().unwrap();
+        assert_eq!(weak_reference.strong_count(), 0);
+    }
 }


### PR DESCRIPTION
Adds a regression test covering repeated `shutdown()` calls on the ads client.

`MozAdsClient::shutdown` takes `&self` and goes through a lock, so a double shutdown is reachable from the foreign side. Both pieces of state it tears down are already `Option::take()` — `MozAdsTelemetryWrapper::shutdown` (`ffi/telemetry.rs`) and `MARSTransport::shutdown_db` (`mars/transport.rs`) — so the behaviour is correct today; this test pins it down.

The test builds the client with a real `HttpCache`, since that's where a regression would bite: `HttpCache::shutdown_db(self)` consumes and calls `conn.close()`, so replacing the `take()` with a borrow would make the second close error.

### Pull Request checklist ###
- [x] **Breaking changes**: no API changes; test-only.
- [x] **Quality**: `cargo test -p ads-client` passes (96 passed, 1 ignored, 0 failed); `cargo fmt --check` and `cargo clippy -p ads-client --all-targets` are clean.
- [x] **Tests**: this PR is the test. Mutation-checked it: temporarily making `MARSTransport::shutdown_db` return `Err(InvalidQuery)` on an already-shut-down cache makes it fail; restored and re-verified green.
- [x] **Changelog**: not needed — no consumer-visible change.
- [x] **Dependencies**: no new dependencies.