### PR TITLE
docs: Actually fail the build when jazzy fails

### DIFF
--- a/automation/swift-components-docs/generate-static-docs-website.sh
+++ b/automation/swift-components-docs/generate-static-docs-website.sh
@@ -8,4 +8,5 @@ if jazzy --clean; then
     echo "Documentation generated successfully and cleaned up previous output."
 else
     echo "Failed to generate documentation."
+    exit 1
 fi


### PR DESCRIPTION
Looks like doc deployment is broken for a few days now: 
https://github.com/mozilla/application-services/actions/runs/32420528274/job/96591352676

```
<snip>
 /Users/runner/hostedtoolcache/Ruby/3.3.12/arm64/lib/ruby/gems/3.3.0/gems/mustache-1.1.3/lib/mustache/settings.rb:47:in `setup_path': undefined method `map' for an instance of Pathname (NoMethodError)

    path.map{|p| File.expand_path(p)}
        ^^^^
Did you mean?  tap
<snip>
Failed to generate documentation.
All scripts executed successfully.
```

The deploy-docs step fails because the directory is missing, but the build-swift-docs task reports success, because the shell script hides the error.