### PR TITLE
Bug 1972088 - Set up default SQLite pragmas to truncate the -wal file

### DIFF
--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -113,11 +113,10 @@ impl ConnectionInitializer for AutofillConnectionInitializer {
     fn prepare(&self, conn: &Connection, _db_empty: bool) -> Result<()> {
         define_functions(conn)?;
 
+        // Set up default SQLite pragmas to truncate the -wal file.
+        sql_support::setup_sqlite_defaults(conn)?;
+
         let initial_pragmas = "
-            -- use in-memory storage
-            PRAGMA temp_store = 2;
-            -- use write-ahead logging
-            PRAGMA journal_mode = WAL;
             -- autofill does not use foreign keys at present but this is probably a good pragma to set
             PRAGMA foreign_keys = ON;
         ";
@@ -292,6 +291,7 @@ mod tests {
     use crate::db::addresses::get_address;
     use crate::db::credit_cards::get_credit_card;
     use crate::db::test::new_mem_db;
+    use crate::db::AutofillDb;
     use sql_support::open_database::test_utils::MigratedDatabaseFile;
     use sync_guid::Guid;
     use types::Timestamp;
@@ -301,6 +301,31 @@ mod tests {
     const CREATE_V2_DB: &str = include_str!("../../sql/tests/create_v2_db.sql");
     const CREATE_V3_DB: &str = include_str!("../../sql/tests/create_v3_db.sql");
     const CREATE_V4_DB: &str = include_str!("../../sql/tests/create_v4_db.sql");
+
+    #[test]
+    fn test_wal_size_is_bounded() {
+        // A memory database has no -wal file, so open a real one.
+        let db_file = MigratedDatabaseFile::new(AutofillConnectionInitializer, "");
+        let db = AutofillDb::new(&db_file.path).expect("should open the database");
+
+        let journal_mode: String = db
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal_mode, "wal");
+
+        let autocheckpoint: i64 = db
+            .query_row("PRAGMA wal_autocheckpoint", [], |row| row.get(0))
+            .unwrap();
+        assert!(autocheckpoint > 0, "auto-checkpointing is disabled");
+
+        let journal_size_limit: i64 = db
+            .query_row("PRAGMA journal_size_limit", [], |row| row.get(0))
+            .unwrap();
+        assert!(
+            journal_size_limit > 0,
+            "journal_size_limit is {journal_size_limit}, so the -wal file is never truncated"
+        );
+    }
 
     #[test]
     fn test_create_schema_twice() {

--- a/components/support/sql/src/maintenance.rs
+++ b/components/support/sql/src/maintenance.rs
@@ -12,7 +12,7 @@ use rusqlite::{Connection, Result};
 pub fn run_maintenance(conn: &Connection) -> Result<()> {
     vacuum(conn)?;
     conn.execute_one("PRAGMA optimize")?;
-    conn.execute_one("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    conn.execute_one("PRAGMA wal_checkpoint(PASSIVE)")?;
     Ok(())
 }
 

--- a/components/support/sql/src/maintenance.rs
+++ b/components/support/sql/src/maintenance.rs
@@ -12,7 +12,7 @@ use rusqlite::{Connection, Result};
 pub fn run_maintenance(conn: &Connection) -> Result<()> {
     vacuum(conn)?;
     conn.execute_one("PRAGMA optimize")?;
-    conn.execute_one("PRAGMA wal_checkpoint(PASSIVE)")?;
+    conn.execute_one("PRAGMA wal_checkpoint(TRUNCATE)")?;
     Ok(())
 }
 


### PR DESCRIPTION
### Pull Request checklist ###

Since the creation of the ticket, we have brought the `runMaintenance()` periodic job to Fenix. However, while investigating this I noticed that we do not set any default journal size for the WAL which would have prevented the issue, and it is generally a good practice to set defaults.

I've also changed the WAL checkpoint from `PASSIVE` to `TRUNCATE`. Though I'm a bit less certain if this is a good idea or if there are reasons we shouldn't be doing so. So I would love some input and an extra set of eyes on that.

<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
