### PR TITLE
Bug 2069244 - Update the DEPENDENCIES.md to support the new arrayref license URL

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -674,7 +674,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>BSD-2-Clause License: arrayref</name>
-    <url>https://github.com/droundy/arrayref/blob/master/LICENSE</url>
+    <url>https://github.com/droundy/arrayref/blob/main/LICENSE</url>
   </license>
   <license>
     <name>BSD-3-Clause License: bindgen</name>


### PR DESCRIPTION
This patch contains the output of:  `./tools/regenerate_dependency_summaries.sh`