### PR TITLE
Resolve database paths without handing bionic memory to mozjemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,6 @@ dependencies = [
  "thiserror 2.0.3",
  "types",
  "uniffi",
- "url",
 ]
 
 [[package]]
@@ -397,7 +396,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.3",
  "uniffi",
- "url",
 ]
 
 [[package]]
@@ -4157,11 +4155,13 @@ dependencies = [
  "error-support",
  "interrupt-support",
  "lazy_static",
+ "libc",
  "parking_lot",
  "rusqlite",
  "tempfile",
  "text-table",
  "thiserror 2.0.3",
+ "url",
 ]
 
 [[package]]

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -25,7 +25,6 @@ sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "2"
 types = { path = "../support/types" }
 uniffi = { version = "0.31" }
-url = { version = "2.2", features = ["serde"] }
 
 [dev-dependencies]
 libsqlite3-sys = { version = "0.35.0" }

--- a/components/autofill/src/db/mod.rs
+++ b/components/autofill/src/db/mod.rs
@@ -15,12 +15,12 @@ use error_support::error;
 use interrupt_support::{SqlInterruptHandle, SqlInterruptScope};
 use rusqlite::{Connection, OpenFlags};
 use sql_support::open_database;
+use sql_support::path::normalize_database_path;
 use std::sync::Arc;
 use std::{
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
-use url::Url;
 
 pub struct AutofillDb {
     pub writer: Connection,
@@ -29,7 +29,7 @@ pub struct AutofillDb {
 
 impl AutofillDb {
     pub fn new(db_path: impl AsRef<Path>) -> Result<Self> {
-        let db_path = normalize_path(db_path)?;
+        let db_path = normalize_database_path(db_path)?;
         Self::new_named(db_path)
     }
 
@@ -148,47 +148,6 @@ impl CounterUpdate {
             Self::Set(counter) => (":counter", *counter),
         }
     }
-}
-
-fn unurl_path(p: impl AsRef<Path>) -> PathBuf {
-    p.as_ref()
-        .to_str()
-        .and_then(|s| Url::parse(s).ok())
-        .and_then(|u| {
-            if u.scheme() == "file" {
-                u.to_file_path().ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| p.as_ref().to_owned())
-}
-
-fn normalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = unurl_path(p);
-    if let Ok(canonical) = path.canonicalize() {
-        return Ok(canonical);
-    }
-    // It probably doesn't exist yet. This is an error, although it seems to
-    // work on some systems.
-    //
-    // We resolve this by trying to canonicalize the parent directory, and
-    // appending the requested file name onto that. If we can't canonicalize
-    // the parent, we return an error.
-    //
-    // Also, we return errors if the path ends in "..", if there is no
-    // parent directory, etc.
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let parent = path
-        .parent()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let mut canonical = parent.canonicalize()?;
-    canonical.push(file_name);
-    Ok(canonical)
 }
 
 pub(crate) mod sql_fns {

--- a/components/autofill/src/error.rs
+++ b/components/autofill/src/error.rs
@@ -81,6 +81,15 @@ pub enum Error {
     DatabaseClosed,
 }
 
+impl From<sql_support::path::Error> for Error {
+    fn from(e: sql_support::path::Error) -> Self {
+        match e {
+            sql_support::path::Error::IllegalDatabasePath(path) => Error::IllegalDatabasePath(path),
+            sql_support::path::Error::IoError(e) => Error::IoError(e),
+        }
+    }
+}
+
 // Define how our internal errors are handled and converted to external errors
 // See `support/error/README.md` for how this works, especially the warning about PII.
 impl GetErrorHandling for Error {

--- a/components/breach-alerts/Cargo.toml
+++ b/components/breach-alerts/Cargo.toml
@@ -13,7 +13,6 @@ parking_lot = ">=0.11,<=0.12"
 rusqlite = { version = "0.37.0", features = ["functions", "bundled", "unlock_notify"] }
 sql-support = { path = "../support/sql" }
 thiserror = "2"
-url = { version = "2.1" }
 
 [dev-dependencies]
 error-support = { path = "../support/error", features = ["testing"] }

--- a/components/breach-alerts/src/db.rs
+++ b/components/breach-alerts/src/db.rs
@@ -10,11 +10,11 @@ use rusqlite::types::{FromSql, ToSql};
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
 use sql_support::open_database::open_database_with_flags;
+use sql_support::path::normalize_database_path;
 use sql_support::ConnExt;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use url::Url;
 
 /// The inner database connection state, allowing graceful close handling.
 pub enum BreachAlertsDbInner {
@@ -30,7 +30,7 @@ pub struct BreachAlertsDb {
 impl BreachAlertsDb {
     /// Create a new, or fetch an already open, BreachAlertsDb backed by a file on disk.
     pub fn new(db_path: impl AsRef<Path>) -> Result<Self> {
-        let db_path = normalize_path(db_path)?;
+        let db_path = normalize_database_path(db_path)?;
         Self::new_named(db_path)
     }
 
@@ -147,61 +147,6 @@ pub fn delete_meta(db: &Connection, key: &str) -> Result<()> {
     db.conn()
         .execute_cached("DELETE FROM meta WHERE key = :key", &[(":key", &key)])?;
     Ok(())
-}
-
-// Utilities for working with paths.
-// (From places_utils - ideally these would be shared, but the use of
-// ErrorKind values makes that non-trivial.
-
-/// `Path` is basically just a `str` with no validation, and so in practice it
-/// could contain a file URL. Rusqlite takes advantage of this a bit, and says
-/// `AsRef<Path>` but really means "anything sqlite can take as an argument".
-///
-/// Swift loves using file urls (the only support it has for file manipulation
-/// is through file urls), so it's handy to support them if possible.
-fn unurl_path(p: impl AsRef<Path>) -> PathBuf {
-    p.as_ref()
-        .to_str()
-        .and_then(|s| Url::parse(s).ok())
-        .and_then(|u| {
-            if u.scheme() == "file" {
-                u.to_file_path().ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| p.as_ref().to_owned())
-}
-
-/// As best as possible, convert `p` into an absolute path, resolving
-/// all symlinks along the way.
-///
-/// If `p` is a file url, it's converted to a path before this.
-fn normalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = unurl_path(p);
-    if let Ok(canonical) = path.canonicalize() {
-        return Ok(canonical);
-    }
-    // It probably doesn't exist yet. This is an error, although it seems to
-    // work on some systems.
-    //
-    // We resolve this by trying to canonicalize the parent directory, and
-    // appending the requested file name onto that. If we can't canonicalize
-    // the parent, we return an error.
-    //
-    // Also, we return errors if the path ends in "..", if there is no
-    // parent directory, etc.
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let parent = path
-        .parent()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let mut canonical = parent.canonicalize()?;
-    canonical.push(file_name);
-    Ok(canonical)
 }
 
 // Helpers for tests

--- a/components/breach-alerts/src/error.rs
+++ b/components/breach-alerts/src/error.rs
@@ -36,6 +36,15 @@ pub enum Error {
     DatabaseConnectionClosed,
 }
 
+impl From<sql_support::path::Error> for Error {
+    fn from(e: sql_support::path::Error) -> Self {
+        match e {
+            sql_support::path::Error::IllegalDatabasePath(path) => Error::IllegalDatabasePath(path),
+            sql_support::path::Error::IoError(e) => Error::IoError(e),
+        }
+    }
+}
+
 /// Result for the public API.
 pub type ApiResult<T> = std::result::Result<T, BreachAlertsApiError>;
 

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -6,12 +6,12 @@ use crate::bookmark_sync::BookmarksSyncEngine;
 use crate::db::db::{PlacesDb, SharedPlacesDb};
 use crate::error::*;
 use crate::history_sync::HistorySyncEngine;
-use crate::util::normalize_path;
 use error_support::handle_error;
 use interrupt_support::register_interrupt;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use rusqlite::OpenFlags;
+use sql_support::path::normalize_database_path;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -138,7 +138,7 @@ pub struct PlacesApi {
 impl PlacesApi {
     /// Create a new, or fetch an already open, PlacesApi backed by a file on disk.
     pub fn new(db_name: impl AsRef<Path>) -> Result<Arc<Self>> {
-        let db_name = normalize_path(db_name)?;
+        let db_name = normalize_database_path(db_name)?;
         Self::new_or_existing(db_name)
     }
 

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -115,6 +115,15 @@ pub enum Error {
     InvalidMetadataObservation(#[from] InvalidMetadataObservation),
 }
 
+impl From<sql_support::path::Error> for Error {
+    fn from(e: sql_support::path::Error) -> Self {
+        match e {
+            sql_support::path::Error::IllegalDatabasePath(path) => Error::IllegalDatabasePath(path),
+            sql_support::path::Error::IoError(e) => Error::IoError(e),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum InvalidPlaceInfo {
     #[error("No url specified")]

--- a/components/places/src/util.rs
+++ b/components/places/src/util.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::{Error, Result};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use url::Url;
 
 /// Equivalent to `&s[..max_len.min(s.len())]`, but handles the case where
@@ -17,26 +17,6 @@ pub fn slice_up_to(s: &str, max_len: usize) -> &str {
         idx -= 1;
     }
     &s[..idx]
-}
-
-/// `Path` is basically just a `str` with no validation, and so in practice it
-/// could contain a file URL. Rusqlite takes advantage of this a bit, and says
-/// `AsRef<Path>` but really means "anything sqlite can take as an argument".
-///
-/// Swift loves using file urls (the only support it has for file manipulation
-/// is through file urls), so it's handy to support them if possible.
-fn unurl_path(p: impl AsRef<Path>) -> PathBuf {
-    p.as_ref()
-        .to_str()
-        .and_then(|s| Url::parse(s).ok())
-        .and_then(|u| {
-            if u.scheme() == "file" {
-                u.to_file_path().ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| p.as_ref().to_owned())
 }
 
 /// If `p` is a file URL, return it, otherwise try and make it one.
@@ -57,37 +37,6 @@ pub fn ensure_url_path(p: impl AsRef<Path>) -> Result<Url> {
     }
 }
 
-/// As best as possible, convert `p` into an absolute path, resolving
-/// all symlinks along the way.
-///
-/// If `p` is a file url, it's converted to a path before this.
-pub fn normalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = unurl_path(p);
-    if let Ok(canonical) = path.canonicalize() {
-        return Ok(canonical);
-    }
-    // It probably doesn't exist yet. This is an error, although it seems to
-    // work on some systems.
-    //
-    // We resolve this by trying to canonicalize the parent directory, and
-    // appending the requested file name onto that. If we can't canonicalize
-    // the parent, we return an error.
-    //
-    // Also, we return errors if the path ends in "..", if there is no
-    // parent directory, etc.
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let parent = path
-        .parent()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let mut canonical = parent.canonicalize()?;
-    canonical.push(file_name);
-    Ok(canonical)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -104,16 +53,6 @@ mod test {
         assert_eq!(slice_up_to(s, 7), "abcd");
         assert_eq!(slice_up_to(s, 8), s);
     }
-    #[test]
-    fn test_unurl_path() {
-        assert_eq!(
-            unurl_path("file:///foo%20bar/baz").to_string_lossy(),
-            "/foo bar/baz"
-        );
-        assert_eq!(unurl_path("/foo bar/baz").to_string_lossy(), "/foo bar/baz");
-        assert_eq!(unurl_path("../baz").to_string_lossy(), "../baz");
-    }
-
     #[test]
     fn test_ensure_url() {
         assert_eq!(

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -19,6 +19,10 @@ tempfile = "3.1.0"
 text-table = { path = "../text-table", optional = true }
 parking_lot = ">=0.11,<=0.12"
 rusqlite = { version = "0.37.0", features = ["functions", "limits", "bundled", "unlock_notify"] }
+url = "2.1"
+
+[target.'cfg(target_os = "android")'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 error-support = { path = "../error", features = ["testing"] }

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -15,6 +15,7 @@ mod lazy;
 mod maintenance;
 mod maybe_cached;
 pub mod open_database;
+pub mod path;
 mod repeat;
 
 pub use conn_ext::*;

--- a/components/support/sql/src/path.rs
+++ b/components/support/sql/src/path.rs
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::path::{Path, PathBuf};
+
+use url::Url;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    // This will happen if you provide something absurd like
+    // "/" or "" as your database path. For more subtley broken paths,
+    // we'll likely return an IoError.
+    #[error("Illegal database path: {0:?}")]
+    IllegalDatabasePath(PathBuf),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// `Path` is basically just a `str` with no validation, and so in practice it
+/// could contain a file URL. Rusqlite takes advantage of this a bit, and says
+/// `AsRef<Path>` but really means "anything sqlite can take as an argument".
+///
+/// Swift loves using file urls (the only support it has for file manipulation
+/// is through file urls), so it's handy to support them if possible.
+fn unurl_path(p: impl AsRef<Path>) -> PathBuf {
+    p.as_ref()
+        .to_str()
+        .and_then(|s| Url::parse(s).ok())
+        .and_then(|u| {
+            if u.scheme() == "file" {
+                u.to_file_path().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| p.as_ref().to_owned())
+}
+
+#[cfg(not(target_os = "android"))]
+fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
+    path.canonicalize()
+}
+
+/// `std::fs::canonicalize` asks `realpath` to allocate the resolved path and
+/// releases it with `free`. On Android those are not the same allocator when
+/// the caller links against mozglue, because bionic keeps its internal
+/// `malloc` calls to itself while `free` resolves to mozjemalloc. Passing a
+/// `PATH_MAX` buffer keeps the result caller owned.
+#[cfg(target_os = "android")]
+fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
+    use std::ffi::{CStr, CString, OsString};
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let path = CString::new(path.as_os_str().as_bytes())?;
+    let mut buffer = [0 as libc::c_char; libc::PATH_MAX as usize];
+    // SAFETY: `buffer` is the `PATH_MAX` bytes `realpath` requires, and `path`
+    // is a valid NUL terminated string for the duration of the call.
+    let resolved = unsafe { libc::realpath(path.as_ptr(), buffer.as_mut_ptr()) };
+    if resolved.is_null() {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: on success `realpath` returns `buffer`, NUL terminated.
+    let bytes = unsafe { CStr::from_ptr(resolved) }.to_bytes().to_vec();
+    Ok(PathBuf::from(OsString::from_vec(bytes)))
+}
+
+/// As best as possible, convert `p` into an absolute path, resolving
+/// all symlinks along the way.
+///
+/// If `p` is a file url, it's converted to a path before this.
+pub fn normalize_database_path(p: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = unurl_path(p);
+    if let Ok(canonical) = canonicalize(&path) {
+        return Ok(canonical);
+    }
+    // It probably doesn't exist yet. This is an error, although it seems to
+    // work on some systems.
+    //
+    // We resolve this by trying to canonicalize the parent directory, and
+    // appending the requested file name onto that. If we can't canonicalize
+    // the parent, we return an error.
+    //
+    // Also, we return errors if the path ends in "..", if there is no
+    // parent directory, etc.
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
+
+    let mut canonical = canonicalize(parent)?;
+    canonical.push(file_name);
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_unurl_path() {
+        assert_eq!(
+            unurl_path("file:///foo%20bar/baz").to_string_lossy(),
+            "/foo bar/baz"
+        );
+        assert_eq!(unurl_path("/foo bar/baz").to_string_lossy(), "/foo bar/baz");
+        assert_eq!(unurl_path("../baz").to_string_lossy(), "../baz");
+    }
+
+    #[test]
+    fn test_normalize_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("places.sqlite");
+        std::fs::write(&path, b"").unwrap();
+
+        assert_eq!(
+            normalize_database_path(&path).unwrap(),
+            canonicalize(&path).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_normalize_nonexistent_leaf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("places.sqlite");
+
+        assert_eq!(
+            normalize_database_path(&path).unwrap(),
+            canonicalize(dir.path()).unwrap().join("places.sqlite")
+        );
+    }
+
+    #[test]
+    fn test_normalize_nonexistent_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing").join("places.sqlite");
+
+        assert!(matches!(
+            normalize_database_path(&path),
+            Err(Error::IoError(_))
+        ));
+    }
+
+    #[test]
+    fn test_normalize_malformed_path() {
+        assert!(matches!(
+            normalize_database_path(""),
+            Err(Error::IllegalDatabasePath(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_normalize_file_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("places.sqlite");
+        std::fs::write(&path, b"").unwrap();
+        let url = Url::from_file_path(&path).unwrap();
+
+        assert_eq!(
+            normalize_database_path(url.as_str()).unwrap(),
+            canonicalize(&path).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_normalize_resolves_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("places.sqlite");
+        let link = dir.path().join("link.sqlite");
+        std::fs::write(&target, b"").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert_eq!(
+            normalize_database_path(&link).unwrap(),
+            canonicalize(&target).unwrap()
+        );
+    }
+}

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -10,6 +10,7 @@ use rusqlite::types::{FromSql, ToSql};
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
 use sql_support::open_database::open_database_with_flags;
+use sql_support::path::normalize_database_path;
 use sql_support::ConnExt;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -36,7 +37,7 @@ pub struct StorageDb {
 impl StorageDb {
     /// Create a new, or fetch an already open, StorageDb backed by a file on disk.
     pub fn new(db_path: impl AsRef<Path>) -> Result<Self> {
-        let db_path = normalize_path(db_path)?;
+        let db_path = normalize_database_path(db_path)?;
         Self::new_named(db_path)
     }
 
@@ -175,28 +176,8 @@ pub fn delete_meta(db: &Connection, key: &str) -> Result<()> {
 }
 
 // Utilities for working with paths.
-// (From places_utils - ideally these would be shared, but the use of
+// (From places_utils - ideally this would be shared, but the use of
 // ErrorKind values makes that non-trivial.
-
-/// `Path` is basically just a `str` with no validation, and so in practice it
-/// could contain a file URL. Rusqlite takes advantage of this a bit, and says
-/// `AsRef<Path>` but really means "anything sqlite can take as an argument".
-///
-/// Swift loves using file urls (the only support it has for file manipulation
-/// is through file urls), so it's handy to support them if possible.
-fn unurl_path(p: impl AsRef<Path>) -> PathBuf {
-    p.as_ref()
-        .to_str()
-        .and_then(|s| Url::parse(s).ok())
-        .and_then(|u| {
-            if u.scheme() == "file" {
-                u.to_file_path().ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| p.as_ref().to_owned())
-}
 
 /// If `p` is a file URL, return it, otherwise try and make it one.
 ///
@@ -215,37 +196,6 @@ pub fn ensure_url_path(p: impl AsRef<Path>) -> Result<Url> {
         let u = Url::from_file_path(p).map_err(|_| Error::IllegalDatabasePath(p.to_owned()))?;
         Ok(u)
     }
-}
-
-/// As best as possible, convert `p` into an absolute path, resolving
-/// all symlinks along the way.
-///
-/// If `p` is a file url, it's converted to a path before this.
-fn normalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = unurl_path(p);
-    if let Ok(canonical) = path.canonicalize() {
-        return Ok(canonical);
-    }
-    // It probably doesn't exist yet. This is an error, although it seems to
-    // work on some systems.
-    //
-    // We resolve this by trying to canonicalize the parent directory, and
-    // appending the requested file name onto that. If we can't canonicalize
-    // the parent, we return an error.
-    //
-    // Also, we return errors if the path ends in "..", if there is no
-    // parent directory, etc.
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let parent = path
-        .parent()
-        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
-
-    let mut canonical = parent.canonicalize()?;
-    canonical.push(file_name);
-    Ok(canonical)
 }
 
 // Helpers for tests

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -92,6 +92,15 @@ pub enum Error {
     SyncError(String),
 }
 
+impl From<sql_support::path::Error> for Error {
+    fn from(e: sql_support::path::Error) -> Self {
+        match e {
+            sql_support::path::Error::IllegalDatabasePath(path) => Error::IllegalDatabasePath(path),
+            sql_support::path::Error::IoError(e) => Error::IoError(e),
+        }
+    }
+}
+
 impl GetErrorHandling for Error {
     type ExternalError = WebExtStorageApiError;
 


### PR DESCRIPTION
std::fs::canonicalize asks realpath to allocate the resolved path and
releases it with free. On Android those are not the same allocator once the
consumer links against mozglue, because bionic keeps its own malloc while
free resolves to mozjemalloc, and Fenix segfaults in arena_dalloc.

Firefox hit the same crash in kvstore and works around it by passing realpath
a caller owned PATH_MAX buffer so nothing has to be freed:
https://searchfox.org/mozilla-central/source/toolkit/components/kvstore/src/fs.rs
This applies the same fix here. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1531887 for the history.

places, autofill, breach-alerts and webext-storage each carried a copy of
normalize_path, so this moves one copy to sql_support::path and gives it an
Android canonicalize that uses that buffer.
