### PR TITLE
Refresh time_last_modified when an address is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Full Changelog](In progress)
 
+## ✨ What's Changed ✨
+
+### Autofill
+
+- `update_address()` now sets `time_last_modified` to the time of the update, matching `update_credit_card()` and `update_passport()`.
+
 # v156.0 (_2026-08-27_)
 
 ## ✨ What's Changed ✨

--- a/components/autofill/src/db/addresses.rs
+++ b/components/autofill/src/db/addresses.rs
@@ -322,6 +322,7 @@ pub(crate) fn update_address(
             country             = :country,
             tel                 = :tel,
             email               = :email,
+            time_last_modified  = :time_last_modified,
             sync_change_counter = sync_change_counter + 1
         WHERE guid              = :guid",
         rusqlite::named_params! {
@@ -335,6 +336,7 @@ pub(crate) fn update_address(
             ":country": address.country,
             ":tel": address.tel,
             ":email": address.email,
+            ":time_last_modified": Timestamp::now(),
             ":guid": guid,
         },
     )?;
@@ -674,6 +676,36 @@ mod tests {
 
         //check that the sync_change_counter was incremented
         assert_eq!(1, updated_address.metadata.sync_change_counter);
+    }
+
+    #[test]
+    fn test_address_update_refreshes_time_last_modified() -> Result<()> {
+        let db = new_mem_db();
+
+        // Backdated, so the update has something to move it away from: two
+        // calls in the same millisecond would tell us nothing.
+        add_address_with_meta(&db, test_fields("123 Main Street"), test_meta("abc", 0))?;
+        assert_eq!(
+            get_address(&db, &Guid::new("abc"))?
+                .metadata
+                .time_last_modified
+                .as_millis(),
+            3000
+        );
+
+        update_address(&db, &Guid::new("abc"), &test_fields("456 Second Avenue"))?;
+
+        // Consumers reconcile on this field -- latest wins -- so an update that
+        // leaves it alone makes the record look older than it is.
+        assert!(
+            get_address(&db, &Guid::new("abc"))?
+                .metadata
+                .time_last_modified
+                .as_millis()
+                > 3000
+        );
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
update_address wrote the content columns but left time_last_modified at its creation value, unlike update_credit_card and update_passport.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
