### PR TITLE
Bug 2064758 - Only log remote settings downloads on error

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -647,7 +647,11 @@ impl ViaductApiClient {
     }
 
     fn make_request(&mut self, url: Url) -> Result<Response> {
-        breadcrumb!("make_request: {url}");
+        self._make_request(url.clone())
+            .inspect_err(|e| breadcrumb!("Request error: {e} ({url})"))
+    }
+
+    fn _make_request(&mut self, url: Url) -> Result<Response> {
         self.remote_state.ensure_no_backoff()?;
 
         let req = Request::get(url);


### PR DESCRIPTION
We got reports that there were generating lots of log lines on iOS (breadcrumbs are also logged as warnings to the console).  I changed the code to only report the breadcrumbs for error downloads, which should allow us to track down bad URLs without overloading the log files.

Another option was to only report the breadcrumb, but not log.  I didn't like this one, since I think the same issue could spam the breadcrumb list and make them less useful.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/releases.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](https://github.com/mozilla/application-services/blob/main/CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
