### PR TITLE
Apply the python envs plugin only outside mozilla-central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ buildscript {
 plugins {
     alias libs.plugins.detekt
     alias libs.plugins.gradle.download.task  // Downloading libs/archives from Taskcluster.
+    alias libs.plugins.python.envs.plugin apply false
+    alias libs.plugins.kotlin.serialization apply false
 }
 
 allprojects {

--- a/components/ads-client/android/build.gradle
+++ b/components/ads-client/android/build.gradle
@@ -17,8 +17,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -17,8 +17,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -14,16 +14,13 @@ buildscript {
 
         dependencies {
             classpath libs.mozilla.glean.gradle.plugin
+            classpath libs.kotlin.serialization
         }
-    }
-
-    dependencies {
-        classpath libs.kotlin.serialization
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply plugin: 'kotlinx-serialization'

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     }
 }
 
-plugins {
-    alias libs.plugins.python.envs.plugin
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: libs.plugins.python.envs.plugin.get().pluginId
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,3 +92,4 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 gradle-download-task = { id = "de.undercouch.download", version.ref = "gradle-download-task" }
 python-envs-plugin = {id = "com.jetbrains.python.envs", version.ref = "python-envs-plugin"}
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
mozilla-central no longer carries the plugin in its version catalog
(Bug 2067314), so a component that names the alias fails to configure there.

A plugins block also made Gradle resolve the rest of that script's buildscript
classpath against the plugin repositories, which is what let support/error
pull in the kotlin serialization plugin without declaring any. Both plugins
are now declared once at the root with apply false and applied by id.

See https://phabricator.services.mozilla.com/D322009
