### PR TITLE
Bug 2065595 - Provide an API for querying enrollments without instantiating a NimbusClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v156.0 (In progress)
 
+## ✨ What's Changed ✨
+
+### Nimbus
+
+- A new API has been added to get the list of enrolled experiments and rollouts without instantiating a NimbusClient: `get_active_enrollments()`. ([#7560](https://github.com/mozilla/application-services/pull/7560))
+
 [Full Changelog](In progress)
 
 # v155.0 (_2026-08-13_)
@@ -36,7 +42,7 @@ In the cases where the failed before, they're now no-ops.
 
 ### Remote Settings
 - Replacing v1 routes with v2 routes, removing added v2 routes ([#7492](https://github.com/mozilla/application-services/pull/7339))
-- Verify signature of imported data when `.get()` is called with `sync_if_empty: true` ([#7518](https://github.com/mozilla/application-services/pull/7518)) 
+- Verify signature of imported data when `.get()` is called with `sync_if_empty: true` ([#7518](https://github.com/mozilla/application-services/pull/7518))
 - Do not quote `_since` values with the v2 API ([#7523](https://github.com/mozilla/application-services/pull/7523))
 
 ### Sync Manager

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -14,6 +14,11 @@ dictionary CalculatedAttributes {
     string? region;
 };
 
+dictionary EnrollmentSlugs {
+    string slug;
+    string branch_slug;
+};
+
 namespace nimbus {
 
     /// A test utility used to validate event queries against the jexl evaluator.
@@ -25,6 +30,13 @@ namespace nimbus {
     ///
     [Throws=NimbusError]
     CalculatedAttributes get_calculated_attributes(i64? installation_date, string db_path, string locale);
+
+    /// Return the list of active experiments.
+    ///
+    /// Intended to be called in instances where a full Nimbus Client cannot be
+    /// instantiated (e.g., in crash reporting infrastructure).
+    [Throws=NimbusError]
+    sequence<EnrollmentSlugs> get_active_enrollments([ByRef] string db_path);
 };
 
 dictionary AppContext {

--- a/components/nimbus/src/schema.rs
+++ b/components/nimbus/src/schema.rs
@@ -28,6 +28,12 @@ pub struct EnrolledExperiment {
     pub is_rollout: bool,
 }
 
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+pub struct EnrollmentSlugs {
+    pub slug: String,
+    pub branch_slug: String,
+}
+
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️
 // ⚠️ in `test_lib_bw_compat.rs`, and may require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]

--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashSet;
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -52,7 +52,8 @@ use crate::stateful::targeting::{RecordedContext, execute_event_queries, validat
 use crate::stateful::updating::{read_and_remove_pending_experiments, write_pending_experiments};
 use crate::strings::fmt_with_map;
 use crate::{
-    AvailableExperiment, AvailableRandomizationUnits, EnrolledExperiment, EnrollmentStatus,
+    AvailableExperiment, AvailableRandomizationUnits, EnrolledExperiment, EnrollmentSlugs,
+    EnrollmentStatus,
 };
 use crate::{Experiment, ExperimentBranch, NimbusError, NimbusTargetingHelper, Result};
 
@@ -1054,6 +1055,30 @@ impl NimbusClient {
     pub fn get_experiment_enrollment(&self, slug: &str) -> Result<Option<ExperimentEnrollment>> {
         self.database_cache.get_experiment_enrollment(slug)
     }
+}
+
+pub fn get_active_enrollments<P: AsRef<Path>>(db_path: &P) -> Result<Vec<EnrollmentSlugs>> {
+    let db = Database::open_single(db_path.as_ref(), StoreId::Enrollments)?;
+    let reader = db.read()?;
+    let enrollments: Vec<ExperimentEnrollment> = db.store.collect_all(&reader)?;
+
+    Ok(enrollments
+        .into_iter()
+        .filter_map(|enrollment| {
+            if let EnrollmentStatus::Enrolled {
+                branch: branch_slug,
+                ..
+            } = enrollment.status
+            {
+                Some(EnrollmentSlugs {
+                    slug: enrollment.slug,
+                    branch_slug,
+                })
+            } else {
+                None
+            }
+        })
+        .collect())
 }
 
 pub struct NimbusStringHelper {

--- a/components/nimbus/src/tests/stateful/test_persistence.rs
+++ b/components/nimbus/src/tests/stateful/test_persistence.rs
@@ -7,12 +7,16 @@ use std::path::Path;
 
 use rkv::StoreOptions;
 
+use crate::enrollment::{
+    DisqualifiedReason, EnrolledReason, ExperimentEnrollment, NotEnrolledReason,
+};
 use crate::error::Result;
 use crate::evaluator::get_calculated_attributes;
 use crate::metrics::{DatabaseLoadExtraDef, DatabaseMigrationExtraDef};
 use crate::stateful::enrollment::{get_experiment_participation, get_rollout_participation};
 use crate::stateful::persistence::*;
 use crate::tests::helpers::TestMetrics;
+use crate::{EnrollmentSlugs, EnrollmentStatus, get_active_enrollments};
 
 #[test]
 fn test_db_upgrade_no_version() -> Result<()> {
@@ -697,6 +701,86 @@ fn test_migrate_db_idempotent() -> Result<()> {
     );
 
     assert_eq!(metrics.get_database_migration_events(), []);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_active_enrollments() -> Result<()> {
+    error_support::init_for_tests();
+
+    let tmp_dir = tempfile::tempdir()?;
+
+    {
+        let db = Database::open_single(&tmp_dir, StoreId::Enrollments)?;
+        let mut writer = db.write()?;
+
+        db.store.put(
+            &mut writer,
+            "experiment-enrolled",
+            &ExperimentEnrollment {
+                slug: "experiment-enrolled".into(),
+                status: EnrollmentStatus::Enrolled {
+                    reason: EnrolledReason::Qualified,
+                    branch: "treatment-a".into(),
+                    prev_gecko_pref_states: None,
+                },
+            },
+        )?;
+        db.store.put(
+            &mut writer,
+            "experiment-wasenrolled",
+            &ExperimentEnrollment {
+                slug: "experiment-wasenrolled".into(),
+                status: EnrollmentStatus::WasEnrolled {
+                    branch: "control".into(),
+                    experiment_ended_at: 0,
+                },
+            },
+        )?;
+        db.store.put(
+            &mut writer,
+            "experiment-disqualified",
+            &ExperimentEnrollment {
+                slug: "experiment-disqualified".into(),
+                status: EnrollmentStatus::Disqualified {
+                    branch: "control".into(),
+                    reason: DisqualifiedReason::OptOut,
+                },
+            },
+        )?;
+        db.store.put(
+            &mut writer,
+            "experiment-notenrolled",
+            &ExperimentEnrollment {
+                slug: "experiment-notenrolled".into(),
+                status: EnrollmentStatus::NotEnrolled {
+                    reason: NotEnrolledReason::NotTargeted,
+                },
+            },
+        )?;
+        db.store.put(
+            &mut writer,
+            "experiment-error",
+            &ExperimentEnrollment {
+                slug: "experiment-error".into(),
+                status: EnrollmentStatus::Error {
+                    reason: "uh oh".into(),
+                },
+            },
+        )?;
+
+        writer.commit()?;
+    }
+
+    let active_enrollments = get_active_enrollments(&tmp_dir)?;
+    assert_eq!(
+        &active_enrollments,
+        &[EnrollmentSlugs {
+            slug: "experiment-enrolled".into(),
+            branch_slug: "treatment-a".into(),
+        }]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
We need an API to read the list of enrollments from the database in situations where we cannot instantiate a full NimbusClient, e.g., in the Fenix crashreporter.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
