### PR TITLE
[AC-150] Add blocks parameter to all ads-client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - `update_address()` now sets `time_last_modified` to the time of the update, matching `update_credit_card()` and `update_passport()`.
 
+### Ads-Client
+
+- Added `blocks: Vec<String>` to `ffi::MozAdsRequestOptions`, `AdsClient::request*_ads`, `MARSClient::fetch_ads`, `mars::AdRequest`, and `mars::AdRequest::try_new`. This is serialized and passed to MARS so that it can remove blocks server-side.
+
 # v156.0 (_2026-08-27_)
 
 ## ✨ What's Changed ✨

--- a/components/ads-client/src/client.rs
+++ b/components/ads-client/src/client.rs
@@ -198,9 +198,10 @@ where
         flags: AdRequestFlags,
         options: Option<CachePolicy>,
         ohttp: bool,
+        blocks: Vec<String>,
     ) -> Result<HashMap<String, AdImage>, RequestAdsError> {
         let response = self
-            .request_ads::<AdImage>(ad_placement_requests, flags, options, ohttp)
+            .request_ads::<AdImage>(ad_placement_requests, flags, options, ohttp, blocks)
             .inspect_err(|e| {
                 self.telemetry.record(e);
             })?;
@@ -214,8 +215,10 @@ where
         flags: AdRequestFlags,
         options: Option<CachePolicy>,
         ohttp: bool,
+        blocks: Vec<String>,
     ) -> Result<HashMap<String, Vec<AdSpoc>>, RequestAdsError> {
-        let result = self.request_ads::<AdSpoc>(ad_placement_requests, flags, options, ohttp);
+        let result =
+            self.request_ads::<AdSpoc>(ad_placement_requests, flags, options, ohttp, blocks);
         result
             .inspect_err(|e| {
                 self.telemetry.record(e);
@@ -232,8 +235,10 @@ where
         flags: AdRequestFlags,
         options: Option<CachePolicy>,
         ohttp: bool,
+        blocks: Vec<String>,
     ) -> Result<HashMap<String, AdTile>, RequestAdsError> {
-        let result = self.request_ads::<AdTile>(ad_placement_requests, flags, options, ohttp);
+        let result =
+            self.request_ads::<AdTile>(ad_placement_requests, flags, options, ohttp, blocks);
         result
             .inspect_err(|e| {
                 self.telemetry.record(e);
@@ -250,15 +255,21 @@ where
         flags: AdRequestFlags,
         options: Option<CachePolicy>,
         ohttp: bool,
+        blocks: Vec<String>,
     ) -> Result<AdResponse<A>, RequestAdsError>
     where
         A: AdResponseValue,
     {
         let context_id = self.get_context_id()?;
         let cache_policy = options.unwrap_or_default();
-        let (mut response, request_hash) =
-            self.client
-                .fetch_ads::<A>(context_id, flags, placements, cache_policy, ohttp)?;
+        let (mut response, request_hash) = self.client.fetch_ads::<A>(
+            context_id,
+            flags,
+            placements,
+            cache_policy,
+            ohttp,
+            blocks,
+        )?;
         response.enrich_callbacks(&request_hash);
         Ok(response)
     }
@@ -336,6 +347,7 @@ mod tests {
             AdRequestFlags::default(),
             None,
             false,
+            Default::default(),
         );
         assert!(result.is_ok());
         m.assert();
@@ -360,6 +372,7 @@ mod tests {
             AdRequestFlags::default(),
             None,
             false,
+            Default::default(),
         );
         assert!(result.is_ok());
         m.assert();
@@ -384,6 +397,7 @@ mod tests {
             AdRequestFlags::default(),
             None,
             false,
+            Default::default(),
         );
         assert!(result.is_ok());
         m.assert();
@@ -425,6 +439,7 @@ mod tests {
             AdRequestFlags::default(),
             None,
             false,
+            Default::default(),
         );
         assert!(result.is_ok());
         m.assert();
@@ -486,6 +501,7 @@ mod tests {
                 AdRequestFlags::default(),
                 None,
                 false,
+                Default::default(),
             )
             .unwrap();
         let callback_url = response.values().next().unwrap().callbacks.click.clone();
@@ -500,6 +516,7 @@ mod tests {
                 AdRequestFlags::default(),
                 None,
                 false,
+                Default::default(),
             )
             .unwrap();
 
@@ -511,6 +528,7 @@ mod tests {
                 AdRequestFlags::default(),
                 Some(CachePolicy::default()),
                 false,
+                Default::default(),
             )
             .unwrap();
 

--- a/components/ads-client/src/ffi.rs
+++ b/components/ads-client/src/ffi.rs
@@ -57,6 +57,8 @@ impl From<MozAdsContextIdProviderWrapper> for Box<dyn ContextIdProvider> {
 
 #[derive(Default, uniffi::Record)]
 pub struct MozAdsRequestOptions {
+    #[uniffi(default)]
+    pub blocks: Vec<String>,
     pub cache_policy: Option<MozAdsCachePolicy>,
     #[uniffi(default)]
     pub flags: HashMap<String, bool>,

--- a/components/ads-client/src/lib.rs
+++ b/components/ads-client/src/lib.rs
@@ -126,9 +126,10 @@ impl MozAdsClient {
         let options = options.unwrap_or_default();
         let flags = AdRequestFlags::from(&options);
         let ohttp = options.ohttp;
-        let cache_policy: CachePolicy = options.into();
+        let cache_policy = options.cache_policy.map(CachePolicy::from);
+        let blocks = options.blocks;
         let response = inner
-            .request_image_ads(requests, flags, Some(cache_policy), ohttp)
+            .request_image_ads(requests, flags, cache_policy, ohttp, blocks)
             .map_err(ComponentError::RequestAds)?;
         Ok(response.into_iter().map(|(k, v)| (k, v.into())).collect())
     }
@@ -145,9 +146,10 @@ impl MozAdsClient {
         let options = options.unwrap_or_default();
         let flags = AdRequestFlags::from(&options);
         let ohttp = options.ohttp;
-        let cache_policy: CachePolicy = options.into();
+        let cache_policy = options.cache_policy.map(CachePolicy::from);
+        let blocks = options.blocks;
         let response = inner
-            .request_spoc_ads(requests, flags, Some(cache_policy), ohttp)
+            .request_spoc_ads(requests, flags, cache_policy, ohttp, blocks)
             .map_err(ComponentError::RequestAds)?;
         Ok(response
             .into_iter()
@@ -167,9 +169,10 @@ impl MozAdsClient {
         let options = options.unwrap_or_default();
         let flags = AdRequestFlags::from(&options);
         let ohttp = options.ohttp;
-        let cache_policy: CachePolicy = options.into();
+        let cache_policy = options.cache_policy.map(CachePolicy::from);
+        let blocks = options.blocks;
         let response = inner
-            .request_tile_ads(requests, flags, Some(cache_policy), ohttp)
+            .request_tile_ads(requests, flags, cache_policy, ohttp, blocks)
             .map_err(ComponentError::RequestAds)?;
         Ok(response.into_iter().map(|(k, v)| (k, v.into())).collect())
     }

--- a/components/ads-client/src/mars.rs
+++ b/components/ads-client/src/mars.rs
@@ -68,12 +68,19 @@ where
         placements: Vec<AdPlacementRequest>,
         cache_policy: CachePolicy,
         ohttp: bool,
+        blocks: Vec<String>,
     ) -> Result<(AdResponse<A>, RequestHash), FetchAdsError>
     where
         A: AdResponseValue,
     {
-        let mut ad_request =
-            AdRequest::try_new(context_id, self.environment, flags, ohttp, placements)?;
+        let mut ad_request = AdRequest::try_new(
+            blocks,
+            context_id,
+            self.environment,
+            flags,
+            ohttp,
+            placements,
+        )?;
         let request_hash = RequestHash::new(&ad_request);
 
         if ohttp {
@@ -239,6 +246,7 @@ mod tests {
             make_happy_placement_requests(),
             CachePolicy::default(),
             false,
+            Default::default(),
         );
         assert!(result.is_ok());
         let (response, _request_hash) = result.unwrap();
@@ -272,6 +280,7 @@ mod tests {
                 make_happy_placement_requests(),
                 CachePolicy::default(),
                 false,
+                Default::default(),
             )
             .unwrap();
         assert_eq!(response1, expected);
@@ -284,6 +293,7 @@ mod tests {
                 make_happy_placement_requests(),
                 CachePolicy::default(),
                 false,
+                Default::default(),
             )
             .unwrap();
         assert_eq!(response2, expected);

--- a/components/ads-client/src/mars/ad_request.rs
+++ b/components/ads-client/src/mars/ad_request.rs
@@ -17,6 +17,8 @@ const ENDPOINT: &str = "/ads";
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct AdRequest {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub blocks: Vec<String>,
     pub context_id: String,
     /// Skipped to exclude from the request body
     #[serde(skip)]
@@ -64,6 +66,7 @@ impl From<AdRequest> for Request {
 
 impl AdRequest {
     pub fn try_new(
+        blocks: Vec<String>,
         context_id: String,
         environment: Environment,
         flags: AdRequestFlags,
@@ -75,6 +78,7 @@ impl AdRequest {
         };
 
         let mut request = AdRequest {
+            blocks,
             context_id,
             environment,
             flags,
@@ -199,6 +203,7 @@ mod tests {
     #[test]
     fn test_build_ad_request_happy() {
         let request = AdRequest::try_new(
+            Default::default(),
             TEST_CONTEXT_ID.to_string(),
             Environment::Test,
             HashMap::from([("contextual_placement".to_string(), true)]),
@@ -225,6 +230,7 @@ mod tests {
         .unwrap();
 
         let expected_request = AdRequest {
+            blocks: Default::default(),
             context_id: TEST_CONTEXT_ID.to_string(),
             environment: Environment::Test,
             flags: HashMap::from([("contextual_placement".to_string(), true)]),
@@ -256,6 +262,7 @@ mod tests {
     #[test]
     fn test_ad_request_omits_flags_when_none_are_set() {
         let request = AdRequest::try_new(
+            Default::default(),
             TEST_CONTEXT_ID.to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -280,6 +287,7 @@ mod tests {
     #[test]
     fn test_ad_request_serializes_explicit_false_flag() {
         let request = AdRequest::try_new(
+            Default::default(),
             TEST_CONTEXT_ID.to_string(),
             Environment::Test,
             HashMap::from([("contextual_placement".to_string(), false)]),
@@ -301,8 +309,59 @@ mod tests {
     }
 
     #[test]
+    fn test_ad_request_omits_blocks_when_none() {
+        let request = AdRequest::try_new(
+            Default::default(),
+            TEST_CONTEXT_ID.to_string(),
+            Environment::Test,
+            AdRequestFlags::default(),
+            false,
+            vec![AdPlacementRequest {
+                content: None,
+                count: 1,
+                placement: "example_placement".to_string(),
+            }],
+        )
+        .unwrap();
+
+        assert!(request.flags.is_empty());
+
+        let serialized = to_value(&request).unwrap();
+        assert!(
+            serialized.get("blocks").is_none(),
+            "blocks object must be omitted from the wire when no blocks are set, got: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_ad_request_includes_blocks_when_present() {
+        let request = AdRequest::try_new(
+            vec!["test".to_string()],
+            TEST_CONTEXT_ID.to_string(),
+            Environment::Test,
+            AdRequestFlags::default(),
+            false,
+            vec![AdPlacementRequest {
+                content: None,
+                count: 1,
+                placement: "example_placement".to_string(),
+            }],
+        )
+        .unwrap();
+
+        assert!(request.flags.is_empty());
+
+        let serialized = to_value(&request).unwrap();
+        assert!(
+            serialized.get("blocks").is_some(),
+            "blocks object must be included from the wire when blocks are set, got: {serialized}"
+        );
+    }
+
+    #[test]
     fn test_ad_request_serializes_with_contextual_placement_flag_and_mixed_content() {
         let request = AdRequest::try_new(
+            Default::default(),
             "context-123".to_string(),
             Environment::Test,
             HashMap::from([("contextual_placement".to_string(), true)]),
@@ -359,6 +418,7 @@ mod tests {
         };
 
         let req_off = AdRequest::try_new(
+            Default::default(),
             "same-id".to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -367,6 +427,7 @@ mod tests {
         )
         .unwrap();
         let req_on = AdRequest::try_new(
+            Default::default(),
             "same-id".to_string(),
             Environment::Test,
             HashMap::from([("contextual_placement".to_string(), true)]),
@@ -381,6 +442,7 @@ mod tests {
     #[test]
     fn test_build_ad_request_fails_on_duplicate_placement_id() {
         let request = AdRequest::try_new(
+            Default::default(),
             TEST_CONTEXT_ID.to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -410,6 +472,7 @@ mod tests {
     #[test]
     fn test_build_ad_request_fails_on_empty_request() {
         let request = AdRequest::try_new(
+            Default::default(),
             TEST_CONTEXT_ID.to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -435,6 +498,7 @@ mod tests {
         let context_id_b = "dddd-eeee-ffff".to_string();
 
         let req1 = AdRequest::try_new(
+            Default::default(),
             context_id_a,
             Environment::Test,
             AdRequestFlags::default(),
@@ -443,6 +507,7 @@ mod tests {
         )
         .unwrap();
         let req2 = AdRequest::try_new(
+            Default::default(),
             context_id_b,
             Environment::Test,
             AdRequestFlags::default(),
@@ -459,6 +524,7 @@ mod tests {
         use crate::http_cache::RequestHash;
 
         let req1 = AdRequest::try_new(
+            Default::default(),
             "same-id".to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -472,6 +538,7 @@ mod tests {
         .unwrap();
 
         let req2 = AdRequest::try_new(
+            Default::default(),
             "same-id".to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -500,6 +567,7 @@ mod tests {
         };
 
         let req_direct = AdRequest::try_new(
+            Default::default(),
             "same-id".to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -508,6 +576,7 @@ mod tests {
         )
         .unwrap();
         let req_ohttp = AdRequest::try_new(
+            Default::default(),
             "same-id".to_string(),
             Environment::Test,
             AdRequestFlags::default(),
@@ -524,6 +593,7 @@ mod tests {
         use std::collections::hash_map::DefaultHasher;
 
         let request = AdRequest::try_new(
+            Default::default(),
             TEST_CONTEXT_ID.to_string(),
             Environment::Test,
             AdRequestFlags::default(),


### PR DESCRIPTION
This makes sure that all requests can filter blocks out server-sided when needed.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
