### PR TITLE
CI: Use newer Ruby for doc generation

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
 
       - name: Install Jazzy
         run: gem install jazzy


### PR DESCRIPTION
Looks like CI is still breaking: https://github.com/mozilla/application-services/actions/runs/34419277066/job/102690962158

That's not visible on PRs because that task only runs on pushes to main, so I figured I just update Ruby and you can see if that's enough.